### PR TITLE
feat(silver): add operational models and watcher read views

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ VALID_COLLECTORS := rust go
 
 .PHONY: help guard up init generate e2e down reset logs ps \
         build test test-generator test-collector-rust test-collector-go \
-        lint lint-generator lint-collector-rust lint-collector-go
+        test-silver sample-silver lint lint-generator lint-collector-rust lint-collector-go
 
 # Docker runner for per-service build/test/lint — no host toolchains required.
 DK_RUN := docker run --rm --user $(shell id -u):$(shell id -g) -v "$(CURDIR)":/w
@@ -65,6 +65,12 @@ build:               ## Build all service images (generator + both collectors)
 	COMPOSE_PROFILES=rust,go docker compose build
 
 test: test-generator test-collector-rust test-collector-go  ## Run all unit test suites
+
+test-silver:            ## Verify Bronze→Silver load and Silver read-model invariants
+	docker compose exec -T clickhouse clickhouse-client --multiquery < infra/clickhouse/tests/02-silver-layer.test.sql
+
+sample-silver:          ## Print representative rows from the Silver models
+	docker compose exec -T clickhouse clickhouse-client --multiquery --format PrettyCompact < infra/clickhouse/queries/02-silver-sample.sql
 
 test-generator:      ## Generator unit tests (pytest)
 	$(DK_RUN) -w /w/services/generator-python -e HOME=/tmp -e CONTRACTS_DIR=/w/contracts/generator/v1 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # Both collectors write this bronze split schema directly (ADR-0007); the tables must
       # exist before either collector connects, so they are created here on boot.
       - ./infra/clickhouse/init.d/01-bronze-otel.sql:/docker-entrypoint-initdb.d/02-bronze-otel.sql:ro
-      # POD 3 typed Silver models and Watcher read models (ADR-0009).
+      # POD 3 typed Silver models and Watcher read models (ADR-0010).
       - ./infra/clickhouse/init.d/02-silver-layer.sql:/docker-entrypoint-initdb.d/03-silver-layer.sql:ro
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8123/?query=SELECT+1"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       # Both collectors write this bronze split schema directly (ADR-0007); the tables must
       # exist before either collector connects, so they are created here on boot.
       - ./infra/clickhouse/init.d/01-bronze-otel.sql:/docker-entrypoint-initdb.d/02-bronze-otel.sql:ro
+      # POD 3 typed Silver models and Watcher read models (ADR-0009).
+      - ./infra/clickhouse/init.d/02-silver-layer.sql:/docker-entrypoint-initdb.d/03-silver-layer.sql:ro
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8123/?query=SELECT+1"]
       interval: 5s

--- a/docs/adr/0009-silver-v1-operational-model.md
+++ b/docs/adr/0009-silver-v1-operational-model.md
@@ -1,0 +1,76 @@
+# ADR-0009 · Silver v1 operational model
+
+| Field | Value |
+|---|---|
+| Status | Proposed |
+| Date | 2026-08-18 |
+| Owners | Pod 3 |
+| Proposer | Sentinel team |
+| Supersedes | — |
+| Related | ADR-0007 · Pod 2 → Pod 3 read contract |
+
+## Context
+
+The canonical Bronze layer preserves the OTel Collector schema and carries Sentinel dimensions inside attribute Maps. The first Watchers need typed, indexed dimensions and stable one-minute inputs for latency and operational-volume detection. The current telemetry does not carry business row counts, schema snapshots, dataset identity, or expected schedules, so the first Silver contract must not imply support for those semantics.
+
+## Decision
+
+Create Silver v1 in ClickHouse with three physical, append-only models fed by materialized views:
+
+- `silver.operation_executions`, one row per Bronze span;
+- `silver.log_events`, one row per Bronze log record;
+- `silver.metric_observations`, one row per Bronze gauge or sum data point.
+
+Expose the complete set of read models supported by the guaranteed Bronze fields:
+
+- `silver.metric_rollup_1m`, with count, sum, sum-of-squares, min, max, average, and population standard deviation;
+- `silver.service_health_1m`, with operation/error counts and p50/p95/p99/max span latency;
+- `silver.log_health_1m`, with log/error counts, severity, and affected traces;
+- `silver.telemetry_coverage_1m`, with span/log/metric coverage per service and component;
+- `silver.trace_summary`, one correlated summary per non-empty trace id;
+- `silver.run_summary`, evidence counts and observed duration per Sentinel run.
+
+Materialize `sentinel.scenario`, `sentinel.run_id`, `cloud.provider`, `sentinel.synthetic`, and `contract_version` as typed columns. Convert span duration from nanoseconds to milliseconds. Retain the source attribute Maps for drill-down and forward-compatible dimensions. Match Bronze's 30-day retention.
+
+The materialized views process new Bronze inserts. Historical loading is an explicit deployment/backfill operation; the schema does not use `POPULATE` because it can miss concurrent inserts.
+
+## Options considered
+
+| Option | Advantages | Disadvantages |
+|---|---|---|
+| Query Bronze directly | No duplicated storage or deployment object | Repeated Map probes and conversions; Watchers couple to the Collector schema |
+| Typed physical models plus read views | Stable Watcher contract, simple ingestion, typed hot path | Duplicates selected telemetry; analytical views compute at read time |
+| Pre-aggregated `AggregatingMergeTree` only | Fast baseline queries | Loses row-level evidence and complicates reprocessing/debugging |
+
+## Trade-offs
+
+Ordinary rollup views favor correctness and iteration speed for the MVP over maximum query performance. They can become materialized aggregate tables when measured Watcher latency or data volume requires it without changing the row-level Silver models.
+
+`operation.request_count` and span counts represent operations, not committed business records. The Volume Watcher built on this version is therefore operational-volume detection only.
+
+## Consequences
+
+- Latency, error, operational-volume, and dependency Watchers can use stable, typed Silver inputs.
+- Watcher queries no longer depend on Bronze attribute Map syntax or nanosecond conversion.
+- Schema, business-volume, freshness, and storage Watchers still require new producer signals/contracts.
+- Service dependency edges remain deferred because current live telemetry does not populate parent span ids.
+- Deployments over existing Bronze data require a controlled backfill before parity checks pass.
+
+## Risks
+
+- Duplicate Bronze delivery is preserved as duplicate Silver evidence; end-to-end idempotency is not introduced here.
+- Exact quantiles can become expensive at high cardinality; the MVP must measure this before choosing approximate/materialized states.
+- A stale ClickHouse volume will not receive new init scripts automatically; apply the DDL explicitly or reset the local volume.
+
+## Next steps
+
+1. Implement the Latency Watcher against `service_health_1m`.
+2. Implement an operational Volume Watcher against `metric_rollup_1m`.
+3. Add explicit backfill tooling with a bounded time range and deduplication policy.
+4. Extend the telemetry contract with business row counts, dataset identity, schema fingerprints, expected schedules, and watermarks.
+
+## References
+
+- [ADR-0007](0007-bronze-canonical-contract.md)
+- [Pod 2 → Pod 3 read contract](../../contracts/collector/v1/pod2-pod3-read-contract.md)
+- [Silver DDL](../../infra/clickhouse/init.d/02-silver-layer.sql)

--- a/docs/adr/0010-silver-v1-operational-model.md
+++ b/docs/adr/0010-silver-v1-operational-model.md
@@ -1,4 +1,4 @@
-# ADR-0009 · Silver v1 operational model
+# ADR-0010 · Silver v1 operational model
 
 | Field | Value |
 |---|---|

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,7 +14,7 @@ This directory holds Sentinel's ADRs. Per the [Crew B WoW spec](../../README.md)
 | 0006 | [Optional trace/span ID representation](0006-optional-id-representation.md) | **Proposed** (refined by 0007) | Pod 2 |
 | 0007 | [Bronze = canonical Pod 2 → Pod 3 contract](0007-bronze-canonical-contract.md) | **Proposed** | Pod 2 · Pod 3 |
 | 0008 | [Contracts registry namespaced by producing Pod](0008-contracts-registry-by-producing-pod.md) | **Proposed** | Pod 1 · Pod 2 |
-| 0009 | [Silver v1 operational model](0009-silver-v1-operational-model.md) | **Proposed** | Pod 3 |
+| 0010 | [Silver v1 operational model](0010-silver-v1-operational-model.md) | **Proposed** | Pod 3 |
 
 ADRs 0001–0003 are the three Sprint 1 ADRs the Commander assigned (`bem-vindos.md`). ADR-0004 is a Pod 2 proposal opening the Collector language bake-off (Sync 02 action A7). ADRs 0005–0006 are Pod 2's Day-3 storage-schema decisions, gating the [Pod 2 → Pod 3 ClickHouse read contract](../../contracts/collector/v1/pod2-pod3-read-contract.md). **ADR-0007 supersedes 0005**: Pod 3's otel-collector-contrib bronze schema (`sentinel.*`) is now the canonical read contract, and the Rust collector writes directly into it (validated end-to-end). **ADR-0008** records the `contracts/` registry structure — namespaced by producing Pod (`generator/` + `collector/`), implementation-agnostic, versioned per boundary.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,7 @@ This directory holds Sentinel's ADRs. Per the [Crew B WoW spec](../../README.md)
 | 0006 | [Optional trace/span ID representation](0006-optional-id-representation.md) | **Proposed** (refined by 0007) | Pod 2 |
 | 0007 | [Bronze = canonical Pod 2 → Pod 3 contract](0007-bronze-canonical-contract.md) | **Proposed** | Pod 2 · Pod 3 |
 | 0008 | [Contracts registry namespaced by producing Pod](0008-contracts-registry-by-producing-pod.md) | **Proposed** | Pod 1 · Pod 2 |
+| 0009 | [Silver v1 operational model](0009-silver-v1-operational-model.md) | **Proposed** | Pod 3 |
 
 ADRs 0001–0003 are the three Sprint 1 ADRs the Commander assigned (`bem-vindos.md`). ADR-0004 is a Pod 2 proposal opening the Collector language bake-off (Sync 02 action A7). ADRs 0005–0006 are Pod 2's Day-3 storage-schema decisions, gating the [Pod 2 → Pod 3 ClickHouse read contract](../../contracts/collector/v1/pod2-pod3-read-contract.md). **ADR-0007 supersedes 0005**: Pod 3's otel-collector-contrib bronze schema (`sentinel.*`) is now the canonical read contract, and the Rust collector writes directly into it (validated end-to-end). **ADR-0008** records the `contracts/` registry structure — namespaced by producing Pod (`generator/` + `collector/`), implementation-agnostic, versioned per boundary.
 

--- a/infra/clickhouse/init.d/02-silver-layer.sql
+++ b/infra/clickhouse/init.d/02-silver-layer.sql
@@ -1,0 +1,394 @@
+-- Sentinel SILVER v1 — typed operational models consumed by the first Watchers.
+--
+-- Bronze remains the immutable OTel landing contract. These models materialize
+-- Sentinel's hot dimensions and normalize durations/metric kinds so Watchers do
+-- not probe attribute Maps or repeat unit conversions in every query.
+--
+-- Materialized views process new inserts only. In production, deploy this DDL
+-- before enabling ingestion. For existing Bronze data, use an explicit backfill
+-- rather than POPULATE so deployment can control the time range and deduplication.
+
+CREATE DATABASE IF NOT EXISTS silver;
+
+CREATE TABLE IF NOT EXISTS silver.operation_executions
+(
+    `event_time` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `end_time` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `scenario` LowCardinality(String) CODEC(ZSTD(1)),
+    `run_id` String CODEC(ZSTD(1)),
+    `cloud_provider` LowCardinality(String) CODEC(ZSTD(1)),
+    `is_synthetic` Bool CODEC(Delta(1), ZSTD(1)),
+    `contract_version` LowCardinality(String) CODEC(ZSTD(1)),
+    `service_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `component_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `component_type` LowCardinality(String) CODEC(ZSTD(1)),
+    `operation_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `trace_id` String CODEC(ZSTD(1)),
+    `span_id` String CODEC(ZSTD(1)),
+    `parent_span_id` String CODEC(ZSTD(1)),
+    `duration_ms` Float64 CODEC(ZSTD(1)),
+    `status_code` LowCardinality(String) CODEC(ZSTD(1)),
+    `is_error` Bool CODEC(Delta(1), ZSTD(1)),
+    `resource_attributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `operation_attributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_run_id run_id TYPE bloom_filter(0.01) GRANULARITY 4
+)
+ENGINE = MergeTree
+PARTITION BY toDate(event_time)
+ORDER BY (scenario, service_name, component_name, operation_name, event_time, trace_id)
+TTL toDateTime(event_time) + toIntervalDay(30)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS silver.operation_executions_mv
+TO silver.operation_executions
+AS SELECT
+    Timestamp AS event_time,
+    addNanoseconds(Timestamp, Duration) AS end_time,
+    ResourceAttributes['sentinel.scenario'] AS scenario,
+    ResourceAttributes['sentinel.run_id'] AS run_id,
+    ResourceAttributes['cloud.provider'] AS cloud_provider,
+    lower(ResourceAttributes['sentinel.synthetic']) = 'true' AS is_synthetic,
+    ResourceAttributes['contract_version'] AS contract_version,
+    ServiceName AS service_name,
+    SpanAttributes['component.name'] AS component_name,
+    SpanAttributes['component.type'] AS component_type,
+    SpanName AS operation_name,
+    TraceId AS trace_id,
+    SpanId AS span_id,
+    ParentSpanId AS parent_span_id,
+    Duration / 1000000.0 AS duration_ms,
+    StatusCode AS status_code,
+    StatusCode = 'Error' AS is_error,
+    ResourceAttributes AS resource_attributes,
+    SpanAttributes AS operation_attributes
+FROM bronze.otel_traces;
+
+CREATE TABLE IF NOT EXISTS silver.log_events
+(
+    `event_time` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `scenario` LowCardinality(String) CODEC(ZSTD(1)),
+    `run_id` String CODEC(ZSTD(1)),
+    `cloud_provider` LowCardinality(String) CODEC(ZSTD(1)),
+    `is_synthetic` Bool CODEC(Delta(1), ZSTD(1)),
+    `contract_version` LowCardinality(String) CODEC(ZSTD(1)),
+    `service_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `component_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `severity_text` LowCardinality(String) CODEC(ZSTD(1)),
+    `severity_number` UInt8,
+    `is_error` Bool CODEC(Delta(1), ZSTD(1)),
+    `body` String CODEC(ZSTD(1)),
+    `trace_id` String CODEC(ZSTD(1)),
+    `span_id` String CODEC(ZSTD(1)),
+    `resource_attributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `log_attributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    INDEX idx_trace_id trace_id TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_run_id run_id TYPE bloom_filter(0.01) GRANULARITY 4,
+    INDEX idx_body body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree
+PARTITION BY toDate(event_time)
+ORDER BY (scenario, service_name, component_name, severity_number, event_time, trace_id)
+TTL toDateTime(event_time) + toIntervalDay(30)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS silver.log_events_mv
+TO silver.log_events
+AS SELECT
+    Timestamp AS event_time,
+    ResourceAttributes['sentinel.scenario'] AS scenario,
+    ResourceAttributes['sentinel.run_id'] AS run_id,
+    ResourceAttributes['cloud.provider'] AS cloud_provider,
+    lower(ResourceAttributes['sentinel.synthetic']) = 'true' AS is_synthetic,
+    ResourceAttributes['contract_version'] AS contract_version,
+    ServiceName AS service_name,
+    LogAttributes['component.name'] AS component_name,
+    SeverityText AS severity_text,
+    SeverityNumber AS severity_number,
+    SeverityNumber >= 17 OR upperUTF8(SeverityText) IN ('ERROR', 'FATAL') AS is_error,
+    Body AS body,
+    TraceId AS trace_id,
+    SpanId AS span_id,
+    ResourceAttributes AS resource_attributes,
+    LogAttributes AS log_attributes
+FROM bronze.otel_logs;
+
+CREATE TABLE IF NOT EXISTS silver.metric_observations
+(
+    `event_time` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `start_time` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    `scenario` LowCardinality(String) CODEC(ZSTD(1)),
+    `run_id` String CODEC(ZSTD(1)),
+    `cloud_provider` LowCardinality(String) CODEC(ZSTD(1)),
+    `is_synthetic` Bool CODEC(Delta(1), ZSTD(1)),
+    `contract_version` LowCardinality(String) CODEC(ZSTD(1)),
+    `service_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `component_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `component_type` LowCardinality(String) CODEC(ZSTD(1)),
+    `metric_name` LowCardinality(String) CODEC(ZSTD(1)),
+    `metric_kind` Enum8('gauge' = 1, 'sum' = 2),
+    `metric_unit` LowCardinality(String) CODEC(ZSTD(1)),
+    `value` Float64 CODEC(ZSTD(1)),
+    `status` LowCardinality(String) CODEC(ZSTD(1)),
+    `resource_attributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    `metric_attributes` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    INDEX idx_run_id run_id TYPE bloom_filter(0.01) GRANULARITY 4
+)
+ENGINE = MergeTree
+PARTITION BY toDate(event_time)
+ORDER BY (scenario, service_name, metric_name, component_name, event_time, metric_kind)
+TTL toDateTime(event_time) + toIntervalDay(30)
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS silver.metric_observations_gauge_mv
+TO silver.metric_observations
+AS SELECT
+    TimeUnix AS event_time,
+    StartTimeUnix AS start_time,
+    ResourceAttributes['sentinel.scenario'] AS scenario,
+    ResourceAttributes['sentinel.run_id'] AS run_id,
+    ResourceAttributes['cloud.provider'] AS cloud_provider,
+    lower(ResourceAttributes['sentinel.synthetic']) = 'true' AS is_synthetic,
+    ResourceAttributes['contract_version'] AS contract_version,
+    ServiceName AS service_name,
+    Attributes['component.name'] AS component_name,
+    Attributes['component.type'] AS component_type,
+    MetricName AS metric_name,
+    'gauge' AS metric_kind,
+    if(MetricUnit != '', MetricUnit, Attributes['unit']) AS metric_unit,
+    Value AS value,
+    Attributes['status'] AS status,
+    ResourceAttributes AS resource_attributes,
+    Attributes AS metric_attributes
+FROM bronze.otel_metrics_gauge;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS silver.metric_observations_sum_mv
+TO silver.metric_observations
+AS SELECT
+    TimeUnix AS event_time,
+    StartTimeUnix AS start_time,
+    ResourceAttributes['sentinel.scenario'] AS scenario,
+    ResourceAttributes['sentinel.run_id'] AS run_id,
+    ResourceAttributes['cloud.provider'] AS cloud_provider,
+    lower(ResourceAttributes['sentinel.synthetic']) = 'true' AS is_synthetic,
+    ResourceAttributes['contract_version'] AS contract_version,
+    ServiceName AS service_name,
+    Attributes['component.name'] AS component_name,
+    Attributes['component.type'] AS component_type,
+    MetricName AS metric_name,
+    'sum' AS metric_kind,
+    if(MetricUnit != '', MetricUnit, Attributes['unit']) AS metric_unit,
+    Value AS value,
+    Attributes['status'] AS status,
+    ResourceAttributes AS resource_attributes,
+    Attributes AS metric_attributes
+FROM bronze.otel_metrics_sum;
+
+CREATE VIEW IF NOT EXISTS silver.metric_rollup_1m AS
+SELECT
+    toStartOfMinute(event_time) AS window_start,
+    scenario,
+    service_name,
+    component_name,
+    metric_name,
+    metric_kind,
+    count() AS sample_count,
+    sum(value) AS sum_value,
+    sum(value * value) AS sum_squares,
+    min(value) AS min_value,
+    max(value) AS max_value,
+    avg(value) AS avg_value,
+    stddevPop(value) AS stddev_value
+FROM silver.metric_observations
+GROUP BY
+    window_start,
+    scenario,
+    service_name,
+    component_name,
+    metric_name,
+    metric_kind;
+
+CREATE VIEW IF NOT EXISTS silver.service_health_1m AS
+SELECT
+    toStartOfMinute(event_time) AS window_start,
+    scenario,
+    service_name,
+    component_name,
+    operation_name,
+    count() AS operation_count,
+    countIf(is_error) AS error_count,
+    error_count / operation_count AS error_rate,
+    quantileExact(0.50)(duration_ms) AS latency_p50_ms,
+    quantileExact(0.95)(duration_ms) AS latency_p95_ms,
+    quantileExact(0.99)(duration_ms) AS latency_p99_ms,
+    max(duration_ms) AS latency_max_ms
+FROM silver.operation_executions
+GROUP BY
+    window_start,
+    scenario,
+    service_name,
+    component_name,
+    operation_name;
+
+CREATE VIEW IF NOT EXISTS silver.log_health_1m AS
+SELECT
+    toStartOfMinute(event_time) AS window_start,
+    scenario,
+    service_name,
+    component_name,
+    count() AS log_count,
+    countIf(is_error) AS error_log_count,
+    error_log_count / log_count AS error_log_rate,
+    max(severity_number) AS max_severity_number,
+    uniqExact(trace_id) AS affected_trace_count
+FROM silver.log_events
+GROUP BY
+    window_start,
+    scenario,
+    service_name,
+    component_name;
+
+CREATE VIEW IF NOT EXISTS silver.trace_summary AS
+SELECT
+    scenario,
+    run_id,
+    trace_id,
+    min(event_time) AS trace_start,
+    max(end_time) AS trace_end,
+    dateDiff('microsecond', trace_start, trace_end) / 1000.0 AS trace_duration_ms,
+    count() AS span_count,
+    countIf(is_error) AS error_span_count,
+    error_span_count > 0 AS has_error,
+    argMin(service_name, event_time) AS entry_service,
+    argMax(service_name, end_time) AS exit_service,
+    groupUniqArray(service_name) AS services,
+    groupUniqArray(component_name) AS components
+FROM silver.operation_executions
+WHERE trace_id != ''
+GROUP BY
+    scenario,
+    run_id,
+    trace_id;
+
+CREATE VIEW IF NOT EXISTS silver.telemetry_coverage_1m AS
+SELECT
+    toStartOfMinute(event_time) AS window_start,
+    scenario,
+    run_id,
+    service_name,
+    component_name,
+    sum(span_count) AS span_count,
+    sum(log_count) AS log_count,
+    sum(metric_count) AS metric_count,
+    uniqExactIf(metric_name, metric_name != '') AS metric_name_count
+FROM
+(
+    SELECT
+        event_time,
+        scenario,
+        run_id,
+        service_name,
+        component_name,
+        '' AS metric_name,
+        toUInt64(1) AS span_count,
+        toUInt64(0) AS log_count,
+        toUInt64(0) AS metric_count
+    FROM silver.operation_executions
+
+    UNION ALL
+
+    SELECT
+        event_time,
+        scenario,
+        run_id,
+        service_name,
+        component_name,
+        '' AS metric_name,
+        toUInt64(0) AS span_count,
+        toUInt64(1) AS log_count,
+        toUInt64(0) AS metric_count
+    FROM silver.log_events
+
+    UNION ALL
+
+    SELECT
+        event_time,
+        scenario,
+        run_id,
+        service_name,
+        component_name,
+        metric_name,
+        toUInt64(0) AS span_count,
+        toUInt64(0) AS log_count,
+        toUInt64(1) AS metric_count
+    FROM silver.metric_observations
+)
+GROUP BY
+    window_start,
+    scenario,
+    run_id,
+    service_name,
+    component_name;
+
+CREATE VIEW IF NOT EXISTS silver.run_summary AS
+SELECT
+    scenario,
+    run_id,
+    min(event_time) AS run_start,
+    max(event_time) AS run_end,
+    dateDiff('millisecond', run_start, run_end) AS observed_duration_ms,
+    uniqExact(service_name) AS service_count,
+    uniqExactIf(trace_id, trace_id != '') AS trace_count,
+    sum(operation_count) AS operation_count,
+    sum(operation_error_count) AS operation_error_count,
+    sum(log_count) AS log_count,
+    sum(log_error_count) AS log_error_count,
+    sum(metric_count) AS metric_count
+FROM
+(
+    SELECT
+        scenario,
+        run_id,
+        event_time,
+        service_name,
+        trace_id,
+        toUInt64(1) AS operation_count,
+        toUInt64(is_error) AS operation_error_count,
+        toUInt64(0) AS log_count,
+        toUInt64(0) AS log_error_count,
+        toUInt64(0) AS metric_count
+    FROM silver.operation_executions
+
+    UNION ALL
+
+    SELECT
+        scenario,
+        run_id,
+        event_time,
+        service_name,
+        trace_id,
+        toUInt64(0) AS operation_count,
+        toUInt64(0) AS operation_error_count,
+        toUInt64(1) AS log_count,
+        toUInt64(is_error) AS log_error_count,
+        toUInt64(0) AS metric_count
+    FROM silver.log_events
+
+    UNION ALL
+
+    SELECT
+        scenario,
+        run_id,
+        event_time,
+        service_name,
+        '' AS trace_id,
+        toUInt64(0) AS operation_count,
+        toUInt64(0) AS operation_error_count,
+        toUInt64(0) AS log_count,
+        toUInt64(0) AS log_error_count,
+        toUInt64(1) AS metric_count
+    FROM silver.metric_observations
+)
+GROUP BY
+    scenario,
+    run_id;

--- a/infra/clickhouse/queries/02-silver-sample.sql
+++ b/infra/clickhouse/queries/02-silver-sample.sql
@@ -1,0 +1,50 @@
+SELECT *
+FROM silver.run_summary
+ORDER BY run_start DESC
+LIMIT 3;
+
+SELECT
+    window_start,
+    service_name,
+    operation_count,
+    error_count,
+    round(error_rate, 4) AS error_rate,
+    round(latency_p95_ms, 3) AS latency_p95_ms
+FROM silver.service_health_1m
+ORDER BY window_start DESC, service_name
+LIMIT 10;
+
+SELECT
+    event_time,
+    service_name,
+    component_name,
+    severity_text,
+    body,
+    trace_id
+FROM silver.log_events
+WHERE is_error
+ORDER BY event_time DESC
+LIMIT 5;
+
+SELECT
+    event_time,
+    service_name,
+    component_name,
+    metric_name,
+    metric_kind,
+    value,
+    metric_unit
+FROM silver.metric_observations
+ORDER BY event_time DESC
+LIMIT 5;
+
+SELECT
+    trace_id,
+    span_count,
+    error_span_count,
+    entry_service,
+    exit_service,
+    round(trace_duration_ms, 3) AS trace_duration_ms
+FROM silver.trace_summary
+ORDER BY trace_start DESC
+LIMIT 5;

--- a/infra/clickhouse/tests/02-silver-layer.test.sql
+++ b/infra/clickhouse/tests/02-silver-layer.test.sql
@@ -1,0 +1,116 @@
+SELECT throwIf(
+    (SELECT count() FROM silver.operation_executions) = 0,
+    'silver.operation_executions is empty'
+);
+
+SELECT throwIf(
+    (SELECT count() FROM silver.metric_observations) = 0,
+    'silver.metric_observations is empty'
+);
+
+SELECT throwIf(
+    (SELECT count() FROM silver.log_events) = 0,
+    'silver.log_events is empty'
+);
+
+SELECT throwIf(
+    (SELECT count() FROM silver.operation_executions) !=
+        (SELECT count() FROM bronze.otel_traces),
+    'trace row count differs between bronze and silver'
+);
+
+SELECT throwIf(
+    (SELECT count() FROM silver.metric_observations) !=
+        (SELECT count() FROM bronze.otel_metrics_gauge) +
+        (SELECT count() FROM bronze.otel_metrics_sum),
+    'metric row count differs between bronze and silver'
+);
+
+SELECT throwIf(
+    (SELECT count() FROM silver.log_events) !=
+        (SELECT count() FROM bronze.otel_logs),
+    'log row count differs between bronze and silver'
+);
+
+SELECT throwIf(
+    (SELECT countIf(
+        scenario = '' OR run_id = '' OR service_name = '' OR contract_version = ''
+    ) FROM silver.operation_executions) != 0,
+    'required typed dimensions are missing from operation executions'
+);
+
+SELECT throwIf(
+    (SELECT countIf(duration_ms < 0) FROM silver.operation_executions) != 0,
+    'negative duration found in operation executions'
+);
+
+SELECT throwIf(
+    (SELECT sum(sample_count) FROM silver.metric_rollup_1m) !=
+        (SELECT count() FROM silver.metric_observations),
+    'metric rollup does not cover every metric observation'
+);
+
+SELECT throwIf(
+    (SELECT sum(operation_count) FROM silver.service_health_1m) !=
+        (SELECT count() FROM silver.operation_executions),
+    'service health rollup does not cover every operation execution'
+);
+
+SELECT throwIf(
+    (SELECT sum(log_count) FROM silver.log_health_1m) !=
+        (SELECT count() FROM silver.log_events),
+    'log health rollup does not cover every log event'
+);
+
+SELECT throwIf(
+    (SELECT count() FROM silver.trace_summary) !=
+        (SELECT uniqExact(trace_id) FROM silver.operation_executions WHERE trace_id != ''),
+    'trace summary does not contain exactly one row per trace'
+);
+
+SELECT throwIf(
+    (SELECT sum(span_count) FROM silver.telemetry_coverage_1m) !=
+        (SELECT count() FROM silver.operation_executions),
+    'telemetry coverage span count differs from silver evidence'
+);
+
+SELECT throwIf(
+    (SELECT sum(log_count) FROM silver.telemetry_coverage_1m) !=
+        (SELECT count() FROM silver.log_events),
+    'telemetry coverage log count differs from silver evidence'
+);
+
+SELECT throwIf(
+    (SELECT sum(metric_count) FROM silver.telemetry_coverage_1m) !=
+        (SELECT count() FROM silver.metric_observations),
+    'telemetry coverage metric count differs from silver evidence'
+);
+
+SELECT throwIf(
+    (SELECT sum(operation_count) FROM silver.run_summary) !=
+        (SELECT count() FROM silver.operation_executions),
+    'run summary operation count differs from silver evidence'
+);
+
+SELECT throwIf(
+    (SELECT sum(log_count) FROM silver.run_summary) !=
+        (SELECT count() FROM silver.log_events),
+    'run summary log count differs from silver evidence'
+);
+
+SELECT throwIf(
+    (SELECT sum(metric_count) FROM silver.run_summary) !=
+        (SELECT count() FROM silver.metric_observations),
+    'run summary metric count differs from silver evidence'
+);
+
+SELECT
+    (SELECT count() FROM silver.operation_executions) AS operation_executions,
+    (SELECT count() FROM silver.log_events) AS log_events,
+    (SELECT count() FROM silver.metric_observations) AS metric_observations,
+    (SELECT count() FROM silver.metric_rollup_1m) AS metric_rollup_windows,
+    (SELECT count() FROM silver.service_health_1m) AS service_health_windows,
+    (SELECT count() FROM silver.log_health_1m) AS log_health_windows,
+    (SELECT count() FROM silver.trace_summary) AS traces,
+    (SELECT count() FROM silver.telemetry_coverage_1m) AS coverage_windows,
+    (SELECT count() FROM silver.run_summary) AS runs;


### PR DESCRIPTION
## Summary

- add ADR-0009 defining the Pod 3 Silver v1 operational contract
- materialize typed operation, log, and metric evidence from canonical Bronze
- expose one-minute metric, service-health, log-health, and telemetry-coverage read models
- expose trace and Sentinel-run summaries
- load the Silver DDL automatically during ClickHouse initialization
- add reproducible validation and sample-query targets

## Silver objects

Physical evidence tables:
- `silver.operation_executions`
- `silver.log_events`
- `silver.metric_observations`

Watcher read models:
- `silver.metric_rollup_1m`
- `silver.service_health_1m`
- `silver.log_health_1m`
- `silver.telemetry_coverage_1m`
- `silver.trace_summary`
- `silver.run_summary`

## Validation

Executed a clean end-to-end run with the Rust collector:

```text
make reset
make e2e COLLECTOR=rust WINDOW=10s
make test-silver
make sample-silver
```

Loaded and validated:
- 1,340 operation executions
- 1,340 log events
- 5,090 metric observations
- 520 trace summaries
- 32 metric rollup windows
- 7 service-health windows
- 7 log-health windows
- 7 telemetry-coverage windows
- 1 run summary

All 18 Bronze-to-Silver parity, typing, and coverage invariants passed.

## Current contract boundary

This Silver version supports operational latency, errors, signal coverage, and operation-volume analysis. Business row counts, schema drift, dataset freshness, storage state, and dependency edges remain deferred until their source telemetry is available.