### PR TITLE
docs: refresh after the Rust selection + ADR-0009 agentic gitflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Sentinel — Claude Code Project Context
 
-> Last updated: 2026-06-09
+> Last updated: 2026-08-18
 
 ## Mission
 
@@ -16,7 +16,7 @@ Generator ──▶ OTel Collector ──▶ ClickStack (ClickHouse)
               └─ OTLP gRPC :4317
 ```
 
-First cloud target: **GCP**. Python is OUT for the Collector (perf); Go and Rust are on the bake-off table (see [ADR-0004](../docs/adr/0004-collector-implementation-language.md)).
+First cloud target: **GCP**. Python was ruled out for the Collector (perf). The Rust-vs-Go bake-off is **settled in practice: Rust was selected** and `services/collector-go/` was removed from the repo in PR #28 (merged 2026-08-12). ⚠️ [ADR-0004](../docs/adr/0004-collector-implementation-language.md) still reads `Proposed` and still frames the bake-off as open — the decision was taken by merge, not by ADR. Closing that record is a Pod 2 action item.
 
 **Eight-stage spine (vendor-agnostic):**
 
@@ -32,12 +32,14 @@ otel_core → rolling_stats → tiered_engine → cross_watcher → policy_engin
 
 > Source of truth: [README §8](../README.md) + the contract docs below. This block is the quick orientation; don't let it drift.
 
-- **Collector-rust is functional end-to-end** (verified live 2026-06-09): both ingest paths land in ClickHouse — file/NDJSON (golden `baseline_seed42.jsonl` → 48 logs / 48 spans / 183 metrics) and OTLP gRPC `:4317`.
-- **gRPC receive-boundary validation** is policy-gated via `contract.grpc_validation` (`off` / `warn` / `strict`, **default `warn`**). File mode still uses `contract.strict` (all-or-nothing). Foreign OTLP legitimately lacks the 5 `sentinel.*` keys → `strict` would drop it, hence `warn` default. Code: `src/grpc.rs` (`apply_validation`), `src/config.rs`.
-- **Pod 1 → Pod 2 input contract:** `v1.0.0` **frozen**; local `contract/schema/otlp_output.schema.json` verified byte-identical to upstream `001-otel-data-generator`.
-- **Pod 2 → Pod 3 read contract:** **`v1.0.0-rc.1`** — *authoritative release candidate* (build against it), not frozen. Freeze gates open: ADR-0005 + ADR-0006 acceptance, Pod 3 sign-off (Pod 3/B3 still unstaffed). Day-4 round-trip gate ✅. Doc: [`contracts/collector/v1/pod2-pod3-read-contract.md`](../contracts/collector/v1/pod2-pod3-read-contract.md).
-- **ADR-0004/0005/0006 all still `Proposed`.** ADR-0004 (language bake-off) does **not** block the read-contract freeze.
-- **README Phase-1 realignment in flight (uncommitted, 2026-06-09).** README §1/§2 were realigned to the original proposal (`victor_docs/Sentinel-Spec-diagram.png`): **Phase 1 = telemetry foundation** (POD1 generate → POD2 ingest/transform → POD3 storage / data-modelling / consumption); **Watchers · Detection · CrewAI · Remediation = future phase**. The diagram now draws **Contract ② *after* ClickHouse** (it *is* the CH schema, per ADR-0005). ⚠️ **Not yet ratified — do not propagate here:** the **Crew B layout below still lists B3 = Volume/Schema/Latency/Storage watchers**, which diverges from the README's POD3=storage/read-layer framing. Realign this file only after Captain/Commander sign off on the Pod↔layer mapping. ClickHouse operational ownership stays unassigned.
+- **Rust is the selected collector**; `services/collector-go/` was deleted in PR #28 (merged 2026-08-12). `services/collector-rust/` is the only ingestion path in the repo.
+- **Collector-rust writes the bronze schema directly** into ClickHouse database `bronze` (`otel_logs / otel_traces / otel_metrics_gauge / otel_metrics_sum`, otel-collector-contrib v0.105.0 style). Both ingest paths verified: OTLP gRPC `:4317` and file/NDJSON (golden `baseline_seed42.jsonl` → 48 logs / 48 spans / 183 metrics).
+- **Latest E2E snapshot (2026-08-04):** 233,100 signals in 4.5s (~51.4k signals/s), 0 rejected / 0 dropped / 0 export errors, avg ClickHouse export latency 32.3ms, 100% of flush attempts ≤80ms. A reproducible local snapshot — *not* a production SLO.
+- **gRPC receive-boundary validation** is policy-gated via `contract.grpc_validation` (`off` / `warn` / `strict`, **default `warn`**). File mode uses `contract.strict` (all-or-nothing). Foreign OTLP legitimately lacks the 5 `sentinel.*` keys → `strict` would drop it, hence the `warn` default. Code: `src/grpc.rs` (`apply_validation`), `src/config.rs`.
+- **Pod 1 → Pod 2 input contract:** `v1.0.0` **frozen**, at [`contracts/generator/v1/`](../contracts/generator/v1/).
+- **Pod 2 → Pod 3 read contract:** **`v1.0.0.1`** — the bronze DDL is the contract (ADR-0007 supersedes ADR-0005). Agreed boundary; Pod 3 sign-off still pending. Doc: [`contracts/collector/v1/pod2-pod3-read-contract.md`](../contracts/collector/v1/pod2-pod3-read-contract.md).
+- **ADR status:** 0004 (language) `Proposed` — stale, see above · ~~0005~~ superseded by 0007 · 0006 (optional-ID) `Proposed`, refined by 0007 · 0007 (bronze = canonical contract) `Proposed`, Pod 3 sign-off pending · 0008 (contracts registry by producing Pod) `Proposed`, in effect on `main`.
+- **README Phase-1 realignment is landed** (PR #26, merged 2026-06-30; refined by #28). README §1/§2 follow the original proposal (`victor_docs/Sentinel-Spec-diagram.png`): **Phase 1 = telemetry foundation** (POD1 generate → POD2 ingest/transform → POD3 storage / data-modelling / consumption); **Watchers · Detection · CrewAI · Remediation = future phase**. Contract ② is drawn **after** ClickHouse (it *is* the CH schema). ⚠️ **Still not ratified — do not propagate:** the **Crew B layout below still lists B3 = Volume/Schema/Latency/Storage watchers**, which diverges from the README's POD3 = storage/read-layer framing. Realign this file only after Captain/Commander sign off on the Pod↔layer mapping. ClickHouse operational ownership stays unassigned.
 
 ## Crew B layout (you are here)
 
@@ -60,16 +62,18 @@ sentinel/
 │   ├── adr/                       # Architecture Decision Records (numbered, versioned)
 │   └── research/                  # Companion research briefs (referenced by ADRs)
 ├── services/
-│   ├── collector-rust/            # Rust collector scaffold (ADR-0004)
-│   ├── collector-go/              # Go collector scaffold (sibling, pending)
-│   └── generator/                 # Python data generator (Pod 1)
-├── infra/                         # ClickHouse, Docker compose, deployment configs
+│   ├── collector-rust/            # Rust collector — SELECTED implementation (Pod 2)
+│   └── generator-python/          # Python data generator, otelgen CLI (Pod 1)
+├── contracts/                     # contract registry, namespaced by producing Pod
+│   ├── generator/v1/              #   Pod 1 → Pod 2 input contract
+│   └── collector/v1/              #   Pod 2 → Pod 3 read contract (bronze)
+├── infra/                         # ClickHouse bootstrap + Pod-3-owned bronze DDL (init.d/)
 ├── .claude/
 │   ├── CLAUDE.md                  # This file
 │   ├── agents/                    # Specialized subagents (16) + _schema.json + _template.md.example
 │   ├── skills/                    # Slash commands (10) + _template.md.example
 │   ├── kb/                        # Knowledge bases (11 seed KBs) + _templates/ + _index.yaml
-│   ├── docs/                      # Internal standards (5 — OCR, ingestion, roadmap, glossary, Rust standards)
+│   ├── docs/                      # Internal standards (6 — OCR, ingestion, roadmap, glossary, Rust standards, agentic gitflow)
 │   └── rules/                     # Path-scoped instruction files (1 — kb-enrichment)
 └── README.md
 ```
@@ -123,7 +127,7 @@ Skill frontmatter follows [`.claude/skills/_template.md.example`](skills/_templa
 | Storage | `kb/storage/clickhouse/` | Schema, native vs HTTP, ClickStack, OTel schema in CH |
 | Cloud | `kb/cloud/gcp-telemetry/` | Cloud Monitoring, Cloud Logging, PubSub formats |
 | Languages | `kb/languages/rust/` | Tokio, tonic, error handling, async patterns |
-| Languages | `kb/languages/go/` | Concurrency, channels, OTel Collector internals |
+| Languages | `kb/languages/go/` | Concurrency, channels, OTel Collector internals *(retained as reference; the Go collector was removed in PR #28)* |
 | Contracts | `kb/contracts/` | Pydantic (Python), Protobuf (Go/Rust), versioning, boundary validation |
 | Detection | `kb/detection/anomaly-detection/` | Statistical baselines, z-scores, rolling windows |
 | Process | `kb/process/crew-b-wow/` | Sentinel WoW: syncs, ADRs, PR flow, attribution, 7 CI gates |
@@ -149,7 +153,7 @@ KB routing:
 | ClickHouse schema, native protocol, performance | `kb/storage/clickhouse/` |
 | GCP telemetry shapes (logs/metrics/traces) | `kb/cloud/gcp-telemetry/` |
 | Rust async (tokio, tonic) | `kb/languages/rust/` |
-| Go concurrency, OTel Collector internals | `kb/languages/go/` |
+| Go concurrency, OTel Collector internals *(reference only — no Go in the repo)* | `kb/languages/go/` |
 | Pydantic / Protobuf contract validation | `kb/contracts/` |
 | Anomaly detection (z-scores, rolling windows) | `kb/detection/anomaly-detection/` |
 | Crew B WoW, ADRs, PR flow | `kb/process/crew-b-wow/` |
@@ -161,11 +165,12 @@ KB routing:
 Per Sync 01 + `bem-vindos.md`:
 
 - **`main` is protected.** Feature branches: `feat/<area>-<short>`, `fix/`, `chore/`, `docs/`.
+- **Agent fleets follow [ADR-0009](../docs/adr/0009-agentic-gitflow.md)** — *seam → swimlane → leg → task*: one `git worktree` per agent (`leg/<area>/<task>-v<n>` in `.worktrees/`), legs declaring **disjoint paths**, 1 review to squash into the swimlane, 2 approvals + a **merge commit** into `main` so per-leg attribution survives. Mechanics: [`AGENTIC_GITFLOW.md`](docs/AGENTIC_GITFLOW.md). ⚠️ The merge-commit rule amends the WoW below and is **pending ratification**.
 - **Conventional Commits.** `<type>(<scope>): <description>`
 - **Signed commits.** `git commit -S`.
 - **Mandatory attribution trailer** on every commit: `Co-Authored-By: <human>`, `Co-Authored-By: <LLM model>`, optional `Reviewed-by: <bot>`.
-- **7 CI gates** (all must pass before human review): ruff · mypy --strict · pytest >80% · bandit + safety · markdownlint · CodeRabbit · Docker build.
-- **2 approvals** required: first peer, second Captain. Squash-merge to main.
+- **7 CI gates** (all must pass before human review): ruff · mypy --strict · pytest >80% · bandit + safety · markdownlint · CodeRabbit · Docker build. ⚠️ This is the *agreement* from Sync 01, not the current state: only [`rust-ci.yml`](../.github/workflows/rust-ci.yml) is implemented today.
+- **2 approvals** required: first peer, second Captain. Squash-merge to main *(ADR-0009 proposes a merge commit for swimlane→main — pending ratification)*.
 - **Weekly sync** Tuesday Zoom ~60min.
 - **Tool freedom on input, rigor on output.** Pick any LLM coding tool (Claude Code, Cursor, Codex CLI, Aider, etc.); the contract is honest attribution + 7-gate CI.
 
@@ -184,6 +189,7 @@ Full WoW: `kb/process/crew-b-wow/index.md`.
 | Generate / refresh a README | `/readme-maker` |
 | Process a document (PDF, transcript) into KB | `/ingest-doc <path>` |
 | Onboard a new Astronaut to Pod 2's Rust path | `/day-1-rust` |
+| Run an agent fleet across parallel legs | [`docs/AGENTIC_GITFLOW.md`](docs/AGENTIC_GITFLOW.md) |
 | Design OTel Collector pipeline | otel-collector-specialist agent |
 | Design ClickHouse schema | clickhouse-engineer agent |
 | Optimize Rust async code | rust-specialist agent |
@@ -218,6 +224,7 @@ Full WoW: `kb/process/crew-b-wow/index.md`.
 - ADR index: `../docs/adr/README.md`
 - OCR strategy: `./docs/OCR_STRATEGY.md`
 - Roadmap: `./docs/ROADMAP.md`
+- Agentic gitflow: `./docs/AGENTIC_GITFLOW.md` (mechanics) + `../docs/adr/0009-agentic-gitflow.md` (the decision)
 - Glossary: `./docs/CREW_B_GLOSSARY.md`
 
 ---

--- a/.claude/docs/AGENTIC_GITFLOW.md
+++ b/.claude/docs/AGENTIC_GITFLOW.md
@@ -1,0 +1,343 @@
+# Agentic gitflow — practical guide
+
+> The mechanics of [ADR-0009](../../docs/adr/0009-agentic-gitflow.md).
+> The ADR says *why* and *what the rules are*; this file is *how you run it*.
+> Last updated: 2026-08-18
+
+## The model in one line
+
+**Seam** (ownership boundary) → **swimlane** (`feat/…`, one effort) → **legs**
+(`leg/…`, one worktree per agent, disjoint paths) → **tasks** (commits).
+
+## What a worktree is (the part everyone asks about)
+
+`git worktree` gives one clone **several working directories at once**, each with a different
+branch checked out, all sharing the same `.git`. That is the whole trick: two agents editing
+"the same repo" are really editing **different files on disk**, so they cannot collide — while
+still sharing every commit, ref and object.
+
+```text
+sentinel/                              ← the MAIN worktree · branch feat/collector-histograms · you
+├── .git/                              ← ONE object store + refs, shared by everything below
+├── services/ contracts/ infra/ …      ← your files
+└── .worktrees/                        ← gitignored
+    ├── otlp-mapping-v1/               ← a LEG worktree · branch leg/…/otlp-mapping-v1 · agent A1
+    │   └── services/ contracts/ …     ←   a COMPLETE second checkout, its own files
+    └── exporter-rows-v1/              ← a LEG worktree · branch leg/…/exporter-rows-v1 · agent A2
+        └── services/ contracts/ …     ←   a COMPLETE third checkout, its own files
+```
+
+Each leg directory is a full working copy — the agent `cd`s into it and never leaves. Three
+facts that follow, and that trip people up:
+
+| Fact | Consequence |
+|---|---|
+| A worktree is **local** — nothing on `origin` | To open a PR you must `git push -u origin <leg-branch>` first |
+| Git **refuses** the same branch in two worktrees | That is the guardrail, not a bug |
+| Each worktree has **its own** `target/`, `.venv/` | Share the build caches, or N agents = N cold Rust builds (see below) |
+
+See [ADR-0009](../../docs/adr/0009-agentic-gitflow.md) for the diagram version of this.
+
+## Lifecycle
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant M as main
+    participant S as swimlane<br/>feat/collector-histograms
+    participant W as leg worktree<br/>.worktrees/otlp-mapping-v1
+    participant P as PR
+
+    M->>S: git switch -c feat/collector-histograms
+    S->>W: git worktree add -b leg/…/otlp-mapping-v1
+    Note over W: agent works · tasks = commits<br/>ONLY inside its declared paths
+    W->>P: git push -u origin leg/…/otlp-mapping-v1
+    P->>S: PR --base feat/collector-histograms · 1 review + CI · SQUASH
+    S-->>W: sibling legs rebase onto the lane
+    M-->>S: lane rebases onto main after every main merge
+    W->>W: git worktree remove (leg is disposable)
+    S->>P: PR --base main · 2 approvals · MERGE COMMIT
+    P->>M: one commit per leg lands on main
+```
+
+## Commands
+
+### 1 · Open the swimlane
+
+```sh
+git switch main && git pull --ff-only
+git switch -c feat/collector-histograms
+git push -u origin feat/collector-histograms
+```
+
+### 2 · Fan out a leg (one per agent)
+
+```sh
+git worktree add  -b <new-branch>  <new-directory>  <start-point>
+
+git worktree add  -b leg/collector-histograms/otlp-mapping-v1  .worktrees/otlp-mapping-v1  feat/collector-histograms
+```
+
+One command, two things created: the **branch** and the **directory**. Verify:
+
+```sh
+git worktree list
+# /home/you/sentinel                             abc1234 [feat/collector-histograms]
+# /home/you/sentinel/.worktrees/otlp-mapping-v1  abc1234 [leg/collector-histograms/otlp-mapping-v1]
+```
+
+The agent runs with `.worktrees/otlp-mapping-v1` as its working directory and never leaves it —
+`cd`-ing back to the parent puts it on someone else's branch.
+
+**Declare the paths first.** Before opening a leg, write down what it owns. Two open legs
+in the same swimlane must not overlap (ADR-0009 R1):
+
+| Leg | Declared paths |
+|---|---|
+| `otlp-mapping-v1` | `services/collector-rust/src/otlp.rs` |
+| `exporter-rows-v1` | `services/collector-rust/src/clickhouse_exporter.rs` |
+
+If two legs need the same file, they are one leg — or the shared change lands first as its
+own leg and the others rebase onto it.
+
+### 3 · Fan in
+
+Worktrees are **local**; a PR needs the branch on `origin`:
+
+```sh
+cd .worktrees/otlp-mapping-v1
+git push -u origin leg/collector-histograms/otlp-mapping-v1
+gh pr create --base feat/collector-histograms \
+  --title "feat(collector): map OTLP histogram data points" \
+  --body "Declared paths: services/collector-rust/src/otlp.rs"
+```
+
+Gate: **1 reviewer** (may be the `code-reviewer` agent) + full CI. Merge style: **squash** —
+one commit per leg, attribution trailers preserved.
+
+### 4 · Sync (the step everyone skips)
+
+After each fan-in, every surviving leg rebases onto the lane:
+
+```sh
+cd .worktrees/exporter-rows-v1
+git fetch origin
+git rebase origin/feat/collector-histograms
+```
+
+After every merge to `main`, the lane rebases onto `main`:
+
+```sh
+git switch feat/collector-histograms
+git fetch origin && git rebase origin/main
+git push --force-with-lease
+```
+
+`--force-with-lease`, never `--force`: it refuses if someone else pushed meanwhile.
+
+### 5 · Retire the leg
+
+```sh
+git worktree remove .worktrees/otlp-mapping-v1
+git branch -d leg/collector-histograms/otlp-mapping-v1
+git worktree prune          # clean stale admin files
+git worktree list           # verify
+```
+
+A leg that went wrong is not salvaged — close it and open `-v2`.
+
+### 6 · Close the swimlane
+
+```sh
+gh pr create --base main --title "feat(collector): bronze exporter" --body "…"
+```
+
+Gate: **2 approvals** (peer + Captain) + full CI. Merge style: **merge commit**, so `main`
+keeps one commit per leg with its trailers intact. This is the one place we deviate from the
+WoW's "squash-merge to main" — see [ADR-0009 § Trade-offs](../../docs/adr/0009-agentic-gitflow.md#trade-offs).
+
+## Shared build caches — do this before running agents
+
+Each worktree gets its own `target/`. The collector's is multiple GB and rebuilds cold, so
+N worktrees without a shared cache make parallel agents **slower** than serial. Export before
+launching the fleet:
+
+```sh
+export CARGO_TARGET_DIR="$HOME/.cache/sentinel-cargo-target"   # one build cache, all worktrees
+export UV_CACHE_DIR="$HOME/.cache/sentinel-uv"                 # same idea for the generator
+```
+
+Cargo locks the target dir, so concurrent builds queue rather than corrupt — slower than N
+independent caches at peak, but vastly cheaper than N cold builds. Prefer `sccache` if the
+fleet grows past ~4 agents.
+
+## Worked example — two swimlanes end to end
+
+Two real open items, run concurrently by four agents. Follow it top to bottom.
+
+### The seam check, before anything is created
+
+| Swimlane | Seam (owner) | Leg | Declared paths |
+|---|---|---|---|
+| **A** `feat/collector-histograms` | `services/collector-rust/**` (Pod 2) | `otlp-mapping-v1` | `services/collector-rust/src/otlp.rs` |
+| | | `exporter-rows-v1` | `services/collector-rust/src/clickhouse_exporter.rs` |
+| **B** `feat/silver-rolling-stats` | `infra/clickhouse/**` (Pod 3) | `silver-ddl-v1` | `infra/clickhouse/init.d/02-silver.sql` |
+| | | `read-models-v1` | `infra/clickhouse/silver/models/**` |
+
+Every cell in the last column is disjoint from every other — **within** a lane (R1) and
+**across** the two lanes. That is the whole authorization to run all four agents at once. Do
+this table first; if two rows collide, you do not have two legs, you have one.
+
+### Step 1 — open both lanes from `main`
+
+```sh
+git switch main && git pull --ff-only
+git switch -c feat/collector-histograms && git push -u origin feat/collector-histograms
+git switch main
+git switch -c feat/silver-rolling-stats  && git push -u origin feat/silver-rolling-stats
+git switch main     # ← REQUIRED: a branch checked out here cannot be checked out in a worktree
+```
+
+### Step 2 — fan out four legs
+
+Worktrees are flat: lanes and legs all live side by side under `.worktrees/`. Since you can
+only stand in one directory at a time, give each **lane** a worktree too — otherwise you
+cannot hold both open.
+
+```sh
+git worktree add .worktrees/lane-histograms feat/collector-histograms
+git worktree add .worktrees/lane-silver     feat/silver-rolling-stats
+
+# lane A's legs — note the start-point is lane A, not main
+git worktree add -b leg/collector-histograms/otlp-mapping-v1 \
+    .worktrees/otlp-mapping-v1   feat/collector-histograms
+git worktree add -b leg/collector-histograms/exporter-rows-v1 \
+    .worktrees/exporter-rows-v1  feat/collector-histograms
+
+# lane B's legs
+git worktree add -b leg/silver-rolling-stats/silver-ddl-v1 \
+    .worktrees/silver-ddl-v1     feat/silver-rolling-stats
+git worktree add -b leg/silver-rolling-stats/read-models-v1 \
+    .worktrees/read-models-v1    feat/silver-rolling-stats
+```
+
+On disk:
+
+```text
+sentinel/                            ▸ main                                 👤 you
+├── .git/                            ← ONE store, shared by all seven
+└── .worktrees/
+    ├── lane-histograms/             ▸ feat/collector-histograms            👤 integrator A
+    ├── otlp-mapping-v1/             ▸ leg/collector-histograms/otlp-…      🤖 agent A1
+    ├── exporter-rows-v1/            ▸ leg/collector-histograms/exporter-…  🤖 agent A2
+    ├── lane-silver/                 ▸ feat/silver-rolling-stats            👤 integrator B
+    ├── silver-ddl-v1/               ▸ leg/silver-rolling-stats/silver-ddl… 🤖 agent B1
+    └── read-models-v1/              ▸ leg/silver-rolling-stats/read-models…🤖 agent B2
+```
+
+`git worktree list` prints exactly these seven lines. Four agents now edit four disjoint sets
+of files simultaneously.
+
+### Step 3 — fan in, with the rebase that everyone forgets
+
+Agent A1 finishes first:
+
+```sh
+cd .worktrees/otlp-mapping-v1
+git push -u origin leg/collector-histograms/otlp-mapping-v1
+gh pr create --base feat/collector-histograms \
+  --title "feat(collector): map OTLP histogram data points" \
+  --body "Declared paths: services/collector-rust/src/otlp.rs"
+# 1 review + full CI → SQUASH
+```
+
+**The moment it merges, A2 is stale.** Rebase it before it goes anywhere near a PR:
+
+```sh
+cd ../exporter-rows-v1
+git fetch origin && git rebase origin/feat/collector-histograms
+```
+
+B1 and B2 do the same inside lane B — and they are unaffected by anything in lane A, which is
+the payoff of the seam check in the first place.
+
+### Step 4 — lane A closes; lane B pays the rebase
+
+```sh
+cd ../lane-histograms
+gh pr create --base main --title "feat(collector): histogram metric support" --body "…"
+# 2 approvals (peer + Captain) + full CI → MERGE COMMIT
+```
+
+`main` now carries **two** commits from lane A — one per leg, each with its own
+`Co-Authored-By` trailers — under one merge commit. That is exactly what the merge-commit rule
+buys.
+
+Lane B is now behind `main`:
+
+```sh
+cd ../lane-silver
+git fetch origin && git rebase origin/main
+git push --force-with-lease
+```
+
+Then lane B closes the same way.
+
+### Step 5 — clean up
+
+```sh
+cd ~/sentinel
+git worktree remove .worktrees/otlp-mapping-v1
+git worktree remove .worktrees/exporter-rows-v1
+git worktree remove .worktrees/lane-histograms
+git worktree prune && git worktree list      # verify only live ones remain
+```
+
+### The counterexample — when two lanes are *not* independent
+
+Histogram support is the honest version of this story: the collector cannot emit a histogram
+the **input contract has no type for**. So the work also touches `contracts/generator/` — a
+**third seam, jointly owned by Pod 1 and Pod 2**.
+
+That crossing is neither a leg of lane A nor a sibling lane. It is a **predecessor**:
+
+```text
+feat/contract-v2-histograms   ──lands first──▶   feat/collector-histograms   ──▶ main
+        (seam: contracts/, Pod 1 + Pod 2)              (rebases onto it)
+```
+
+**Work that crosses a seam gets sequenced, never fanned out.** If your path table shows a leg
+reaching into a seam another Pod owns, stop: that is a separate swimlane, and it goes first.
+
+## Naming
+
+| Thing | Pattern | Example |
+|---|---|---|
+| Swimlane branch | `feat/<area>-<short>` (also `fix/`, `chore/`, `docs/`) | `feat/collector-histograms` |
+| Leg branch | `leg/<area>/<task>-v<n>` | `leg/collector-histograms/otlp-mapping-v1` |
+| Worktree directory | `.worktrees/<task>-v<n>` | `.worktrees/otlp-mapping-v1` |
+
+Branch names describe the **work**, never the mechanism — `worktree/logo-v1` bakes a tool
+into a permanent record and lies as soon as the same task runs without a worktree.
+
+## Checklist before opening a leg
+
+- [ ] Declared paths written down, and disjoint from every other open leg
+- [ ] Work is genuinely parallel — if it depends on another leg, **stack** it (branch from that leg, PR into it) instead of fanning out
+- [ ] ≥2 agents will actually run concurrently — otherwise work directly in the swimlane
+- [ ] `CARGO_TARGET_DIR` / `UV_CACHE_DIR` exported
+- [ ] Commits will carry `Co-Authored-By:` for both the human and the model (WoW)
+
+## Gotchas
+
+- **`git worktree remove` fails on a dirty worktree.** Inspect before `--force`; that's uncommitted agent work.
+- **Deleting the directory by hand leaves stale admin state.** Use `git worktree remove`, or `git worktree prune` afterwards.
+- **Merging the swimlane to `main` retargets open leg PRs on GitHub.** Close legs before closing the lane.
+- **`.worktrees/` must be gitignored** — otherwise a worktree gets committed into the repo it lives in.
+
+## See also
+
+- [ADR-0009](../../docs/adr/0009-agentic-gitflow.md) — the decision and its rules
+- [ADR-0008](../../docs/adr/0008-contracts-registry-by-producing-pod.md) — the ownership seams R1 rides on
+- [Crew B WoW](../kb/process/crew-b-wow/index.md) — branching, commits, attribution, CI gates
+- `git worktree` — <https://git-scm.com/docs/git-worktree>

--- a/.claude/docs/ROADMAP.md
+++ b/.claude/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 # `.claude/` Roadmap
 
 > Evolution plan for Sentinel's Claude Code knowledge system.
-> Last updated: 2026-06-01
+> Last updated: 2026-08-18
 
 The `.claude/` environment isn't shipped once and forgotten — it grows as the project does. This roadmap maps the four growth phases to the Sentinel program's 20-week DataShip Mission 2026 timeline.
 
@@ -11,9 +11,9 @@ The `.claude/` environment isn't shipped once and forgotten — it grows as the 
 
 **Delivered:**
 - `.claude/CLAUDE.md` — project context with full lookup tables
-- 8 skills: `create-agent`, `create-kb`, `create-skill`, `enrich-kb`, `readme-maker`, `update-kbs`, `ingest-doc`, `adr`
-- 12 specialized agents across 8 categories
-- 10 seed KBs covering OTel, ClickHouse, Rust, Go, GCP telemetry, contracts, anomaly detection, agentic patterns, Crew B WoW
+- 8 skills at bootstrap: `create-agent`, `create-kb`, `create-skill`, `enrich-kb`, `readme-maker`, `update-kbs`, `ingest-doc`, `adr` *(now 10 — `arch-review` and `day-1-rust` added since)*
+- 12 specialized agents across 8 categories *(now 16)*
+- 10 seed KBs covering OTel, ClickHouse, Rust, Go, GCP telemetry, contracts, anomaly detection, agentic patterns, Crew B WoW *(now 11 — `communication/architecture-diagramming` added)*
 - 4 internal docs: `OCR_STRATEGY.md`, `INGESTION_WORKFLOW.md`, `ROADMAP.md` (this file), `CREW_B_GLOSSARY.md`
 - Path-scoped rules for KB enrichment and attribution
 
@@ -28,7 +28,7 @@ The `.claude/` environment isn't shipped once and forgotten — it grows as the 
 
 **Backlog:**
 - **ADR-001 / ADR-002 / ADR-003 in `docs/adr/`** — opened by the Commander, drafted by Crew B. The `/adr` skill produces the scaffold; `kb-architect` validates references.
-- **Bake-off harness KB** at `kb/process/bakeoff/` — how the Rust-vs-Go Collector comparison runs (load gen, ClickHouse instance, metric collection).
+- ~~**Bake-off harness KB** at `kb/process/bakeoff/`~~ — **dropped.** The Rust-vs-Go comparison was settled in-repo (Rust selected, PR #28, merged 2026-08-12) without a standalone harness KB.
 - **First weekly sync ingest** via `/ingest-doc` of the next Tuesday transcript → `kb/process/crew-b-wow/syncs/`.
 - **Captain's status template** — possibly a `/status` skill if the Captain (whoever wears the hat) wants to automate it.
 

--- a/.claude/docs/RUST_PROJECT_STANDARDS.md
+++ b/.claude/docs/RUST_PROJECT_STANDARDS.md
@@ -1,6 +1,6 @@
 # Rust Project Standards — the UV-equivalent setup for Sentinel
 
-> Last updated: 2026-06-01
+> Last updated: 2026-08-18
 > Goal: deliver the same simple, standardized contributor experience for Rust services in Sentinel that `uv` delivers for our Python projects.
 
 ## Why this doc exists
@@ -20,14 +20,14 @@ Rust delivers the same posture differently: most of it is built into `cargo` fro
 
 ## Scoping principle (polyglot monorepo)
 
-Sentinel is a **polyglot monorepo**: the Collector (Rust) is one of N peer components alongside `services/generator/` (Python/UV), `services/collector-go/` (Go), future watchers, the action dispatcher, and `infra/`. The scoping rule:
+Sentinel is a **polyglot monorepo**: the Collector (Rust) is one of N peer components alongside `services/generator-python/` (Python/UV), future watchers, the action dispatcher, and `infra/`. (A Go collector was a peer during the bake-off; Rust was selected and `services/collector-go/` was removed in PR #28, merged 2026-08-12. The scoping rule below is language-count-agnostic — it still governs the next component in any language.) The scoping rule:
 
-- **Language-specific config lives inside the component directory it governs** — `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `rustfmt.toml`, `clippy.toml`, `deny.toml` live at `services/collector-rust/`. Same pattern for `pyproject.toml`/`uv.lock` at `services/generator/` and `go.mod` at `services/collector-go/`.
+- **Language-specific config lives inside the component directory it governs** — `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `rustfmt.toml`, `clippy.toml`, `deny.toml` live at `services/collector-rust/`. Same pattern for `pyproject.toml`/`uv.lock` at `services/generator-python/`, and for whatever manifest the next component's language uses.
 - **Cross-cutting config lives at the repo root** — `justfile` (delegates per-language), `.pre-commit-config.yaml` (multi-language hooks), `.markdownlint.json`, `.editorconfig`, `.github/workflows/`, top-level `README.md`, `docs/`, `infra/`.
 
-This keeps every component self-contained (`cd services/X && just ci` always works) while letting the root coordinate (`just ci` at root walks every component). It also lets `.github/workflows/rust-ci.yml` use `paths: [services/collector-rust/**]` so a Python-only PR doesn't trigger Rust builds.
+The intent: every component self-contained (`cd services/X && just ci`) while the root coordinates (`just ci` at root walking every component). **Today only `services/collector-rust/justfile` exists** — the root delegator is still to be written, so cross-component coordination goes through the root `Makefile` instead. It also lets `.github/workflows/rust-ci.yml` use `paths: [services/collector-rust/**]` so a Python-only PR doesn't trigger Rust builds.
 
-> **Note on `rust-toolchain.toml`:** `rustup` walks *up* the directory tree to find it. Keeping it at `services/collector-rust/` scopes the pinned 1.83.0 toolchain to that subtree only — an adjacent Rust tool elsewhere in the repo picks its own toolchain.
+> **Note on `rust-toolchain.toml`:** `rustup` walks *up* the directory tree to find it. Keeping it at `services/collector-rust/` scopes the pinned 1.96.0 toolchain to that subtree only — an adjacent Rust tool elsewhere in the repo picks its own toolchain.
 
 > **Note on Cargo workspaces:** Today there is exactly one Rust crate, so a workspace adds zero value. When a second Rust crate appears, promote `services/collector-rust/Cargo.toml` to a `[workspace]` in place, or create `services/Cargo.toml` as a workspace governing multiple Rust members — defer the choice until you actually have N≥2 crates (YAGNI).
 
@@ -60,16 +60,19 @@ All paths below are relative to `services/collector-rust/` unless noted as **(re
 
 For any Rust service in this repo (`services/collector-rust/`, future `services/X-rust/`):
 
+> ⚠️ **This is the TARGET layout, not the current one.** Every root-level file below is
+> marked with its real status; only the ones marked ✅ exist today. Don't cite the missing
+> ones as if they were in place.
+
 ```text
 sentinel/
-├── justfile                         # ROOT — cross-cutting task runner (delegates per-language)
-├── .pre-commit-config.yaml          # ROOT — multi-language hooks (Rust + Python + markdown)
-├── .markdownlint.json               # ROOT — cross-cutting
-├── .editorconfig                    # ROOT — cross-cutting
+├── justfile                         # ROOT — cross-cutting task runner   ⛔ NOT YET
+├── .pre-commit-config.yaml          # ROOT — multi-language hooks        ⛔ NOT YET
+├── .markdownlint.json               # ROOT — cross-cutting               ⛔ NOT YET (WoW lists it as a gate)
+├── .editorconfig                    # ROOT — cross-cutting               ⛔ NOT YET
 ├── .github/workflows/
-│   ├── rust-ci.yml                  # paths: [services/collector-rust/**]
-│   ├── python-ci.yml                # paths: [services/generator/**]
-│   └── go-ci.yml                    # paths: [services/collector-go/**]
+│   ├── rust-ci.yml                  # paths: [services/collector-rust/**]  ✅ EXISTS
+│   └── python-ci.yml                # paths: [services/generator-python/**]  ⛔ NOT YET
 └── services/
     ├── collector-rust/              # ── Rust component, fully self-contained ──
     │   ├── Cargo.toml               # package manifest (becomes [workspace] if Rust grows to N≥2 crates)
@@ -78,7 +81,7 @@ sentinel/
     │   ├── rustfmt.toml             # format rules
     │   ├── clippy.toml              # extra lint config (when needed)
     │   ├── deny.toml                # cargo-deny: license + security policy
-    │   ├── justfile                 # Rust-specific recipes, invoked by root justfile
+    │   ├── justfile                 # Rust-specific recipes                ✅ EXISTS
     │   ├── src/
     │   │   ├── main.rs              # binary entry
     │   │   ├── lib.rs               # library entry (for testability)
@@ -88,14 +91,10 @@ sentinel/
     │   ├── benches/                 # criterion benchmarks (opt-in)
     │   │   └── ingest_throughput.rs
     │   └── README.md
-    ├── collector-go/                # ── Go component, sibling (post-bake-off) ──
-    │   ├── go.mod / go.sum
-    │   ├── .golangci.yml
-    │   └── justfile
-    └── generator/                   # ── Python component (Pod 1) ──
-        ├── pyproject.toml
-        ├── uv.lock
-        └── justfile
+    └── generator-python/            # ── Python component (Pod 1) ──
+        ├── pyproject.toml                                                  ✅ EXISTS
+        ├── uv.lock                                                         ✅ EXISTS
+        └── justfile                                                        ⛔ NOT YET
 ```
 
 Mirrors the Python layout: `src/<pkg>/` is `services/<name>/src/`; `tests/` at the service root is `services/<name>/tests/`. Every component is self-contained — `cd services/X && just ci` works without the root being involved.
@@ -233,11 +232,11 @@ workspace = true
 
 ## `services/collector-rust/rust-toolchain.toml` — the `.python-version` equivalent
 
-Lives at `services/collector-rust/` (not the repo root) so the toolchain pin scopes to this component's subtree only. `rustup` walks *up* the directory tree to find it, so any `cargo` command run inside `services/collector-rust/` (or below) picks up Rust 1.83.0 automatically; commands elsewhere in the repo use whatever the contributor's default toolchain is.
+Lives at `services/collector-rust/` (not the repo root) so the toolchain pin scopes to this component's subtree only. `rustup` walks *up* the directory tree to find it, so any `cargo` command run inside `services/collector-rust/` (or below) picks up Rust 1.96.0 automatically; commands elsewhere in the repo use whatever the contributor's default toolchain is.
 
 ```toml
 [toolchain]
-channel = "1.83.0"                   # pin the Rust version exactly
+channel = "1.96.0"                   # pin the Rust version exactly
 components = [
     "rustfmt",
     "clippy",
@@ -248,7 +247,7 @@ targets = ["x86_64-unknown-linux-musl"]  # for distroless container builds
 profile = "minimal"
 ```
 
-A contributor running `cd sentinel/services/collector-rust && cargo build` automatically gets Rust 1.83.0 installed by `rustup`. No "what version are you running?" debates.
+A contributor running `cd sentinel/services/collector-rust && cargo build` automatically gets Rust 1.96.0 installed by `rustup`. No "what version are you running?" debates.
 
 ## `services/collector-rust/rustfmt.toml` — formatting
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ hyperdx_data/
 
 # Tooling
 .mcp.json
+
+# Agentic gitflow worktrees (ADR-0009)
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,14 @@
 # CLAUDE.md — Sentinel monorepo
 
 Context for working in this repository. Sentinel is an autonomous, OTel-native
-observability and data-pipeline anomaly-detection platform. This branch is the
-integrated monorepo baseline (`v0.0.1`) gluing the POD branches together.
+observability and data-pipeline anomaly-detection platform. `main` is the
+integrated monorepo: every Pod's component behind versioned contracts.
 
 ## Pipeline
 
 ```
-generator (otelgen) ──OTLP gRPC :4317──▶ collector (rust | go) ──▶ ClickHouse :8123/:9000 ──▶ Play UI :8123/play
-                       │                  (selected via COLLECTOR)
+generator (otelgen) ──OTLP gRPC :4317──▶ collector-rust ──HTTP :8123──▶ ClickHouse bronze.* ──▶ Play UI :8123/play
+                       │                                                  (Pod-3-owned DDL, auto-applied on boot)
                        └── validates against contracts/generator/v1 (single source of truth)
 ```
 
@@ -20,11 +20,10 @@ contracts/                 # SSOT contract registry, namespaced by producing Pod
   collector/v1/            #   POD 2 → POD 3 read contract (bronze semantic layer, bronze.*)
 services/
   generator-python/        # POD 1 — synthetic OTLP generator (otelgen CLI); config/ holds scenarios/topology/provider_profiles
-  collector-rust/          # POD 2 — OTLP→ClickHouse collector (Rust); own DDL in infra/clickhouse/ddl/
-  collector-go/            # POD 2 — OTLP→ClickHouse collector (Go);   own DDL in migrations/
-infra/                     # ClickHouse bootstrap (init user/db + users.d network override)
-docs/                      # shared docs (clickhouse-schema-divergence.md)
-docker-compose.yml         # root orchestrator (rust|go profiles)
+  collector-rust/          # POD 2 — OTLP→ClickHouse collector (Rust), the selected implementation
+infra/                     # ClickHouse bootstrap (users/db init + users.d network override + bronze DDL in init.d/)
+docs/                      # shared docs (ADRs, research, proposals)
+docker-compose.yml         # root orchestrator
 Makefile                   # one-command UX
 ```
 
@@ -32,34 +31,45 @@ Makefile                   # one-command UX
 
 | Command | What it does |
 |---------|--------------|
-| `make e2e COLLECTOR=rust\|go` | Full pipeline: build+up clickhouse+collector → apply its DDL → generate → land rows |
-| `make up / init / generate / logs / down / reset` | Individual pipeline steps |
+| `make e2e` | Full pipeline: up (ClickHouse + collector) → init → generate → land rows in `bronze.*` |
+| `make up / init / generate / logs / ps / down / reset` | Individual pipeline steps (`init` is a no-op: bronze auto-applies on ClickHouse boot) |
 | `make build` | Build all service images |
-| `make test` | All unit suites (generator pytest, `cargo test`, `go test`) |
-| `make lint` | ruff + `cargo fmt/clippy` + `go vet` |
-| `make help` | List targets + active `COLLECTOR/SCENARIO/SEED/WINDOW` |
+| `make test` | All unit suites (`test-generator` pytest + `test-collector-rust` cargo) |
+| `make lint` | `lint-generator` (ruff) + `lint-collector-rust` (cargo fmt --check + clippy) |
+| `make help` | List targets + active `SCENARIO/SEED/WINDOW` |
 
-Variables: `COLLECTOR` (rust\|go, default rust), `SCENARIO`, `SEED`, `WINDOW`.
+Variables: `SCENARIO` (default `baseline`), `SEED` (`42`), `WINDOW` (`5m`).
 
 ## Conventions
 
-- **Each service keeps its native toolchain** (`pyproject`/`otelgen`, `cargo`/`just`, `go`/`make`). Don't impose a shared build system.
-- **`contracts/` is the contract registry, namespaced by producing Pod.** `generator/v1/` is the POD 1 → POD 2 input contract — the producer (generator) owns it and consumers reference it via `CONTRACTS_DIR` (`/contracts/generator/v1` in containers). `collector/v1/` is the POD 2 → POD 3 read contract (the bronze semantic layer, database `bronze`) — one shared, implementation-agnostic contract every collector writes into. Bump versions per boundary by directory (`generator/v2/`, `collector/v2/`) for breaking changes.
-- **Only one collector runs at a time** — both bind OTLP `:4317`. The generator targets the `collector` network alias, so it works regardless of which is active.
-- **Both collectors now write the identical bronze split schema directly into database `bronze`** (POD 2 → POD 3 landing — `otel_logs / otel_traces / otel_metrics_gauge / otel_metrics_sum`, OTel-contrib style with metrics split by data-point type, Sentinel-enriched via `ResourceAttributes`). Cross-collector equivalence is verified (identical row counts). The old normalized `default.*` write path (and the `otel_metrics_1m` rollup MV) is retired.
-- **POD 3's canonical bronze** (database `bronze`, `bronze.*`, OTel-contrib style, metrics split by type) is auto-applied on ClickHouse boot from `infra/clickhouse/init.d/01-bronze-otel.sql`. **Both collectors write directly into it** — the former collector→bronze gap is now closed (historical rationale: [docs/research/pod3-bronze-gap.md](docs/research/pod3-bronze-gap.md)).
+- **Each service keeps its native toolchain** (`pyproject`/`otelgen`, `cargo`). Don't impose a shared build system.
+- **`contracts/` is the contract registry, namespaced by producing Pod.** `generator/v1/` is the POD 1 → POD 2 input contract — the producer (generator) owns it and consumers reference it via `CONTRACTS_DIR` (`/contracts/generator/v1` in containers). `collector/v1/` is the POD 2 → POD 3 read contract (the bronze semantic layer, database `bronze`) — implementation-agnostic, so it survives a collector swap. Bump versions per boundary by directory (`generator/v2/`, `collector/v2/`) for breaking changes.
+- **Rust is the selected collector implementation.** The Go collector was removed from the repo in PR #28 (merged 2026-08-12); `services/collector-rust/` is the only ingestion path. ADR-0004 still carries `Proposed` and has not been updated to record the selection — see *Known doc drift* below.
+- **The collector writes the bronze split schema directly into database `bronze`** (`otel_logs / otel_traces / otel_metrics_gauge / otel_metrics_sum`, otel-collector-contrib v0.105.0 style with metrics split by data-point type, Sentinel-enriched via `ResourceAttributes`). The old normalized `default.*` write path and the `otel_metrics_1m` rollup MV are retired; the rollup is now a Pod 3 silver artifact.
+- **The bronze DDL is Pod-3-owned** and auto-applies on ClickHouse boot from `infra/clickhouse/init.d/01-bronze-otel.sql`. The collector issues no DDL — it only `INSERT`s. (The repo calls this policy `create_schema:false`, borrowing the contrib exporter's flag name; it is not a literal key in our Rust config.)
+- **Agent-assisted work follows [ADR-0009](docs/adr/0009-agentic-gitflow.md)** — *seam → swimlane → leg → task*. One `git worktree` per agent under `.worktrees/`, branches named `leg/<area>/<task>-v<n>`, and **every leg declares disjoint paths** before it opens. Commands and gotchas: [`.claude/docs/AGENTIC_GITFLOW.md`](.claude/docs/AGENTIC_GITFLOW.md). Export a shared `CARGO_TARGET_DIR` before running a fleet, or N worktrees means N cold Rust builds.
 - **No comments-as-noise**; match each service's existing style. Keep the repo clean for the agentic phase that follows this baseline.
 
 ## Gotchas
 
-- **Stale ClickHouse volume:** `CREATE TABLE IF NOT EXISTS` won't update a changed schema. After a collector DDL change, `make reset` before `make init`, or inserts fail with `NO_SUCH_COLUMN`.
-- **Dev-only ClickHouse auth:** `infra/clickhouse-init.sql` creates `otelgen`/`sentinel` (Go's DSN) and `infra/clickhouse-users.d/` opens the `default` user to the Docker network (Rust). Local only — do not expose beyond the compose network.
-- The Rust collector only enters OTLP **server** mode when its config (`services/collector-rust/config.docker.yaml`) has a `grpc` section.
+- **Stale ClickHouse volume:** `CREATE TABLE IF NOT EXISTS` won't update a changed schema. After a DDL change, `make reset` before `make up`, or inserts fail with `NO_SUCH_COLUMN`.
+- **Dev-only ClickHouse auth:** `infra/clickhouse-users.d/` opens the `default` user to the Docker network (the Rust collector's HTTP path). `infra/clickhouse-init.sql` also creates an `otelgen` user — vestigial from the Go collector's DSN, unused today. Local only — do not expose beyond the compose network.
+- The Rust collector only enters OTLP **server** mode when its config (`services/collector-rust/config.docker.yaml`) has a `grpc` section. Without it, it runs FILE mode (read `input` once, exit).
+- **ClickHouse port:** the collector's `clickhouse` crate speaks RowBinary over **HTTP :8123**, not native :9000.
 
 ## Status & what's next
 
-`v0.0.1` baseline is verified end-to-end (generator 176 unit tests; both collectors unit + live-ClickHouse integration; full `make e2e` for both). Not yet on `main`.
+Pod 2's Rust collector is verified end-to-end on `main`: generator → OTLP `:4317` → `bronze.*`, lossless. Latest local snapshot (2026-08-04): 233,100 signals in 4.5s, 0 rejected / 0 dropped / 0 export errors, avg export latency 32.3ms. Golden file-mode round-trip: 48 logs / 48 spans / 183 metrics. Full detail in [README §8](README.md).
 
-POD 2 (collector → bronze) and POD 3 (canonical bronze DDL) have landed: both collectors write the identical bronze split schema directly into database `bronze` (metrics split by type), and cross-collector equivalence is verified. The former collector→bronze gap is now **closed** (historical rationale: `docs/research/pod3-bronze-gap.md`).
+**Open:** ADR-0007 acceptance (Pod 3 sign-off) · Pod 3 silver (rolling-stats, read models) · histogram/summary metrics (no v1.0.0 type) · CI beyond `rust-ci.yml` (branch protection, pre-commit gates) · the agentic layer (agent fleet, KBs, routines).
 
-Still deferred: contract *enforcement* in the Go collector, CI/CD + branch protection + pre-commit gates, and the agentic layer (agent fleet, KBs, routines). See [.claude/sdd/reports/BUILD_REPORT_MONOREPO_INTEGRATION.md](.claude/sdd/reports/BUILD_REPORT_MONOREPO_INTEGRATION.md).
+**Known doc drift** — decisions taken by merge that the records don't yet reflect:
+
+| Drift | Where | Resolution owner |
+|---|---|---|
+| ADR-0004 still `Proposed`, still frames Rust-vs-Go as an open bake-off | `docs/adr/0004-collector-implementation-language.md` | Pod 2 — needs `Accepted` + a selection note |
+| ADR-0007 / ADR-0008 still `Proposed` | `docs/adr/` | cross-Pod ratification at sync |
+| Pod↔layer mapping unratified (README POD3 = storage/read-layer vs `.claude/CLAUDE.md` B3 = watchers) | `.claude/CLAUDE.md` | Captain / Commander |
+| ADR-0009 amends the WoW's "squash-merge to main" rule | `docs/adr/0009-agentic-gitflow.md` | Captain / Commander |
+
+Historical records under `docs/research/`, `docs/proposals/`, `docs/clickhouse-schema-divergence*.md` and `.claude/sdd/` are point-in-time artifacts — they mention the Go collector by design. Don't "fix" them; they carry a superseded banner.

--- a/README.md
+++ b/README.md
@@ -187,8 +187,9 @@ Run `make help` for all targets and the active `SCENARIO / SEED / WINDOW`. Per-c
 
 ## 7. Ownership & boundaries
 
-- **`main` is protected.** Feature branches `feat/<area>-<short>`; Conventional Commits; signed commits; attribution trailers; squash-merge after 2 approvals (peer + Captain).
-- **Per-component CI** is path-filtered so each component's gates run independently.
+- **`main` is protected.** Feature branches `feat/<area>-<short>`; Conventional Commits; signed commits; attribution trailers; 2 approvals (peer + Captain).
+- **Agent-assisted work follows [ADR-0009](docs/adr/0009-agentic-gitflow.md)** — *seam → swimlane → leg → task*: one git worktree per agent, legs declaring **disjoint paths**, squash into the swimlane and a merge commit into `main` so per-leg attribution survives. Mechanics: [`.claude/docs/AGENTIC_GITFLOW.md`](.claude/docs/AGENTIC_GITFLOW.md).
+- **Per-component CI** is path-filtered so each component's gates run independently. Today only [`rust-ci.yml`](.github/workflows/rust-ci.yml) exists — four jobs: gates (fmt · clippy · test · release build) · integration (live-ClickHouse round-trip) · supply-chain (cargo-deny) · docker-build. A Python gate for `services/generator-python/` is still open.
 - **Contracts are jointly owned** by the Pods on both sides of a boundary (input = Pod 1 + Pod 2; the bronze read schema = Pod 2 + Pod 3). **Components are singly owned.**
 - The **bronze DDL is Pod-3-owned** (`create_schema:false`); collectors only `INSERT`.
 
@@ -209,7 +210,7 @@ Run `make help` for all targets and the active `SCENARIO / SEED / WINDOW`. Per-c
 | Prometheus `/metrics` endpoint on `:9090` | ✅ |
 | Graceful shutdown with final buffer flush | ✅ |
 | Distroless Docker image + root compose orchestrator | ✅ |
-| CI: fmt · clippy · tests · cargo-deny · docker-build | ✅ |
+| CI: gates (fmt · clippy · test · build) · integration (live ClickHouse) · cargo-deny · docker-build | ✅ |
 | Pod 3 silver (rolling-stats rollup, read models) | 🔶 in progress |
 
 **Latest local E2E snapshot** — Docker/Linux arm64, scenario `baseline`, seed `42`, window `5m` (2026-08-04):
@@ -240,6 +241,8 @@ This workload met the collector health gates: no signal loss, no contract reject
 | 3 | Sentinel keys are `Map` probes under bronze (no typed columns) — materialize in silver? | Open | [ADR-0007 §Trade-offs](docs/adr/0007-bronze-canonical-contract.md) |
 | 4 | `otel_metrics_1m` rolling-stats moved to Pod 3 silver (Tier-1 input) | Handoff | [read contract §2.3](contracts/collector/v1/pod2-pod3-read-contract.md) |
 | 5 | Histogram / Summary metrics not emitted (no v1.0.0 type) | Known gap | `services/collector-rust/src/otlp.rs` |
+| 6 | Python CI gate for `services/generator-python/` not yet added | Open | [`.github/workflows/`](.github/workflows/) |
+| 7 | Agentic gitflow amends the WoW's squash-to-main rule (needs ratification) | Pending | [ADR-0009](docs/adr/0009-agentic-gitflow.md) |
 
 ---
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -11,7 +11,9 @@ inside an implementation.
 | **`collector/`** | Pod 2 → Pod 3 (read) | [`collector/v1/pod2-pod3-read-contract.md`](collector/v1/pod2-pod3-read-contract.md) — the ClickHouse **bronze** read interface (the semantic layer over [`infra/clickhouse/init.d/01-bronze-otel.sql`](../infra/clickhouse/init.d/01-bronze-otel.sql)); machine-readable companion [`pod2-pod3-read-contract.yaml`](collector/v1/pod2-pod3-read-contract.yaml) | `v1.0.0.1` |
 
 - **`generator/`** is the producer (generator) single source of truth for the Pod 1 → Pod 2
-  OTLP handoff. Both collectors (Rust + Go) validate against it; neither keeps its own copy.
+  OTLP handoff. The collector validates against it and keeps no copy of its own. (Written while
+  Rust and Go both consumed it; the Go collector was removed in PR #28, merged 2026-08-12 — the
+  contract is deliberately implementation-agnostic, so nothing about it changed.)
 - **`collector/`** is the Pod 2 → Pod 3 bronze-schema boundary — one shared, implementation-
   agnostic contract that every collector implementation writes into. See
   [ADR-0007](../docs/adr/0007-bronze-canonical-contract.md).

--- a/docs/adr/0008-contracts-registry-by-producing-pod.md
+++ b/docs/adr/0008-contracts-registry-by-producing-pod.md
@@ -101,6 +101,13 @@ edits Pod 1 generator code). Both are paid once and were validated end-to-end (b
   `make e2e COLLECTOR=go` → `default.*` 40,200 / 40,200 / 152,700; 0 generator failures
   (schema resolved from `/contracts/generator/v1`).
 
+> **Reading this later:** the evidence line above is a point-in-time record from 2026-06-23,
+> when both collectors existed. `make e2e COLLECTOR=rust|go`, the Go collector and the
+> `default.*` schema were all removed in PR #28 (merged 2026-08-12); the database formerly
+> called `sentinel` is now `bronze`. The commands are not runnable today — they are kept as
+> the evidence that was actually produced. The registry structure this ADR decides is
+> unaffected.
+
 ## Risks
 
 - **Cross-Pod churn.** Pod 1's generator code and both collectors' env changed. Mitigated by

--- a/docs/adr/0009-agentic-gitflow.md
+++ b/docs/adr/0009-agentic-gitflow.md
@@ -1,0 +1,290 @@
+# ADR-0009 · Agentic gitflow — seam → swimlane → leg → task
+
+| Field | Value |
+|---|---|
+| Status | Proposed — process change; acceptance = Captain + Commander ratification at the sync |
+| Date | 2026-08-18 |
+| Owners | Crew B (all Pods) |
+| Proposer | Victor Urquiola (from the Commander's whiteboard sketch) |
+| Supersedes | — (amends the WoW branching + merge rules; see [Trade-offs](#trade-offs)) |
+| Related | [ADR-0008](0008-contracts-registry-by-producing-pod.md) (the ownership seams this rides on) · [WoW](../../.claude/kb/process/crew-b-wow/index.md) · practical guide [`.claude/docs/AGENTIC_GITFLOW.md`](../../.claude/docs/AGENTIC_GITFLOW.md) |
+
+> **This is a process ADR, not an architecture one.** It exists because agentic development
+> breaks an assumption our WoW was written under: that one contributor works in one checkout
+> at a time. When N agents edit files concurrently, branch hygiene stops being style and
+> becomes a correctness property.
+
+## Context
+
+Crew B is moving from human-paced contribution to **agent fleets**: several coding agents
+working simultaneously inside one repository. Two things break immediately.
+
+1. **One checkout, N writers.** Agents editing the same working tree corrupt each other —
+   half-applied edits, races on the index, `git checkout` under a peer's feet. The isolation
+   primitive that fixes this is `git worktree`: separate working directories sharing one
+   `.git`, so branches are cheap and truly parallel.
+2. **Our merge gate does not scale to agent output volume.** The WoW requires 2 approvals
+   (peer + Captain) and the CI gates on every PR to `main`. An agent produces many small,
+   cheap, disposable changes. Applying the full human gate to each one burns the scarcest
+   resource we have — Captain attention — on the lowest-blast-radius diffs.
+
+The Commander sketched a four-level decomposition — **seam → swimlanes → legs → tasks** —
+with worktrees fanning out of a feature branch and returning by Pull Request. This ADR
+records that shape, resolves the vocabulary, and adds the three rules the sketch left
+implicit (path disjointness, sync cadence, per-level gates).
+
+## Decision
+
+**Adopt the four-level decomposition below as Crew B's branching model for agent-assisted work.**
+
+| Level | Is | Git artifact | Lifetime |
+|---|---|---|---|
+| **Seam** | the **ownership boundary** the work crosses — a Pod's zone or a contract boundary. Not a git object; it is what decides whether two pieces of work can run in parallel | — (`contracts/`, `services/<component>/`, `infra/`) | permanent |
+| **Swimlane** | one coherent effort inside a seam, owned by one Pod | `feat/<area>-<short>` | days–weeks |
+| **Leg** | one parallelizable chunk of a swimlane, executed by one agent in its own worktree | `leg/<area>/<task>-v<n>` + worktree at `.worktrees/<task>-v<n>` | hours–days, disposable |
+| **Task** | a unit of work inside a leg | commits | minutes–hours |
+
+### What a leg physically is
+
+A leg is **two things at once, and that pairing is the whole point**: a *branch* (what git
+tracks) and a **separate working directory on disk** (what the agent actually edits). That
+directory is a **git worktree** — created with one command, sharing the parent clone's `.git`:
+
+```sh
+git worktree add -b leg/collector-histograms/otlp-mapping-v1 .worktrees/otlp-mapping-v1 feat/collector-histograms
+#                   ^ new branch                             ^ new directory            ^ branches from here
+```
+
+After running it twice, one clone looks like this:
+
+```mermaid
+flowchart TB
+    W0["📁 sentinel/<br/>THE MAIN WORKTREE<br/>▸ <b>feat/collector-histograms</b><br/>👤 you — the integrator"]
+    W1["📁 sentinel/.worktrees/otlp-mapping-v1<br/>A LEG WORKTREE<br/>▸ <b>leg/collector-histograms/otlp-mapping-v1</b><br/>🤖 agent A1 — owns src/otlp.rs"]
+    W2["📁 sentinel/.worktrees/exporter-rows-v1<br/>A LEG WORKTREE<br/>▸ <b>leg/collector-histograms/exporter-rows-v1</b><br/>🤖 agent A2 — owns src/clickhouse_exporter.rs"]
+
+    GIT[("🗄️ sentinel/.git — ONE object store, ONE set of refs, shared by all three<br/>git refuses to check out the same branch in two worktrees")]
+
+    W0 ---|"separate files on disk"| GIT
+    W1 ---|"separate files on disk"| GIT
+    W2 ---|"separate files on disk"| GIT
+
+    classDef wt fill:#ffffff,stroke:#475569,stroke-width:2px,color:#1e293b;
+    classDef main fill:#eef6ff,stroke:#4a86c5,stroke-width:2px,color:#0d2a45;
+    classDef store fill:#fde68a,stroke:#b45309,stroke-width:4px,color:#3a2f00;
+    class W1,W2 wt;
+    class W0 main;
+    class GIT store;
+```
+
+Three directories, three branches checked out simultaneously, **one** `.git`. That is what
+makes N agents parallel: agent A1 editing `src/otlp.rs` in one directory
+cannot touch agent A2's files in another, because they are different files on disk — while
+both still share every commit, ref and object with the parent clone. No second clone, no
+`git switch` under a peer's feet, no half-applied edits.
+
+Git enforces one guardrail for free: **the same branch cannot be checked out in two worktrees
+at once.** It refuses. That is the feature, not an obstacle.
+
+Two consequences worth internalizing before running a fleet:
+
+- **A worktree is local.** It has no presence on `origin`. To open a PR from a leg you must
+  push its branch first (`git push -u origin leg/…`).
+- **Each worktree has its own build artifacts** (`target/`, `.venv/`). That is the cost of
+  the isolation, and it is why the shared-cache setup in [the guide](../../.claude/docs/AGENTIC_GITFLOW.md)
+  is not optional.
+
+### The whole flow — two swimlanes, four agents, one trunk
+
+Everything above, in one picture. Two **real** Sentinel work items that are open right now
+(README §9 item 5, and the Pod 3 silver row), each fanned out to two agents:
+
+```mermaid
+%% NOTE: SEAMB is declared BEFORE SEAMA on purpose — dagre renders the last-declared
+%% cluster nearest the top, so this is what puts LANE A above `main` and LANE B below.
+%% Swapping them back flips the layout. Keep the order.
+flowchart TB
+    MAIN[["<b>main</b><br/>protected trunk"]]
+
+    subgraph SEAMB["🟠 LANE B · SEAM infra/clickhouse/** · Pod 3"]
+        direction TB
+        SB["📁 .worktrees/lane-silver<br/><b>feat/silver-rolling-stats</b>"]
+        B1["📁 .worktrees/silver-ddl-v1<br/><b>leg/silver-rolling-stats/silver-ddl-v1</b><br/>🤖 B1 · owns init.d/02-silver.sql"]
+        B2["📁 .worktrees/read-models-v1<br/><b>leg/silver-rolling-stats/read-models-v1</b><br/>🤖 B2 · owns silver/models/**"]
+        SB ==>|"② worktree"| B1
+        SB ==>|"② worktree"| B2
+        B1 -->|"③ PR · squash"| SB
+        B2 -->|"③ PR · squash"| SB
+        SB -.->|"④ rebase"| B1
+        SB -.->|"④ rebase"| B2
+    end
+
+    subgraph SEAMA["🟡 LANE A · SEAM services/collector-rust/** · Pod 2"]
+        direction TB
+        SA["📁 .worktrees/lane-histograms<br/><b>feat/collector-histograms</b>"]
+        A1["📁 .worktrees/otlp-mapping-v1<br/><b>leg/collector-histograms/otlp-mapping-v1</b><br/>🤖 A1 · owns src/otlp.rs"]
+        A2["📁 .worktrees/exporter-rows-v1<br/><b>leg/collector-histograms/exporter-rows-v1</b><br/>🤖 A2 · owns src/clickhouse_exporter.rs"]
+        SA ==>|"② worktree"| A1
+        SA ==>|"② worktree"| A2
+        A1 -->|"③ PR · squash"| SA
+        A2 -->|"③ PR · squash"| SA
+        SA -.->|"④ rebase"| A1
+        SA -.->|"④ rebase"| A2
+    end
+
+    MAIN ==>|"① branch"| SA
+    MAIN ==>|"① branch"| SB
+    SA ==>|"⑤ PR · 2 approvals · merge commit"| MAIN
+    SB ==>|"⑤ PR · 2 approvals · merge commit"| MAIN
+    MAIN -.->|"④ rebase lane"| SA
+    MAIN -.->|"④ rebase lane"| SB
+
+    classDef trunk fill:#1e293b,stroke:#0f172a,stroke-width:4px,color:#ffffff;
+    classDef zoneA fill:#fef9c3,stroke:#ca8a04,stroke-width:3px,color:#3f2d00;
+    classDef zoneB fill:#ffedd5,stroke:#ea580c,stroke-width:3px,color:#431407;
+    classDef laneA fill:#fde047,stroke:#a16207,stroke-width:3px,color:#3f2d00;
+    classDef laneB fill:#fdba74,stroke:#c2410c,stroke-width:3px,color:#431407;
+    classDef legA fill:#ffffff,stroke:#a16207,stroke-width:2px,color:#3f2d00;
+    classDef legB fill:#ffffff,stroke:#c2410c,stroke-width:2px,color:#431407;
+    class MAIN trunk;
+    class SEAMA zoneA;
+    class SEAMB zoneB;
+    class SA laneA;
+    class SB laneB;
+    class A1,A2 legA;
+    class B1,B2 legB;
+```
+
+**Diagram key** — read it vertically. **Swimlane A on top, `main` in the middle, swimlane B
+below**: the trunk sits between the two lanes it serves. Inside each lane the flow runs downward
+too — the lane's own worktree first, its legs beneath it.
+
+- **Dark** = the protected trunk · **🟡 yellow = swimlane A**, **🟠 orange = swimlane B**, each
+  shading its whole seam · **white** = a disposable leg worktree, bordered in its lane's colour.
+- **Colour is never the only cue.** Every cluster is also labelled `LANE A` / `LANE B`, and the
+  branch name is **bold** inside every box — so this survives greyscale and colour-blind readers.
+- **Every box is a directory on disk** (📁) holding exactly one branch and one worker.
+- **Solid** = work fanning out and PRs coming back · **dotted ④ = the sync edges**, which the
+  original sketch omitted and which are what keep the model from rotting.
+
+Read one lane and you have the whole lifecycle: **① branch** from `main` → **② `git worktree add`**
+one directory per agent → **③ PR** back into the lane (1 review + full CI, squash) →
+**④ rebase** continuously, both siblings onto the lane and the lane onto `main` →
+**⑤ PR** to `main` (2 approvals, merge commit). Steps ③ and ⑤ are rule R3; step ④ is R2.
+
+**Why both lanes can run at the same time:** they sit in **different seams**. Lane A never
+leaves `services/collector-rust/`; lane B never leaves `infra/clickhouse/`. Neither can break
+the other, so both branch from `main` independently and merge back independently — whichever
+lands first, the other rebases.
+
+**This is R1 applied at two levels.** The disjoint-paths test governs *both* fan-outs: the four
+legs against each other, and the two lanes against each other. One test, two levels — which is
+the reason "seam" sits at the top of the hierarchy rather than being a synonym for `main`.
+
+**When lanes are *not* independent, the seam says so — and orders them.** Histogram support is
+the honest example: the collector cannot emit a histogram the input contract has no type for,
+so the work also touches `contracts/generator/`, a **third seam jointly owned by Pod 1 and
+Pod 2**. That crossing is not a leg and not a sibling lane — it is a *predecessor*. The
+contract bump lands as its own swimlane first; `feat/collector-histograms` rebases onto it and
+only then can finish. **Work that crosses a seam is sequenced, never fanned out.**
+
+A command-by-command walkthrough of exactly these two lanes — including the `git worktree list`
+output and the cleanup — is in
+[`.claude/docs/AGENTIC_GITFLOW.md`](../../.claude/docs/AGENTIC_GITFLOW.md#worked-example--two-swimlanes-end-to-end).
+
+
+Four rules make it work. The first three were implicit in the sketch:
+
+**R1 · Legs declare disjoint paths.** Every leg names the paths it owns before it opens. Two
+open legs in a swimlane **may not** declare overlapping paths. If they must overlap, they are
+one leg — or the shared part is extracted into a leg that lands first. This is what makes
+"seam" load-bearing rather than decorative: parallelism is bounded by *ownership*, not by how
+independent the tasks sound in prose. Sentinel already has these seams from
+[ADR-0008](0008-contracts-registry-by-producing-pod.md) — `contracts/`, `infra/`,
+`services/collector-rust/`, `services/generator-python/` are disjoint by construction.
+
+**R2 · Sync flows both ways.** The lane rebases onto `main` after every merge to `main`.
+Surviving legs rebase onto the lane after every fan-in. Without this, the lane drifts and the
+swimlane→main PR becomes a big-bang merge — precisely the diff our 2-approval gate reviews
+worst.
+
+**R3 · Gates differ by level.** Human attention concentrates where blast radius is.
+
+| PR | Review | CI | Merge style |
+|---|---|---|---|
+| leg → swimlane | 1 reviewer (may be the `code-reviewer` agent) | full gates | **squash** — one commit per leg |
+| swimlane → main | 2 approvals: peer + Captain | full gates | **merge commit** — preserves one commit per leg |
+
+**R4 · Legs are disposable, branches are not named after tools.** A failed leg is closed and
+reopened as `-v2`; nothing is salvaged from it. Branch names describe the *work*
+(`leg/collector-histograms/otlp-mapping-v1`), never the mechanism — the branch outlives the worktree,
+and a name like `worktree/…` lies the moment the same task runs without one. The worktree
+*directory* lives at `.worktrees/<task>-v<n>` (gitignored).
+
+**When not to use legs.** The structure costs a branch, a worktree, a PR, a review and a
+rebase each. It pays only when ≥2 agents work simultaneously on disjoint paths. A single
+sequential task works directly in the swimlane. **Dependent** work does not fan out at all —
+it stacks (leg B branches from leg A, PR B targets branch A). Forcing dependent work into a
+parallel fan-out is the primary way this pattern produces garbage.
+
+## Options considered
+
+| # | Option | Verdict |
+|---|---|---|
+| A | **Agents share one checkout, serialize by lock** | Rejected. Serializes exactly the work we parallelized; a crashed agent holds the lock. |
+| B | **One clone per agent** | Rejected. Full object-store copy per agent, no shared refs, expensive at Rust build sizes. Worktrees give the same isolation for a fraction of the cost. |
+| C | **Legs branch from `main`, PR straight to `main`** | Rejected. Every agent's WIP hits the protected trunk and the full 2-approval gate; no place to integrate a multi-leg effort before human review. |
+| D | **Legs branch from the swimlane, PR to the swimlane** (the sketch) | **Adopted**, plus R1–R4. |
+| E | **Stacked PRs throughout** | Rejected as the default — it serializes review. Retained as the prescribed shape for *dependent* legs. |
+
+## Trade-offs
+
+- **This ADR amends the WoW.** The WoW says "squash-merge to main". R3 keeps squash at
+  leg→swimlane but requires a **merge commit** at swimlane→main. Reason: squashing twice
+  flattens the `Co-Authored-By` attribution trailers our WoW mandates, and we lose which agent
+  authored what. Attribution is a stated Crew B value, so the merge style bends to it rather
+  than the reverse. **This is the change most in need of explicit ratification.**
+- **The 2-approval gate is relaxed at leg level** (1 reviewer, possibly an agent). We trade
+  per-leg human scrutiny for scrutiny concentrated on the integration PR. The counter-argument
+  — that a bad leg reaches `main` with only one human look — is real, and is why the
+  swimlane→main gate keeps both approvals and why R1 keeps legs small and bounded.
+- **Longer-lived integration branches** are a known smell. R2 is the mitigation, not a cure;
+  a swimlane open for more than ~2 weeks should be split.
+
+## Consequences
+
+- Agents get a mechanical, checkable definition of "can these two run in parallel?" — do their
+  declared paths intersect? — instead of a judgement call.
+- `main` history becomes one commit per leg, each carrying its attribution trailers, grouped
+  under a merge commit per swimlane. Reading `main` tells you what was built and by whom.
+- `.worktrees/` must be gitignored, and **shared build caches become mandatory**: each worktree
+  otherwise gets its own `services/collector-rust/target/` (multiple GB, cold rebuild). With 6
+  agent worktrees and no shared `CARGO_TARGET_DIR`, parallel agents are *slower* than serial.
+  Same for the `uv` cache on the Python side. Mechanics in
+  [`.claude/docs/AGENTIC_GITFLOW.md`](../../.claude/docs/AGENTIC_GITFLOW.md).
+- Leg branches must be pushed to `origin` to open a PR — worktrees are local-only.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Path disjointness (R1) is declared but not enforced; two legs overlap anyway | Start as a checklist item in the leg PR template. Escalate to a CI check comparing open legs' declared paths if it bites twice. |
+| Relaxed leg review lets a defect reach the integration branch | Legs are small and bounded by R1; the swimlane→main gate is unchanged; a bad leg is revertible as one squashed commit. |
+| Merge-commit-to-main makes `main` history noisier than today | Accepted deliberately in exchange for attribution fidelity. |
+| Vocabulary collision: "seam" already means *ownership seam* in `kb/communication/architecture-diagramming` | Resolved by using it in exactly that sense here. **Open point for the sync:** the original sketch may have meant seam = `main`. If so, this ADR renames the top level and the rest stands unchanged. |
+| The four levels become ceremony for one-agent work | The "when not to use legs" rule above; legs are opt-in above 2 concurrent agents. |
+
+## Next steps
+
+1. Ratify at the sync — specifically the **merge-commit-to-main** amendment and the **seam** vocabulary.
+2. Land the practical guide [`.claude/docs/AGENTIC_GITFLOW.md`](../../.claude/docs/AGENTIC_GITFLOW.md) and gitignore `.worktrees/`.
+3. Add a leg-PR template carrying the declared-paths checklist (R1).
+4. Add the shared build-cache bootstrap to the worktree setup.
+5. Re-evaluate after one full swimlane runs under it; amend rather than replace.
+
+## References
+
+- The Commander's whiteboard sketch, *Seam ⇒ Swimlanes ⇒ Legs ⇒ Tasks*
+- [ADR-0008](0008-contracts-registry-by-producing-pod.md) — the ownership seams R1 rides on
+- [Crew B WoW](../../.claude/kb/process/crew-b-wow/index.md) — the branching + merge rules this amends
+- `git worktree` — <https://git-scm.com/docs/git-worktree>

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,13 +9,14 @@ This directory holds Sentinel's ADRs. Per the [Crew B WoW spec](../../README.md)
 | 0001 | Blast radius of self-healing | _Pending_ | Crew B (Sprint 1) |
 | 0002 | Where the baseline lives | _Pending_ | Crew B (Sprint 1) |
 | 0003 | Primary user of Sentinel | _Pending_ | Crew B (Sprint 1) |
-| 0004 | [Collector implementation language](0004-collector-implementation-language.md) | **Proposed** | Pod 2 |
+| 0004 | [Collector implementation language](0004-collector-implementation-language.md) | **Proposed** ⚠️ *stale — Rust selected in practice* | Pod 2 |
 | 0005 | [ClickHouse storage schema for OTLP signals](0005-clickhouse-storage-schema.md) | **Superseded by 0007** | Pod 2 |
 | 0006 | [Optional trace/span ID representation](0006-optional-id-representation.md) | **Proposed** (refined by 0007) | Pod 2 |
 | 0007 | [Bronze = canonical Pod 2 → Pod 3 contract](0007-bronze-canonical-contract.md) | **Proposed** | Pod 2 · Pod 3 |
 | 0008 | [Contracts registry namespaced by producing Pod](0008-contracts-registry-by-producing-pod.md) | **Proposed** | Pod 1 · Pod 2 |
+| 0009 | [Agentic gitflow — seam → swimlane → leg → task](0009-agentic-gitflow.md) | **Proposed** | Crew B (all Pods) |
 
-ADRs 0001–0003 are the three Sprint 1 ADRs the Commander assigned (`bem-vindos.md`). ADR-0004 is a Pod 2 proposal opening the Collector language bake-off (Sync 02 action A7). ADRs 0005–0006 are Pod 2's Day-3 storage-schema decisions, gating the [Pod 2 → Pod 3 ClickHouse read contract](../../contracts/collector/v1/pod2-pod3-read-contract.md). **ADR-0007 supersedes 0005**: Pod 3's otel-collector-contrib bronze schema (`sentinel.*`) is now the canonical read contract, and the Rust collector writes directly into it (validated end-to-end). **ADR-0008** records the `contracts/` registry structure — namespaced by producing Pod (`generator/` + `collector/`), implementation-agnostic, versioned per boundary.
+ADRs 0001–0003 are the three Sprint 1 ADRs the Commander assigned (`bem-vindos.md`). ADR-0004 is a Pod 2 proposal opening the Collector language bake-off (Sync 02 action A7). ⚠️ **It is out of date:** Rust was selected and `services/collector-go/` was removed from the repo in PR #28 (merged 2026-08-12). The decision was taken by merge, not by ADR — promoting 0004 to **Accepted** with a selection note is an open Pod 2 action. ADRs 0005–0006 are Pod 2's Day-3 storage-schema decisions, gating the [Pod 2 → Pod 3 ClickHouse read contract](../../contracts/collector/v1/pod2-pod3-read-contract.md). **ADR-0007 supersedes 0005**: Pod 3's otel-collector-contrib bronze schema (database `bronze`, `bronze.*` — renamed from `sentinel` per [ADR-0007's 2026-07-21 amendment](0007-bronze-canonical-contract.md), which disambiguates it from the `sentinel.*` attribute keys) is now the canonical read contract, and the Rust collector writes directly into it (validated end-to-end). **ADR-0008** records the `contracts/` registry structure — namespaced by producing Pod (`generator/` + `collector/`), implementation-agnostic, versioned per boundary. **ADR-0009** is the first *process* ADR: the branching model for agent fleets (seam → swimlane → leg → task, one git worktree per agent), with a practical guide at [`.claude/docs/AGENTIC_GITFLOW.md`](../../.claude/docs/AGENTIC_GITFLOW.md). It amends the WoW's merge rules, so it needs explicit ratification.
 
 ## Template
 

--- a/docs/research/pod3-bronze-gap.md
+++ b/docs/research/pod3-bronze-gap.md
@@ -1,5 +1,12 @@
 # POD2 (Rust collector) → POD3 Bronze — Schema Gap Analysis
 
+> **HISTORICAL (gap closed).** This analysis documented the gap between the collector's
+> normalized `default.*` output and Pod 3's bronze landing. The gap is **closed**: the Rust
+> collector now writes the bronze schema directly (database `bronze`, renamed from `sentinel`
+> per [ADR-0007](../adr/0007-bronze-canonical-contract.md)'s 2026-07-21 amendment). Kept as
+> the decision rationale. References below to `default.*`, the Go collector, or
+> `make COLLECTOR=rust e2e` describe the repo as it was — none of them exist today.
+
 | Field | Value |
 |---|---|
 | Status | **Research / decision-input — not a decision** |

--- a/infra/clickhouse-init.sql
+++ b/infra/clickhouse-init.sql
@@ -1,10 +1,14 @@
 -- Root orchestrator ClickHouse bootstrap (docker-entrypoint-initdb.d).
 --
--- Creates the `otelgen` user + `bronze` database that the Go collector expects
--- (CLICKHOUSE_DSN = clickhouse://otelgen:otelgen_secret@clickhouse:9000/bronze),
--- WITHOUT touching the passwordless `default` user that the Rust collector uses
--- over HTTP :8123. This is orchestration glue only — it creates a user/database,
--- not table schemas. The bronze table DDL is owned by init.d/01-bronze-otel.sql.
+-- Creates the `bronze` database, and deliberately does NOT touch the passwordless
+-- `default` user that the Rust collector uses over HTTP :8123.
+--
+-- The `otelgen` user below is VESTIGIAL: it existed for the Go collector's DSN
+-- (clickhouse://otelgen:otelgen_secret@clickhouse:9000/bronze), and the Go collector was
+-- removed in PR #28 (merged 2026-08-12). Nothing uses it today — safe to drop.
+--
+-- This is orchestration glue only — it creates a user/database, not table schemas.
+-- The bronze table DDL is owned by init.d/01-bronze-otel.sql.
 
 CREATE DATABASE IF NOT EXISTS bronze;
 

--- a/services/collector-rust/Cargo.lock
+++ b/services/collector-rust/Cargo.lock
@@ -356,9 +356,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/services/collector-rust/README.md
+++ b/services/collector-rust/README.md
@@ -1,103 +1,118 @@
-# `sentinel-collector` · Rust (Day 1: NDJSON parser)
+# `sentinel-collector` · Rust
 
-The Rust implementation of the Sentinel OTel Collector. Eventually receives OTLP over gRPC on `:4317`, validates against Pod 1's contract, batches, and exports to ClickHouse.
+The Sentinel OTel Collector — Pod 2's ingestion gateway. Receives OTLP over gRPC on `:4317`
+(or reads Pod 1's NDJSON), validates against the Pod 1 → Pod 2 input contract, buffers and
+batches, and writes directly into Pod 3's **bronze** ClickHouse schema.
 
-> **Status: Day 1 of the [10-day Pod 2 sprint plan](../../docs/research/learning-roadmap-pod2-rust.md).** Currently reads Pod 1's golden NDJSON fixture (`contract/golden/baseline_seed42.jsonl`), deserializes into the canonical `Signal` enum, validates against the v1.0.0 contract, and prints per-signal-type counts. ClickHouse exporter lands Day 3-5; OTLP gRPC receiver lands Day 8-9.
+> **Status: selected implementation, validated end-to-end.** After the language bake-off,
+> Pod 2 standardized on Rust and `services/collector-go/` was removed from the repo
+> (PR #28, merged 2026-08-12). Latest local E2E: 233,100 signals in 4.5s, lossless, avg export
+> latency 32.3ms — see [README §8](../../README.md) for the full snapshot.
+> ⚠️ [ADR-0004](../../docs/adr/0004-collector-implementation-language.md) still reads
+> `Proposed` and has not been updated to record the selection.
 
-## Why this exists
+## What it does
 
-Sync 02 (2026-05-26) action A7 scheduled a bake-off for the Collector implementation language. This crate is the Rust corner. The Go corner should land in a sibling PR at `services/collector-go/` (not yet open).
+| Boundary | Contract | Enforcement |
+|---|---|---|
+| **Inbound** (producer → collector) | [`contracts/generator/v1/schema/otlp_output.schema.json`](../../contracts/generator/v1/schema/otlp_output.schema.json) **v1.0.0** — 3 signal types, 5 guaranteed `sentinel.*`/`cloud.provider` resource keys | gRPC: `contract.grpc_validation` = `off`/`warn`/**`warn` default**/`strict`. File: `contract.strict` (all-or-nothing) |
+| **Outbound** (collector → ClickHouse) | the **bronze DDL** ([`infra/clickhouse/init.d/01-bronze-otel.sql`](../../infra/clickhouse/init.d/01-bronze-otel.sql)), documented by the [Pod 2 → Pod 3 read contract](../../contracts/collector/v1/pod2-pod3-read-contract.md) v1.0.0.1 | Typed rows via the `clickhouse` crate. The collector issues **no DDL at all** — Pod 3 owns the table lifecycle (the repo calls this policy `create_schema:false`, after the contrib exporter's flag) |
 
-The full case is in [`docs/adr/0004-collector-implementation-language.md`](../../docs/adr/0004-collector-implementation-language.md). The receipts are in [`docs/research/rust-otel-collector.md`](../../docs/research/rust-otel-collector.md). Read those first if you arrived here cold.
+`warn` is the gRPC default on purpose: foreign OTLP legitimately lacks the five `sentinel.*`
+keys, so `strict` would silently drop real traffic. Use `strict` only when the sender is
+guaranteed Sentinel-internal.
 
-## Prerequisites
+## Run it
 
-```bash
-# Rust toolchain (stable 1.75+)
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup default stable
-rustup component add rustfmt clippy
+From the repo root (Docker, no host toolchain):
 
-# Verify
-cargo --version
-rustc --version
+```sh
+make e2e        # ClickHouse + collector + generator → bronze.*
+make logs       # tail the collector
 ```
 
-## Build & run (scaffold only)
+Standalone:
 
-```bash
+```sh
 cd services/collector-rust
-cargo build
-cargo run     # logs a startup line in JSON then exits
-cargo test    # runs the scaffold-compiles smoke test
+cargo run -- config.example.yaml   # FILE mode: read the golden NDJSON, tally, exit
+cargo test                         # unit + integration (live-ClickHouse tests are #[ignore]d)
 ```
 
-Both should succeed before the bake-off properly starts.
+**Run modes** are decided by which config sections are present — see
+[`config.example.yaml`](config.example.yaml), which documents every key:
 
-## Lint + format gates
+| `grpc:` | `clickhouse:` | Mode |
+|---|---|---|
+| absent | absent | FILE + count only — parse `input.path`, tally, exit |
+| absent | present | FILE + export — parse `input.path`, write to ClickHouse, exit |
+| present | absent | SERVER + log only — serve `:4317`, count and log requests |
+| present | present | SERVER + export — the production path |
 
-These map to the CI gates in the [Crew B WoW spec](../../docs/adr/) (when ADR-0007 — per-language CI profiles — lands):
+`CLICKHOUSE_URL` and `RUST_LOG` override the config file.
 
-```bash
-cargo fmt --check
-cargo clippy --all-targets -- -D warnings
-cargo test
+## Lint + test gates
+
+These are the gates `.github/workflows/rust-ci.yml` enforces:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --locked
+cargo test --test clickhouse_roundtrip --locked -- --ignored   # needs a live ClickHouse
+cargo deny check                                               # advisories + licenses (deny.toml)
 ```
 
-## What's next (in dependency order)
+CI runs these as four jobs: **gates** (fmt · clippy · test · release build) ·
+**integration** (ClickHouse round-trip against a real container) · **supply-chain**
+(cargo-deny) · **docker-build** (distroless image).
 
-1. **Bind OTLP gRPC server on `:4317`** — `tonic`-based, accepting `ExportTraceServiceRequest`. Smallest possible loop: receive → log → return default response. Goal: prove the wire is alive.
-2. **Connect to ClickHouse** — using the `clickhouse` crate (Native protocol via HTTP). Create one table, write one span. Goal: prove the export side works.
-3. **Glue receive → export with a bounded `mpsc` channel** — backpressure surface for the bake-off. Goal: load-generator pings the receiver, span lands in ClickHouse.
-4. **Batching + flush thresholds** — size + time. Goal: throughput numbers worth measuring.
-5. **Container image** — multi-stage build, distroless final. Goal: 5–20 MB image for cold-start advantage.
-6. **Meta-telemetry** — the Collector emits its own OTel signals. Goal: Sentinel can watch Sentinel.
+The enforced lint policy is package-level `[lints]` in `Cargo.toml`: `unsafe_code = "forbid"`,
+`unwrap_used = "deny"`, `expect_used = "warn"`. **`pedantic`, `nursery` and `missing_docs` are
+deliberately commented out** — aspirational until a dedicated cleanup PR clears the existing
+warnings. Don't assume pedantic is on. (It becomes `[workspace.lints]` if a second Rust crate
+ever appears.) Full standards:
+[`.claude/docs/RUST_PROJECT_STANDARDS.md`](../../.claude/docs/RUST_PROJECT_STANDARDS.md).
 
-Each of these steps is a small PR, reviewed by Pod 2 and merged via the standard 8-step PR flow (signed commits, 2 approvals, 7 CI gates, attribution trailers).
-
-## Directory layout (target)
+## Layout
 
 ```text
 services/collector-rust/
-├── Cargo.toml
-├── README.md         # this file
+├── Cargo.toml · rust-toolchain.toml · rustfmt.toml · clippy.toml · deny.toml
+├── config.example.yaml     # documented reference config
+├── config.docker.yaml      # the compose profile (has `grpc:` → server mode)
+├── Dockerfile              # multi-stage → distroless
+├── justfile                # local dev recipes
 ├── src/
-│   ├── main.rs       # entry point (scaffold)
-│   ├── receiver.rs   # OTLP gRPC server (planned)
-│   ├── exporter.rs   # ClickHouse write path (planned)
-│   ├── pipeline.rs   # receive → batch → export glue (planned)
-│   └── config.rs     # YAML config loader (planned)
-└── tests/            # integration tests against a local ClickHouse container
+│   ├── main.rs             # entry point — picks run mode from config
+│   ├── lib.rs              # module root
+│   ├── config.rs           # YAML loader; unknown keys rejected
+│   ├── contract.rs         # v1.0.0 input-contract validation
+│   ├── otlp.rs             # OTLP protobuf → internal `Signal`
+│   ├── grpc.rs             # tonic OTLP server (:4317) + `apply_validation`
+│   ├── buffer.rs           # bounded buffer, size + interval flush thresholds
+│   ├── clickhouse_exporter.rs  # typed bronze writes (RowBinary over HTTP :8123)
+│   ├── metrics.rs          # Prometheus counters/histograms
+│   └── metrics_server.rs   # `/metrics` on :9090
+└── tests/
+    ├── golden_parse.rs           # golden fixture → 48 logs / 48 spans / 183 metrics
+    ├── grpc_smoke.rs             # server accepts OTLP
+    ├── grpc_export_roundtrip.rs  # OTLP in → bronze rows out
+    └── clickhouse_roundtrip.rs   # live-ClickHouse export (#[ignore]d by default)
 ```
 
-## Bake-off harness (cross-language, not in this crate)
+**Ports:** OTLP gRPC `:4317` · Prometheus `/metrics` `:9090` · ClickHouse **HTTP `:8123`**
+(the `clickhouse` crate speaks RowBinary over HTTP — not native `:9000`).
 
-The bake-off compares this crate to the eventual `services/collector-go/` against a shared:
+## Known gaps
 
-- Load generator (the Python data generator that Vinícius pushed — `services/generator/`)
-- ClickHouse instance (Docker compose, 8 GB VM)
-- Metric collection (Prometheus scraping both Collectors' meta-telemetry)
-- Decision criteria (defined in a future ADR-0006)
-
-The harness lives at `bench/collector-bakeoff/` (also not yet open). Either Pod 2 or the Captain will scaffold it once the language ADR is accepted.
-
-## Contract & boundaries
-
-Per Sync 02 D8, every component declares input/output contracts. The Collector's contracts:
-
-| Boundary | Contract | Validation |
-|---|---|---|
-| **Inbound** (Generator → Collector) | OTLP `ExportTraceServiceRequest` / `ExportMetricsServiceRequest` / `ExportLogsServiceRequest` | `opentelemetry-proto` generated types — protobuf-validated on receive |
-| **Outbound** (Collector → ClickHouse) | RAW table schema (per signal type), defined by Pod 3 | Strongly-typed via `clickhouse` crate `Row` derive; schema-version field in every row |
-
-Contracts are versioned. A breaking change opens a new ADR.
-
-## Attribution
-
-This scaffold was authored with `Co-Authored-By: Claude Opus 4.7` per the [Crew B attribution contract](../../docs/adr/) (see Sync 01 *How we ship*).
+- **Histogram / Summary metrics are not emitted** — the v1.0.0 input contract has no such type (`src/otlp.rs`).
+- **Sentinel keys live in `ResourceAttributes` `Map`** under bronze, not typed columns. Materializing them is a Pod 3 silver decision ([ADR-0007 §Trade-offs](../../docs/adr/0007-bronze-canonical-contract.md)).
 
 ## See also
 
-- [`docs/adr/0004-collector-implementation-language.md`](../../docs/adr/0004-collector-implementation-language.md) — the ADR this scaffold is paired with
-- [`docs/research/rust-otel-collector.md`](../../docs/research/rust-otel-collector.md) — research receipts
-- Sentinel spec (`sentinel.pdf` in Crew B docs) — overall mission + Watcher fleet context
+[ADR-0004](../../docs/adr/0004-collector-implementation-language.md) (language) ·
+[ADR-0006](../../docs/adr/0006-optional-id-representation.md) (optional IDs) ·
+[ADR-0007](../../docs/adr/0007-bronze-canonical-contract.md) (bronze = canonical contract) ·
+[read contract](../../contracts/collector/v1/pod2-pod3-read-contract.md) ·
+[research receipts](../../docs/research/rust-otel-collector.md)


### PR DESCRIPTION
## Why

`main` moved on and the docs didn't. PR #28 (merged 2026-08-12) removed `services/collector-go/` and made Rust the single collector, but the docs still described a two-collector repo — including commands that no longer exist (`make e2e COLLECTOR=rust|go`).

Two things ship here: the doc refresh, and an ADR proposing how we stop this from happening again once agents are doing the writing.

## 1 · `docs(adr)`: ADR-0009 — agentic gitflow

Records the Commander's whiteboard model — **seam → swimlane → leg → task** — with one `git worktree` per agent. Four rules the sketch left implicit:

| Rule | What it says |
|---|---|
| **R1** | Legs (and lanes) declare **disjoint paths** before they open — parallelism is bounded by *ownership*, riding the seams ADR-0008 already established |
| **R2** | Sync flows **both ways**: legs rebase onto the lane, the lane onto `main` |
| **R3** | Gates differ by level — 1 review to squash into the lane; 2 approvals + a merge commit into `main` |
| **R4** | Legs are disposable; branches are named for the **work**, never the tool |

Plus [`.claude/docs/AGENTIC_GITFLOW.md`](.claude/docs/AGENTIC_GITFLOW.md): commands, a worked two-swimlane example using two work items that are actually open (histogram support + Pod 3 silver), and the gotchas. The command sequence was executed against a throwaway repo, not just written down.

### ⚠️ Two things needing explicit ratification

1. **The merge-commit rule amends the WoW.** We say "squash-merge to main"; R3 keeps squash at leg→lane but requires a **merge commit** at lane→`main`. Reason: squashing twice flattens the per-leg `Co-Authored-By` trailers our attribution contract requires. Attribution is a stated Crew B value, so the merge style bends to it — but that's the team's call, not mine.
2. **"Seam"** is used here as *ownership boundary* (matching `kb/communication/architecture-diagramming`). The sketch may have meant `main`. If so, rename the top level; the rest stands.

## 2 · `docs`: the refresh

- **`CLAUDE.md`** — Rust-only pipeline, `bronze.*`, real Makefile targets, plus a **known-doc-drift table**
- **`.claude/CLAUDE.md`** — Pod 2 state was two months stale
- **`services/collector-rust/README.md`** — still said *"Day 1 scaffold, ClickHouse exporter lands Day 3-5"*; rewritten
- **`RUST_PROJECT_STANDARDS.md`** — toolchain pin `1.83.0` → `1.96.0`, root files marked target-not-current
- **`contracts/README.md`**, `docs/adr/README.md`, `ROADMAP.md`, `README.md`, `infra/clickhouse-init.sql` — pointers, counts, CI job list

**Historical records are annotated, not rewritten.** `docs/research/`, `docs/proposals/` and ADR evidence lines describe the repo as it was; falsifying them would be worse than the confusion they cause. They get a banner instead.

**Unresolved decisions are flagged, not resolved.** ADR-0004 still reads `Proposed` though Rust was selected by merge — promoting it is a Pod 2 action. The Pod↔layer mapping stays open for the Captain.

## Verification

97 internal links resolve · 4 mermaid blocks render (checked with `mermaid-cli`, not by eye) · no stale reference left in any *live* doc · no executable SQL changed, comments only · worktree command sequence tested in a scratch repo.

Not run: `make e2e` and the test suites — the only non-markdown changes are `.gitignore` and SQL comments. Say the word if you want it anyway.

## Review notes

- Two commits, ADR first so the pointers added in the refresh resolve at every commit.
- **Commits are not GPG-signed** — no key on this machine. Needs re-signing before merge to satisfy the WoW.
- The diagrams are `flowchart TB` with a `%%` note explaining that `SEAMB` is declared *before* `SEAMA` on purpose — swapping it flips the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
