### PR TITLE
feat(flow-ui): the pipeline watching itself — four boards over /metrics and bronze

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@ integrated monorepo baseline (`v0.0.1`) gluing the POD branches together.
 ## Pipeline
 
 ```
-generator (otelgen) ──OTLP gRPC :4317──▶ collector (rust | go) ──▶ ClickHouse :8123/:9000 ──▶ Play UI :8123/play
-                       │                  (selected via COLLECTOR)
+generator (otelgen) ──OTLP gRPC :4317──▶ collector-rust ──▶ ClickHouse :8123/:9000 ──▶ Play UI :8123/play
+                       │                        │                    │
+                       │                        └── /metrics :9090 ──┴──▶ flow-ui :8080
                        └── validates against contracts/generator/v1 (single source of truth)
 ```
 
@@ -21,7 +22,7 @@ contracts/                 # SSOT contract registry, namespaced by producing Pod
 services/
   generator-python/        # POD 1 — synthetic OTLP generator (otelgen CLI); config/ holds scenarios/topology/provider_profiles
   collector-rust/          # POD 2 — OTLP→ClickHouse collector (Rust); own DDL in infra/clickhouse/ddl/
-  collector-go/            # POD 2 — OTLP→ClickHouse collector (Go);   own DDL in migrations/
+  flow-ui/                 # the pipeline watching itself — four boards over /metrics + bronze
 infra/                     # ClickHouse bootstrap (init user/db + users.d network override)
 docs/                      # shared docs (clickhouse-schema-divergence.md)
 docker-compose.yml         # root orchestrator (rust|go profiles)
@@ -33,6 +34,8 @@ Makefile                   # one-command UX
 | Command | What it does |
 |---------|--------------|
 | `make e2e COLLECTOR=rust\|go` | Full pipeline: build+up clickhouse+collector → apply its DDL → generate → land rows |
+| `make ui` | Start flow-ui on http://localhost:8080 (see `services/flow-ui/README.md`) |
+| `make generate-stream DURATION=10m` | Real-time telemetry paced by the wall clock, rather than a backfilled window |
 | `make up / init / generate / logs / down / reset` | Individual pipeline steps |
 | `make build` | Build all service images |
 | `make test` | All unit suites (generator pytest, `cargo test`, `go test`) |
@@ -48,6 +51,10 @@ Variables: `COLLECTOR` (rust\|go, default rust), `SCENARIO`, `SEED`, `WINDOW`.
 - **Only one collector runs at a time** — both bind OTLP `:4317`. The generator targets the `collector` network alias, so it works regardless of which is active.
 - **Both collectors now write the identical bronze split schema directly into database `bronze`** (POD 2 → POD 3 landing — `otel_logs / otel_traces / otel_metrics_gauge / otel_metrics_sum`, OTel-contrib style with metrics split by data-point type, Sentinel-enriched via `ResourceAttributes`). Cross-collector equivalence is verified (identical row counts). The old normalized `default.*` write path (and the `otel_metrics_1m` rollup MV) is retired.
 - **POD 3's canonical bronze** (database `bronze`, `bronze.*`, OTel-contrib style, metrics split by type) is auto-applied on ClickHouse boot from `infra/clickhouse/init.d/01-bronze-otel.sql`. **Both collectors write directly into it** — the former collector→bronze gap is now closed (historical rationale: [docs/research/pod3-bronze-gap.md](docs/research/pod3-bronze-gap.md)).
+- **flow-ui reads, never writes.** It polls the collector's `/metrics` and queries `bronze.*`
+  read-only, plus Pod 1's `topology/default.yaml` and the collector's `config.docker.yaml`,
+  both mounted read-only — the picture is drawn from the files that define the thing, so it
+  cannot drift from them. Nothing in the pipeline depends on it being up.
 - **No comments-as-noise**; match each service's existing style. Keep the repo clean for the agentic phase that follows this baseline.
 
 ## Gotchas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,8 @@ Makefile                   # one-command UX
 | `make generate-stream DURATION=10m` | Real-time telemetry paced by the wall clock, rather than a backfilled window |
 | `make up / init / generate / logs / down / reset` | Individual pipeline steps |
 | `make build` | Build all service images |
-| `make test` | All unit suites (generator pytest, `cargo test`, `go test`) |
-| `make lint` | ruff + `cargo fmt/clippy` + `go vet` |
+| `make test` | All unit suites (generator pytest, flow-ui pytest, `cargo test`) |
+| `make lint` | ruff (generator + flow-ui) + `cargo fmt/clippy` |
 | `make help` | List targets + active `COLLECTOR/SCENARIO/SEED/WINDOW` |
 
 Variables: `COLLECTOR` (rust\|go, default rust), `SCENARIO`, `SEED`, `WINDOW`.

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ STEP      ?= 1s
 RATE      ?= 200
 
 .PHONY: help up init generate generate-stream ui e2e down reset logs ps \
-        build test test-generator test-collector-rust \
-        lint lint-generator lint-collector-rust
+        build test test-generator test-collector-rust test-flow-ui \
+        lint lint-generator lint-collector-rust lint-flow-ui
 
 # Docker runner for per-service build/test/lint — no host toolchains required.
 DK_RUN := docker run --rm --user $(shell id -u):$(shell id -g) -v "$(CURDIR)":/w
@@ -66,7 +66,7 @@ reset:               ## Stop all services and drop volumes (fresh ClickHouse)
 build:               ## Build all service images (generator + Rust collector)
 	docker compose build
 
-test: test-generator test-collector-rust  ## Run all unit test suites
+test: test-generator test-collector-rust test-flow-ui  ## Run all unit test suites
 
 test-generator:      ## Generator unit tests (pytest)
 	$(DK_RUN) -w /w/services/generator-python -e HOME=/tmp -e CONTRACTS_DIR=/w/contracts/generator/v1 \
@@ -76,7 +76,14 @@ test-collector-rust: ## Rust collector tests (cargo test; live-ClickHouse tests 
 	$(DK_RUN) -w /w/services/collector-rust -e CARGO_HOME=/tmp/cargo -e HOME=/tmp \
 		rust:1.96 cargo test --locked
 
-lint: lint-generator lint-collector-rust  ## Lint all services
+lint: lint-generator lint-collector-rust lint-flow-ui  ## Lint all services
+
+test-flow-ui:        ## flow-ui unit tests (pytest)
+	$(DK_RUN) -w /w/services/flow-ui -e HOME=/tmp \
+		python:3.12-slim bash -c "python -m venv /tmp/v && /tmp/v/bin/pip -q install -e . pytest && /tmp/v/bin/python -m pytest tests -q"
+
+lint-flow-ui:        ## flow-ui lint (ruff)
+	$(DK_RUN) -w /w/services/flow-ui ghcr.io/astral-sh/ruff:latest check src tests scripts
 
 lint-generator:      ## Python lint (ruff)
 	$(DK_RUN) -w /w/services/generator-python ghcr.io/astral-sh/ruff:latest check src

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,12 @@
 SCENARIO  ?= baseline
 SEED      ?= 42
 WINDOW    ?= 5m
+# Stream-mode knobs: DURATION is the wall-clock run cap, STEP the tick interval.
+DURATION  ?= 60s
+STEP      ?= 1s
+RATE      ?= 200
 
-.PHONY: help up init generate e2e down reset logs ps \
+.PHONY: help up init generate generate-stream ui e2e down reset logs ps \
         build test test-generator test-collector-rust \
         lint lint-generator lint-collector-rust
 
@@ -19,6 +23,7 @@ help:                ## Show this help
 		awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "  SCENARIO=$(SCENARIO)  SEED=$(SEED)  WINDOW=$(WINDOW)"
+	@echo "  DURATION=$(DURATION)  STEP=$(STEP)  RATE=$(RATE)   (generate-stream)"
 
 up:                  ## Start ClickHouse + the Rust collector
 	docker compose up -d --build clickhouse collector-rust
@@ -30,6 +35,16 @@ generate:            ## Run the generator → OTLP :4317 (SCENARIO / SEED / WIND
 	docker compose run --rm generator \
 		--scenario $(SCENARIO) --seed $(SEED) --window $(WINDOW) \
 		--delivery otlp --otlp-endpoint http://collector:4317
+
+generate-stream:     ## Generate in real time (paced by wall clock) — DURATION / STEP / RATE
+	docker compose run --rm generator \
+		--mode stream --duration $(DURATION) --step $(STEP) --rate $(RATE) \
+		--scenario $(SCENARIO) --seed $(SEED) \
+		--delivery otlp --otlp-endpoint http://collector:4317
+
+ui:                  ## Start the flow visualizer on http://localhost:8080
+	docker compose up -d --build flow-ui
+	@echo "flow-ui → http://localhost:8080"
 
 e2e: up init generate ## Full configurable pipeline (up + init + generate)
 	@echo "E2E complete with the Rust collector. Inspect at http://localhost:8123/play"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,10 @@ services:
       # Pod 1's declared topology, read-only. The graph is drawn from the producer's
       # own config rather than redrawn here, so the picture cannot drift from it.
       - ./services/generator-python/config:/app/generator-config:ro
+      # The collector's own config, read-only. `contract.grpc_validation` is not exposed as
+      # a metric, so the receive-boundary policy can only be read from the file that sets
+      # it — and the contract board's headline is that policy.
+      - ./services/collector-rust/config.docker.yaml:/app/collector-config.yaml:ro
     ports:
       - "8080:8080"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,29 @@ services:
       clickhouse:
         condition: service_healthy
 
+  flow-ui:
+    build:
+      context: ./services/flow-ui
+    image: sentinel-flow-ui:dev
+    environment:
+      # The browser never reaches these two directly: the collector's /metrics server sets
+      # no CORS header and neither does ClickHouse, so a cross-origin fetch from the page
+      # would be blocked. flow-ui is the only reader of both.
+      COLLECTOR_METRICS_URL: "http://collector:9090/metrics"
+      CLICKHOUSE_URL: "http://clickhouse:8123"
+      CLICKHOUSE_DATABASE: bronze
+    volumes:
+      # Pod 1's declared topology, read-only. The graph is drawn from the producer's
+      # own config rather than redrawn here, so the picture cannot drift from it.
+      - ./services/generator-python/config:/app/generator-config:ro
+    ports:
+      - "8080:8080"
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+      collector-rust:
+        condition: service_started
+
   generator:
     build:
       context: ./services/generator-python

--- a/docs/research/data-observability-competitive-landscape.md
+++ b/docs/research/data-observability-competitive-landscape.md
@@ -1,0 +1,493 @@
+# Data observability — competitive landscape and V2 input
+
+> What the category ships, what users actually use, and where Sentinel already stands on
+> ground nobody else occupies.
+> *2026-09-01 · Pod 2 · input for the V2 roadmap, not a decision*
+
+**Method.** ~200 web searches and ~40 primary-source fetches across vendor docs, changelogs,
+specs, GitHub schemas and analyst summaries. **Coverage is uneven and marked as such** — see
+[§7](#7-coverage-ledger). Monte Carlo, Datadog, Grafana, OpenLineage, Elementary and the
+OpenTelemetry semconv gap are deep and primary-sourced. Bigeye, Anomalo, Sifflet and Databand
+are thin to absent; the search budget ran out. Nothing in those gaps changes the
+recommendations, which rest on the high-confidence lanes.
+
+---
+
+## 1. The one paragraph that matters
+
+Gartner's 2026 Market Guide states the category's technical direction as a **shift away from
+full-table scans toward "continuous telemetry using metadata, logs, and pipeline signals."**
+
+That is a description of Sentinel's architecture. Every incumbent in this space polls a
+warehouse on a schedule; the shift Gartner names is the one they have to make and Sentinel
+starts from.
+
+Elementary's own OSS-vs-Cloud table concedes the same thing from the other side:
+
+| | Their OSS | Their Cloud |
+|---|---|---|
+| Time to detection | **only when dbt runs** | as soon as it happens |
+| Cost | **warehouse compute** | metadata only |
+| Configuration | **manual, many parameters** | automatic |
+
+They monetise fixing exactly what a stream-fed collector gets for free.
+
+**And the incident data says the boundary is the right place to stand.** From Monte Carlo's
+telemetry over 11M+ monitored tables:
+
+| Root cause | Share |
+|---|---|
+| Pipeline execution faults | **26.2 %** |
+| Real-world variation (not an error) | 20.0 % |
+| Ingestion disruptions | **16.6 %** |
+| Platform instability | 15.2 % |
+| Intentional changes / backfills | 14.2 % |
+| Schema drift | 7.8 % |
+
+**~43 % of incidents are execution or ingestion faults** — what an ingestion-boundary
+collector sees first and a warehouse poller sees last. Monitors are placed at the landing
+layer only **34 %** of the time. That mismatch is Sentinel's thesis in one table.
+
+---
+
+## 2. Feature categories, ranked by how universally they ship
+
+| Category | Ships in | Verdict |
+|---|---|---|
+| Freshness · volume · schema-change · alerting with ownership | 12/12 | **Table stakes** |
+| Distribution / column health (null %, uniqueness, min/max) | 11/12 | Table stakes |
+| Table-level lineage · custom SQL rules | 10/12 | Table stakes |
+| Incident grouping and triage · ML/statistical thresholds | 9/12 | Table stakes at enterprise tier |
+| Health / quality scorecards | 8/12 | Rising to table stakes |
+| Column-level lineage · monitoring-as-code | 6/12 | Differentiator |
+| Job/run execution monitoring · automated RCA | 5/12 | Differentiator |
+| Cost/FinOps · SLA + error budgets | 4/12 | Differentiator |
+| **Streaming pathway topology + lag** | **2/12** | ⭐ Wide open — Datadog DSM only |
+| **Data contracts with runtime enforcement** | **2/12** | ⭐ Wide open |
+| **Usage-driven telemetry cost reduction** | **1/12** | ⭐ Wide open — Grafana only |
+| **Receive-boundary / shift-left validation** | **~1/12** | ⭐⭐ Empty |
+
+The last four rows are Sentinel's territory. The first five are the entry fee.
+
+---
+
+## 3. The four structural openings
+
+### 3.1 ⭐⭐ Contracts are defined everywhere and enforced almost nowhere
+
+**ODCS v3.1.0** (Linux Foundation, Dec 2025) settled the *definition* format. Enforcement is
+another story:
+
+| Tool | Enforcement |
+|---|---|
+| DataHub OSS | stores contract objects, **no execution engine** |
+| datacontract-cli | **translation layer**, CI gate only |
+| Confluent Schema Registry | client-side on community licence; broker-side needs Enterprise |
+| Redpanda | broker-side WASM transforms — the one real OSS runtime enforcer |
+| OpenMetadata 1.9+ | first OSS catalogue to *execute* contracts |
+
+> *"The contract sits in a catalog as documentation. The catalog has no opinion about the
+> data flowing past it."*
+
+**Sentinel is already a runtime receive boundary that validates against a versioned contract
+and counts violations per signal type and reason.** That is not a roadmap item — it is a
+shipped differentiator that is currently invisible because nothing renders it.
+
+### 3.2 ⭐⭐ OpenTelemetry has no data-pipeline semantic conventions
+
+Verified firsthand against the semconv registry: it covers HTTP, Database, Messaging, FaaS,
+CI/CD, Object Stores… and **nothing for data pipelines, ETL, data quality, datasets or
+lineage.**
+
+Two proposals exist. Both open, `needs-triage`, **zero maintainer response**:
+
+- [semconv#3762](https://github.com/open-telemetry/semantic-conventions/issues/3762) — `pipeline.*`:
+  `pipeline.run` span, `pipeline.rows_read/written`, `pipeline.quality.rules_passed/failed`,
+  `pipeline.quality.freshness_lag_seconds`
+- [semconv#3909](https://github.com/open-telemetry/semantic-conventions/issues/3909) —
+  `data.staleness.age / .lag / .records.behind / .sla.*`. Its motivation: *"systems can have
+  zero errors and low latency while serving outdated data"* and *"every data-observability
+  vendor computes it in a proprietary, siloed way."*
+
+An earlier attempt to make lineage a top-level OTel signal was **closed** in 2024. The nearest
+precedent, CI/CD semconv, is at Release Candidate and is a near-mechanical adaptation.
+
+**Aligning Sentinel's attribute names with these costs nothing and buys standards-track
+positioning in an empty domain.** Filing on those issues *with a working implementation* is
+real open-source leverage.
+
+### 3.3 ⭐ Streaming-time observability is closed-source and OTel-hostile
+
+Datadog's own compatibility matrix: Data Streams Monitoring is **not supported with OTel
+SDKs** — *"N/A (OTel does not offer DSM functionality)"*. It requires their tracer and a
+proprietary `dd-pathway-ctx` header. **There is no open cross-vendor pathway-context
+standard.** Grafana has no equivalent: Tempo's `service_graphs` derives edges from
+parent-child spans, which **breaks across an async queue boundary**.
+
+The detection-floor argument is well documented: a warehouse check running every 15 minutes
+has a 15-minute detection floor; a streaming check has seconds.
+
+### 3.4 ⭐ OpenLineage has the right payloads, computes nothing, and has no OTLP transport
+
+OpenLineage (LF AI & Data, **Graduated**) already standardises what a detection layer needs:
+
+- **`DataQualityMetricsInputDatasetFacet`** — `rowCount`, `bytes`, `lastUpdated`, plus
+  per-column `nullCount`, `distinctCount`, `sum`, `min`, `max`, `quantiles{}`. A ready-made,
+  standards-backed input schema for rolling-stats baselines.
+- **`DataQualityAssertionsDatasetFacet`** — `{assertion, success, column, severity, expected,
+  actual}` where *"a test can fail without blocking the pipeline when severity is 'warn'"* —
+  **the same warn/strict split Sentinel already implements at the gRPC boundary.**
+
+But there is **no OTLP transport** (Java transports: Http, Kafka, Console, File, GCS, S3,
+Datadog…), and Marquez, the reference UI, has had **no tagged release since 2024-10-24** while
+the spec ships biweekly.
+
+Meanwhile the producers already emit OTLP: **dbt Fusion natively** (`--export-to-otlp`,
+`trace_id ≡ invocation_id`), Airflow native OTel tracing, Databricks OTLP in beta.
+
+**The bridge is missing exactly where Sentinel stands.**
+
+---
+
+## 3.5 ⭐⭐ El territorio pipeline-céntrico está vacante
+
+*Añadido 2026-09-01 tras cerrar la línea Databand/Soda.*
+
+**Databand era el producto pipeline-céntrico líder, y su marca fue retirada.**
+`ibm.com/products/databand` hace **301 → watsonx.data integration**, y esa página de destino
+contiene **cero ocurrencias** de la cadena "Databand" (166 KB de HTML, verificado). El dominio
+`databand.ai` resuelve al redirector de IBM; el blog entero desapareció. El SDK `dbnd` seguía
+publicando en PyPI hasta **2026-03-05**, pero los commits públicos pararon en **marzo 2025** —
+el repo de GitHub es un espejo de un GitLab privado que se congeló un año antes que los
+paquetes.
+
+> **Matiz que no hay que perder:** *no se encontró carta de retiro formal de soporte*. Las
+> páginas de ciclo de vida de IBM siguen sin publicar fecha de EOS (última actualización
+> 2026-02-16), y las SKUs siguen existiendo a efectos de soporte. Lo observable es **retiro de
+> marca y absorción del producto**, no una discontinuación anunciada. No representar lo
+> segundo como confirmado.
+
+**Soda, la independiente más sana, dejó de ser open source.** `soda-core` v3 era Apache-2.0;
+**v4 es Elastic License 2.0** — *"no podés ofrecer el software a terceros como servicio
+gestionado… no podés eludir la funcionalidad de clave de licencia"* — y PyPI declara
+`license: Proprietary`. Además v4 reemplazó SodaCL por una sintaxis de contratos, un cambio
+rompiente. **Quien elija Soda Core "porque es OSS" está trabajando con información vieja.**
+
+Y Soda es **dataset-céntrica**: no tiene modelo de run/task, ni DAG, ni operaciones. Su testing
+de pipelines es un punto de integración, no un sujeto de primera clase.
+
+**Conclusión:** el sujeto *run → task → operación sobre dataset* está vacante. El líder fue
+absorbido y la independiente sana mira tablas en reposo.
+
+### La señal estrella: "la operación que faltó"
+
+Databand podía alertar sobre **una escritura que nunca ocurrió**. Una herramienta que mira
+tablas en reposo **no puede**: ve una tabla desactualizada, no ve que el write no pasó. La
+diferencia sale directamente de tener un modelo pipeline-céntrico y de ninguna otra cosa.
+
+En su UI era un estado de primera clase y graficable — círculo rojo en el gráfico de
+operaciones, × roja en el de tendencia. **La ausencia como señal.** Es la idea más fuerte de
+todo el relevamiento y cae naturalmente del lado de Sentinel.
+
+### Databand construyó el modelo correcto sobre el sustrato equivocado
+
+Su modelo de datos era sólido: `run` → `task_run` (con identidad de intento y **firmas de
+contenido** que permiten decir *"esta tarea se reusó, no se recorrió"*) → operación sobre
+dataset (`read`/`write`/`delete`), más estadísticas por columna y una taxonomía que separa
+métricas **declaradas por el usuario** de las **derivadas por el sistema**.
+
+El sustrato fue el error: un canal RPC propietario con verbos fijos, y para Airflow un
+**monkey-patch de la cluster policy** que envuelve `Operator.execute` y secuestra el logger —
+con un fetcher que exige *"la versión de Airflow debe ser igual a la de Databand"*. Cero
+OpenLineage en todo el repo.
+
+**Cada uno de esos verbos mapea sobre OTLP**: un task run es un span, una operación sobre
+dataset es un span event o un span hijo, las estadísticas de columna son métricas o atributos,
+el estado es status más atributo. Ser OTel-nativo no es una apuesta — **es la corrección al
+fallo específico que mató al antecedente más cercano.**
+
+### Detalles baratos que vale copiar
+
+| De | Qué | Por qué |
+|---|---|---|
+| Databand | **Auto-resolución de alerta al reintentar** — si el run se reinicia, la alerta se cierra sola y sólo vuelve si falla de nuevo | Los reintentos no paginan dos veces |
+| Databand | **Alertas a nivel de fuente**, no de pipeline — conectás un Airflow y todos sus DAGs, presentes y futuros, quedan cubiertos | Cobertura sin configuración desde el día uno |
+| Databand | Un gráfico en el editor de alertas que muestra **el umbral contra el histórico antes de guardar** | Previene la mayoría de las malas configuraciones |
+| Soda | **`auto_exclude_anomalies: True`** en el entrenamiento — los puntos ya marcados no envenenan el ajuste siguiente | Ataca de raíz el *"un problema largo tapa sus huellas"* |
+| Soda | **Backfilling del baseline** — mirar un año atrás para arrancar con modelo en vez de esperar semanas | Time-to-value |
+| Soda | Tres tableros, **cada uno una pregunta**: Ejecutivo *"¿está mejorando?"* · Manager *"¿funciona el programa?"* · Steward *"¿qué arreglo hoy?"* | Arquitectura de información honesta |
+
+### Sobre la detección de anomalías de Soda
+
+La v3 usaba **Facebook Prophet** — confirmado por el pin de dependencias, no por marketing. La
+actual es un modelo propietario **no divulgado** que dice ser *"70 % más preciso que Prophet"*,
+con benchmark interno no reproducible. Venden explicabilidad y no publican el modelo.
+
+Su propia franqueza sobre los límites vale citarla:
+
+> *"Una anomalía sugiere un problema pero no lo confirma. Puede generar falsas alertas. No
+> previene nada: marca cosas después de que pasaron."*
+
+---
+
+## 3.6 ⭐⭐ Nadie hace cumplir un contrato en el borde — y el único que monetiza la negociación cobra por ella
+
+*Añadido 2026-09-01 al cerrar Acceldata · Bigeye · Metaplane · Soda · Great Expectations.*
+
+| Proveedor | Artefacto de contrato | ¿Versionado? | ¿Acuerdo productor↔consumidor? | ¿Bloquea? |
+|---|---|---|---|---|
+| **Soda** | YAML con esquema + calidad + owner en un solo documento | **Sí** — historial ilimitado, **`checksum` por versión**, diff y split-view | **Sí** — roles, estados Open→Done/Won't Do, diff con color, notificaciones, autoridad "Manage Contract" | CI: warn en dev, bloqueo/cuarentena en prod |
+| **Great Expectations** | Expectation Suite | **No** — verificado en el código: no hay campo `version`; `meta` sólo guarda la versión de la librería | No — no modela contraparte | Checkpoint + `fail_task_on_validation_failure` en Airflow |
+| **Bigeye** | Bigconfig YAML (monitores) | Sólo por git | No | **`circuit_breaker_mode` en Airflow — apagado por defecto** |
+| **Metaplane** | Ninguno | No | No | Comentarios en PR, sólo dbt |
+| **Acceldata** | Ninguno — su Schema Drift Policy es diff entre crawls y **ni siquiera se puede correr a mano** | No | Los SLA de Data Products son sociales | No |
+
+**Soda es el único que convierte la negociación en producto — y es exactamente lo que cobra.** Su tier gratuito incluye escaneo, observabilidad, alertas y usuarios ilimitados. El de **US$750/mes** agrega *"contratos de datos colaborativos"* y la interfaz no-code.
+
+> **El motor de checks es commodity. El producto es el acuerdo negociado entre equipos.**
+
+Sumado a que **Soda Core pasó a Elastic License 2.0** (§3.5), shippear firma de contratos productor↔consumidor en OSS genuino pega justo en su línea de monetización, y para compradores con mandato de procurement Apache/MIT ellos ya quedaron descalificados.
+
+**Y nadie implementa semántica de *compatibilidad* de esquema.** El modelo maduro —
+BACKWARD / FORWARD / FULL / TRANSITIVE del Schema Registry de Confluent, más ODCS v3.1.0 —
+vive **fuera de este conjunto de proveedores**. Es prior art probado, barato de adoptar, y
+encaja directo en el registro de contratos que ya existe.
+
+### Tres cosas que validan decisiones ya tomadas
+
+**El default `warn` está bien precedido, no es una concesión.** Los tres que documentan el tema convergieron por separado en enforcement de tres estados: Soda con `warn`/`fail` escalonado por entorno, Bigeye con `circuit_breaker_mode` **apagado por defecto**, GX con niveles de severidad en `notify_on`.
+
+**La identidad estable de cada check es una lección aprendida a los golpes.** Soda shippea `identity:` (v3) y `qualifier` (v4) precisamente para que editar un check no huérfane su historial. Hay que hornearlo desde el día uno, no agregarlo después.
+
+**El arranque en frío se resuelve releyendo historia del almacenamiento.** El backfill por Row Creation Time de Bigeye y el snapshot de metadata de Metaplane convierten una ventana de entrenamiento de 21 días en instantánea. Sentinel tiene `bronze.*` con TTL de 30 días: el baseline se puede bootstrapear el primer día.
+
+### Metodologías de detección, lado a lado
+
+| | Método | Ventana | Estacionalidad |
+|---|---|---|---|
+| **Soda v3** | **Prophet** (pin verificado en el código) | ≥4 medidas, `window_length` 1000 | la de Prophet |
+| **Soda v4** | "Propietario"; la UI es z-score con **z=3 por defecto** | no documentada | no documentada |
+| **Bigeye** | **Selección de modelo sobre una cartera de forecasters** + intervalo de predicción modelado aparte | **21 días**, reentrena cada 24 h | *"tres o más ciclos"* — **sólo semanal por defecto** |
+| **Metaplane** | **Propio, explícitamente no-Prophet, consciente de la forma** (escalera, monótona, escalón); **reentrena tras cada observación** | 3–7 días horarios | día/DoD/WoW/MoM/YoY |
+| **GX Core** | **Ninguno — sólo reglas.** Su detector de outliers es IQR **dentro del lote** | — | — |
+| **GX Cloud** | **10 % de desvío sobre la media móvil de 5 corridas** | 5 corridas | ninguna |
+| **Acceldata** | **No divulgado.** "Un slider." | ? | ? |
+
+**Publicar el algoritmo es una cuña creíble.** Acceldata no divulga nada; Bigeye no nombra
+familias de modelos y su whitepaper está detrás de un formulario; Metaplane publica el
+razonamiento pero no el estimador. Un proyecto abierto que publique **algoritmo, ventana y
+semántica del umbral** se diferencia sólo con transparencia — y la honestidad de Bigeye al
+admitir su límite de *"tres o más ciclos"* compra más credibilidad que un "ML-powered" sin
+calificar.
+
+El argumento más filoso de la categoría es de Metaplane y **es cierto**:
+
+> *"Estos modelos de estantería (Prophet, por ejemplo) están hechos para pronosticar, no para
+> detectar anomalías. Optimizan el objetivo equivocado: minimizar error de pronóstico en vez
+> de identificar correctamente las anomalías."*
+
+### Cuatro ideas de visualización, priorizadas
+
+1. **La banda dibujada y el umbral de alerta tienen que ser el mismo objeto.** Metaplane shippeó una versión donde diferían y llamó públicamente "simplificación" al arreglarlo: *"si ves un valor fuera del área verde, Metaplane mandó una alerta."* No repetir su v1.
+2. **El estado gris del Scorecard de Bigeye** — verde = monitoreado y sano · rojo = monitoreado y fallando · **gris = sin monitor ese día**. Distingue *sano* de *no observado*; casi todos los widgets de salud confunden las dos cosas.
+3. **Marcadores de cambio de configuración sobre la serie temporal** (Soda) — permite distinguir *"cambió el dato"* de *"cambiamos el detector"*.
+4. **Tres estados de resultado, no dos** (Bigeye): Passing · **Alerting** (discrepancia) · **Failing** (error de infraestructura). Soda codifica lo mismo con `has_failures()` vs `has_errors()`. La mayoría confunde *"el check no coincidió"* con *"el check no pudo correr"*.
+
+### La posición desocupada
+
+Metaplane y Bigeye llegaron por separado a los mismos cuatro pilares — métricas, metadata,
+lineaje, logs — y **ambos descartaron *trazas* y agregaron *lineaje***.
+
+Para una herramienta OTel-nativa ese es el hueco interesante: **una traza *es* un registro de
+lineaje con tiempos.** Sostener que lineaje y trazas son el mismo objeto a distinta
+granularidad es una posición que nadie ocupa.
+
+Dato de contexto: **Datadog —el entrante mejor financiado, ya con Metaplane adentro— eligió
+OpenLineage JSON sobre HTTP propietario para lineaje**, mientras su Data Streams Monitoring ya
+funciona con APM instrumentado con OTel. Tratan los dos estándares como adyacentes, no
+competidores. **Un solo formato OTLP que transporte facetas tipo `dataQualityMetrics` /
+`dataQualityAssertions`, con un contexto de traza que abarque app → pipeline → tabla, es una
+arquitectura que nadie de este conjunto construyó.**
+
+### Una advertencia operativa
+
+**Shippear el migrador antes que el cambio rompiente.** GX borró la CLI, el formato de
+configuración, el Validator y los profilers **en una sola release, sin camino automático** — y
+el foro muestra el costo. Soda está cometiendo el mismo error ahora con v3→v4. Aplica directo
+al versionado del registro de contratos de Sentinel.
+
+---
+
+## 4. What the evidence says users actually value
+
+**Anomaly detection wins because it needs the least maintenance.** Monte Carlo measured human
+touches per monitor across 11M+ tables:
+
+| Monitor type | Avg touches |
+|---|---|
+| Custom SQL | 2.35 |
+| Data validation tests | 2.03 |
+| Comparison monitors | 1.63 |
+| **Anomaly detection** | **1.33 — 40 % less** |
+
+This is the strongest quantitative evidence in the corpus, and it directly validates the
+Tier-1-statistical-first plan.
+
+**Alert noise is the category's #1 documented failure mode.**
+
+- A 150-column dataset generates **900–1,200 automated rules**; one 500-asset team faced
+  **3,000+ alerts/week**, cut to **<30 clusters** by lineage-based grouping
+- Engagement **drops ~15 % above 50 alerts/week and a further 20 % above 100**
+- **20 % of users escalate 80 % of alerts**
+- **~34 % of detected "incidents" are not errors** — business variation (20 %) or planned
+  backfills (14.2 %)
+- Grafana's 1,363-respondent survey: alert fatigue is an obstacle for **30 %**
+
+**Detection before the business notices is the purchase driver.** 74 % of data professionals
+say stakeholders find issues first most or all of the time; 68 % report time-to-detection ≥ 4
+hours; time-to-resolution averages 15 hours.
+
+---
+
+## 5. Visualizations worth stealing
+
+| Visualization | What it does | Why |
+|---|---|---|
+| ⭐ **Anomaly chart with expected-range band** | observed line + baseline band + flagged points | Turns *"the test failed"* into *"here is normal, here is where we left it."* Without it a statistical alert is not arguable. Universal across the category |
+| ⭐ **Freshness update timeline** | ticks per update, **▽ marks "now"**, dotted line at the expected gap; hover a gap → both timestamps and the interval | Reads far better than a value chart for arrival/latency. Maps 1:1 onto the Arrival watcher |
+| ⭐ **State timeline** (Grafana panel) | state changes as coloured regions, length = time in state | Highest-leverage pipeline panel: validation-mode changes, per-run status, backfill windows. Answers *when* it broke and *for how long* |
+| **Lineage painted with health** | the DAG, each node carrying one fused status | Lineage without health is documentation; with health it is an incident tool |
+| **Node graph frames** (Grafana) | `mainstat`/`secondarystat`/`arc__*`/`detail__*` | The open answer to Datadog's topology map — any source can emit it |
+| **`Simulate Configuration`** | preview a sensitivity change **against history before saving** | The correct answer to alert fatigue. Almost nobody ships it |
+| **Schema diff with `ordinal_position`** | detects add/drop/retype **and reorder** | OpenLineage models ordinal position for exactly this |
+
+---
+
+## 6. Recommended V2 shortlist
+
+Ordered by (differentiation × evidence) ÷ effort. Every item leans on something that exists.
+
+### Tier 1 — build first
+
+**V2.1 · Contract Health — make the receive boundary visible.**
+The counters already exist (`signals_rejected_total{signal,reason}`, `contract.grpc_validation`
+in `off`/`warn`/`strict`). Nothing renders them. Ship: violation rate per producer × signal ×
+reason over time; a **state timeline of validation mode**; top violating `sentinel.*` keys;
+contract-version adoption per producer; and a **"would-be-rejected under strict"
+counterfactual** so a team can promote `warn → strict` with evidence rather than nerve.
+*Why first:* §3.1 — no competitor has it, and the data is already being collected.
+
+**V2.2 · Arrival + Volume watchers as z-score over bronze, with the band as the primary artifact.**
+Match the documented commercial baseline before beating it: Elementary ships plain z-score,
+threshold 3.0, 1-day bucket, 14-day training, 2-day detection (**nested, not additive**), with
+seasonality as a `PARTITION BY`. Beat it cheaply with a genuinely **sliding** window (theirs is
+cumulative, so *"a long problem covers its own tracks"*), **robust statistics** (MAD/median),
+and **dual warn/error severity**.
+*Why:* §4 — 40 % fewer human touches than any rule-based alternative.
+
+**V2.3 · The flow DAG becomes health-bearing.**
+`services/flow-ui` already renders origin → collector → `bronze.*` with a contract-backed node
+inspector. Add per-node fused health state, edge thickness = throughput, edge colour =
+violation rate, and a state-timeline strip. Emit it as Grafana **node-graph frames** so it
+renders there too with no plugin.
+
+### Tier 2
+
+**V2.4 · Freshness/arrival lag as a first-class signal**, named `data.staleness.*` and
+`pipeline.*` per the two open proposals — free standards positioning (§3.2).
+
+**V2.5 · An alert-noise budget, designed in from day one.** Dedup, lineage-based clustering,
+suppression during declared backfills, per-channel rate ceilings defaulted at the documented
+**50/week and 100/week engagement cliffs**, severity from downstream blast radius. *Not
+retrofittable.*
+
+**V2.6 · Schema watcher with ordinal-position awareness** and a diff view. Attribute violations
+per schema version — Datadog does this for Avro/Protobuf only, **not JSON Schema**, which is
+precisely Sentinel's contract format.
+
+### Tier 3 — strategic bets
+
+**V2.7 · Emit OpenLineage facets over OTLP.** Map per-signal stats onto
+`DataQualityMetricsInputDatasetFacet` and validation results onto
+`DataQualityAssertionsDatasetFacet` (whose `severity: error|warn` already mirrors our policy).
+Publishing the OTLP transport OpenLineage lacks is the highest-leverage open-source
+contribution available here — real gap, real implementation, interoperability with ~16 lineage
+consumers.
+
+**V2.8 · Adopt OpenLineage's facet governance for `contracts/`** — namespaced prefixes,
+per-object immutable `_schemaURL`, a documented custom→standard promotion path. Gives per-facet
+version evolution instead of a monolithic `v1/`→`v2/` bump. **Worth an ADR before the registry
+grows.**
+
+**V2.9 · Usage-driven signal reduction.** Observe which bronze columns and label combinations
+detectors actually read; recommend aggregations at ingestion. Grafana proves the pattern
+(**35 % average cost reduction across 1,500+ orgs**) and it is Cloud-only — an OSS
+implementation is a genuine differentiator.
+
+### Team-decided, not survey-derived
+
+**V2.10 · Language selector — PT-BR · ES · EN.** A dropdown in the header, alongside the
+palette switch. Not a finding from this survey; a Crew decision, recorded here so the roadmap
+is one list. Three things make it larger than string extraction, and they should be settled
+before any code:
+
+1. **The prose IS the product.** Every board publishes its own method — *"median ± 3σ, σ from
+   MAD × 1.4826 · stddev only where MAD collapses"*, *"grey is not observed, never fine"* —
+   and §3.5 argues that publishing algorithm, window and threshold semantics is the
+   differentiation. Translating that is not localisation of labels, it is translating
+   explanation where precision is the whole value. Symbols and identifiers (`σ`, `MAD`,
+   `sentinel.run_id`, table names) stay untranslated.
+2. **The sentences are composed server-side.** `health_note`, `volume_state.why` and the
+   contract notes are assembled in `pipeline.py` and shipped as finished English strings.
+   Either the backend emits a **structured reason** (`{code, params}`) and the client renders
+   it, or the server localises and needs to know the viewer's locale. The first is the right
+   shape and is the actual work in this item; the dropdown is an afternoon.
+3. **Number formatting is per-locale.** pt-BR uses a comma decimal separator; `fmt()` in
+   `app.js` and `fmt()` in `main.py` both hard-code the English convention, and the figures
+   are rendered server-side before any script runs — so the locale has to be known at
+   render time, not only after hydration.
+
+Prerequisite either way: the reason-code refactor. Doing the dropdown first would freeze the
+English strings in place across four boards.
+
+### Explicitly deprioritized
+
+- **Column-level lineage** — highest effort, and there is no column-level transformation graph
+  to derive it from yet. Do stream/table level first.
+- **Cost/FinOps** — needs warehouse billing integration; orthogonal to the OTel thesis.
+- **LLM tiers** — keep at Tier 3 as already planned. 92 % of Grafana respondents see value in
+  AI for anomaly detection, but **26 % cite excessive manual context input as the top barrier**,
+  and Gartner's advice is to *"validate AI claims during the pilot phase."* Tier-1 statistics
+  has better evidence and lower maintenance burden.
+
+---
+
+## 7. Coverage ledger
+
+| Topic | Depth | Confidence |
+|---|---|---|
+| Monte Carlo · Datadog · Grafana | Deep, primary-sourced | High |
+| OpenLineage spec + facets · OTel semconv gap | Deep, verified firsthand | High |
+| Elementary (z-score method, OSS/Cloud split) | Good | Medium-High |
+| Great Expectations · Marquez · ODCS · Dagster | Adequate | Medium |
+| **Databand · Soda** | **Deep, primary-sourced** (línea tardía, 2026-09-01) | **High** |
+| **Acceldata · Bigeye · Metaplane · Great Expectations** | **Deep, primary-sourced** (línea tardía) | **High** |
+| **Anomalo · Sifflet** | **Thin to none** | **—** |
+
+**Three questions worth a fresh search budget:** Anomalo's actual ML method (the
+gradient-boosted-classifier reading is *plausible inference, not confirmed*); Sifflet's
+monitoring-as-code YAML schema (the best available reference for git-managed monitors); and
+whether IBM has published a formal support-withdrawal letter for Databand (§3.5 settles the
+brand withdrawal; the announcement letter remains unfound and `ibm.com/docs` is WAF-blocked to
+automated clients).
+
+---
+
+## 8. Two structural warnings to design around
+
+1. **Tree vs DAG.** OTel spans have one parent; data lineage is a DAG with many. Both
+   OpenLineage's founder and an independent dbt-OTel proof of concept hit this. Decide
+   deliberately — span **links** for extra parents, or lineage as a separate relation joined on
+   `run_id`. Datadog chose links.
+2. **Lossy OTel→Prometheus mapping**, and hard limits if Grafana is ever a render target: max
+   15 promoted Loki labels, 128 structured-metadata attributes / 64 KB, 5 MB per trace.

--- a/services/flow-ui/.dockerignore
+++ b/services/flow-ui/.dockerignore
@@ -1,0 +1,5 @@
+.venv/
+tests/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/services/flow-ui/DESIGN-DIRECTIONS.md
+++ b/services/flow-ui/DESIGN-DIRECTIONS.md
@@ -1,0 +1,281 @@
+# Direcciones visuales — flow UI
+
+> Cinco mundos candidatos para el visualizador de flujo. Elegir **uno** y recién ahí pulir.
+> Las cifras son medidas, no estimadas — ver [§ Datos](#datos-que-usan-las-maquetas).
+> *2026-09-01 · Pod 2 · pendiente de elección*
+
+## Por qué esto existe
+
+La v0 funciona y no emociona. El problema no son los colores: es que **no hay un mundo
+detrás**. Todo pesa lo mismo, seis tiles idénticas, un diagrama con la mitad de aire muerto
+y nada que decir en reposo.
+
+Buscar referencias sueltas y copiar pedazos da un collage. Lo que funciona es elegir un
+mundo y derivar todo de ahí — paleta, tipografía, movimiento y jerarquía salen solos cuando
+el mundo está decidido.
+
+**Las cinco direcciones muestran el mismo DAG, los mismos siete servicios y las mismas
+cifras.** Lo único que varía es el lenguaje visual, que es exactamente la decisión.
+
+---
+
+## El DAG — común a las cinco
+
+Reemplaza la lista de tablas y las barras de lineaje de la v0. Cada caja se despliega.
+
+```mermaid
+flowchart LR
+  subgraph ORIGEN["ORIGEN · 7 servicios"]
+    S1["pubsub-ingestion-topic · 295k"]
+    S2["dataproc-spark-streaming · 148k"]
+    S3["k8s-api-gateway · 118k"]
+    S4["gcs-raw-bucket · 74k"]
+    S5["dataproc-spark-batch · 59k"]
+    S6["gcs-processed-bucket · 59k"]
+    S7["cloud-composer-etl · 12k"]
+  end
+
+  subgraph COL["collector-rust"]
+    R["receive · gRPC :4317"] --> V["validate · warn"] --> B["buffer · signal=all"]
+  end
+
+  subgraph BRONZE["bronze"]
+    T1["otel_traces · 132k"]
+    T2["otel_metrics_gauge · 274k"]
+    T3["otel_logs · 132k"]
+    T4["otel_metrics_sum · 227k"]
+  end
+
+  ORIGEN -->|OTLP| R
+  B --> T1 & T2 & T3 & T4
+```
+
+Tres carriles entran al collector (logs / traces / metrics se distinguen sólo en el borde de
+recepción); **del buffer en adelante hay uno solo**, porque el `BufferedExporter` mezcla todo
+en un lote y etiqueta `signal="all"`. El diagrama se angosta ahí porque las métricas también.
+
+### El inspector: la documentación ya existe
+
+Al desplegar un nodo se abre su ficha. **No hay que escribir esa documentación** — sale
+entera del contrato de lectura Pod 2 → Pod 3 `v1.0.0.1`. Ejemplo real de `bronze.otel_logs`:
+
+| Columna | Tipo | Garantía |
+|---|---|---|
+| `Timestamp` | `DateTime64(9)` | event time, UTC, precisión ns |
+| `ServiceName` | `LowCardinality(String)` | siempre presente · **única columna indexada** |
+| `SeverityText` | `LowCardinality(String)` | `INFO`, `ERROR`, … |
+| `SeverityNumber` | `UInt8` | 0–24 |
+| `Body` | `String` | texto del log |
+| `TraceId` | `String` | hex de 32, **`''` si ausente — nunca `NULL`** |
+| `SpanId` | `String` | hex de 16, `''` si ausente |
+| `LogAttributes` | `Map(LowCardinality(String), String)` | atributos de registro |
+| `ResourceAttributes` | `Map(LowCardinality(String), String)` | incluye las 6 claves `sentinel.*` |
+
+```
+ORDER BY (ServiceName, TimestampDate, TimestampTime)
+PARTITION BY toYYYYMM(TimestampDate) · TTL 30d
+Sin escribir (default por diseño): TraceFlags · Scope* · ResourceSchemaUrl
+```
+
+Eso convierte el contrato en **documentación viva dentro del producto**: abrís la caja y leés
+qué hay adentro, quién lo escribe y qué podés asumir, en el mismo lugar donde ves pasar el
+dato. Ninguna de las cinco direcciones cambia esto; sólo cambia cómo se ve.
+
+---
+
+## 01 · Centro de mando
+
+> **La sala donde alguien está mirando.**
+
+Instrumentación densa, fósforo sobre negro, todo en pantalla es un *readout*. La credibilidad
+viene de la densidad: el tablero dice *acá hay gente operando esto en serio* antes de que
+leas un número. El DAG se lee como esquemático de sistema; el inspector es una ficha técnica.
+
+**Mundo:** la FCR de Houston, consolas Soyuz, terminales de control de vuelo. Nada es
+decorativo porque en ese mundo nada puede serlo.
+
+| Token | Hex | Rol |
+|---|---|---|
+| fondo | `#080A07` | negro cálido con veladura de scanline |
+| fósforo | `#7FE04A` | caudal, vivo, OK |
+| ámbar | `#FFB000` | atención, nodo seleccionado |
+| texto | `#CFE8C0` | lectura |
+
+**Tipografía** — IBM Plex Mono en todo, una sola familia. Mayúsculas con tracking para
+etiquetas; los números mandan.
+
+**Movimiento** — cursor de barrido cada 4 s, valores que tickean dígito a dígito, un punto
+discreto por señal en cada arista. En batch el barrido acelera.
+
+**Costo** — la densidad exige disciplina. Con pocos datos se ve vacía y en reposo hay que
+darle algo que decir. **Es la más difícil de mantener elegante a medida que crece.**
+
+---
+
+## 02 · Sustrato
+
+> **Los datos son corriente, y esto es el chip.**
+
+El pipeline como sustrato de silicio: trazas finas, nodos como encapsulados, corriente que se
+ve pasar. **La de mayor impacto inmediato** — la que hace que alguien se acerque a la
+pantalla. El brillo de cada traza sube con el caudal real, así que la intensidad es un dato,
+no un efecto.
+
+**Mundo:** *die shots* de procesadores, serigrafía de PCB, macro de placas. Belleza que ya
+existe y que nadie asocia con un dashboard.
+
+| Token | Hex | Rol |
+|---|---|---|
+| sustrato | `#04060B` | fondo con grilla de 24px |
+| corriente | `#22D3EE` | caudal principal, glow |
+| traza 2 | `#F0ABFC` | segundo carril |
+| pad | `#FFC53D` | contactos, valores |
+
+**Tipografía** — Plex Mono chico y con mucho tracking, como serigrafía. Números en peso más
+alto para que floten sobre el glow.
+
+**Movimiento** — pulsos recorriendo las trazas; el glow modula con el caudal. Los flushes son
+descargas que iluminan la línea entera un instante.
+
+**Costo** — **el glow es lo que más rápido envejece.** Dosificado se ve caro; pasado de rosca
+se vuelve estética gamer. Necesita mano firme y probablemente un modo sobrio para proyector.
+
+---
+
+## 03 · Tránsito
+
+> **Un mapa de metro que resulta ser tu pipeline.**
+
+La metáfora más legible que existe para *cosas que van de A a B*. Líneas de color, estaciones
+con contadores, transbordos donde los carriles convergen. Nadie necesita que se lo expliquen.
+Es la única que funciona igual impresa, en un slide y en un monitor — y hereda la paleta
+Okabe-Ito, así que es accesible por construcción.
+
+**Mundo:** el Tube map de Beck, el NYC de Vignelli, señalética de aeropuerto. Un siglo
+resolviendo exactamente este problema de lectura.
+
+| Token | Hex | Rol |
+|---|---|---|
+| papel | `#F4F2ED` | fondo claro |
+| logs | `#0072B2` | línea 1 |
+| traces | `#CC79A7` | línea 2 |
+| metrics | `#E69F00` | línea 3 |
+
+**Tipografía** — Plex Sans Condensed: señalética, peso alto, mucho aire. Mono sólo para las
+cifras.
+
+**Movimiento** — los trenes salen con la frecuencia real del flush: uno por segundo en
+stream, siete en batch. **La animación *es* el horario del servicio.**
+
+**Costo** — **la más clara y la menos espectacular.** Brilla en proyector y documentación;
+en una demo a oscuras no arranca el *wow*. Cambiás impacto por legibilidad.
+
+---
+
+## 04 · Observatorio
+
+> **Exposición larga sobre un cielo de señales.**
+
+Campo oscuro, partículas con estela, tipografía fina y espaciada. La calma como declaración:
+*el sistema está bien, mirá qué tranquilo respira*. Cuando algo se rompe, el cielo se altera.
+La más adulta de las cinco y la que mejor envejece: no depende de ningún efecto de moda.
+
+**Mundo:** astrofotografía de larga exposición, espectrogramas, cartas celestes grabadas. El
+dato como fenómeno observado, no como métrica.
+
+| Token | Hex | Rol |
+|---|---|---|
+| cielo | `#05060D` | fondo con halo violeta inferior |
+| violeta | `#8B7FD4` | acento, tercer carril |
+| estela | `#C6CDE6` | trazas de partícula |
+| figura | `#EDF0FA` | cifras |
+
+**Tipografía** — Plex Sans en peso 200–300, tracking amplio en etiquetas, cifras grandes y
+livianas. La tipografía casi no pesa: el campo manda.
+
+**Movimiento** — estelas que persisten unos segundos, como exposición larga. En batch el
+cielo se llena y la estela se acorta: la misma escena, otra energía.
+
+**Costo** — **riesgo real de que no se lea nada a dos metros.** Necesita una capa de cifras
+legibles que no se puede escatimar, y eso tensiona con la calma. La más elegante y la más
+fácil de arruinar.
+
+---
+
+## 05 · Fundición
+
+> **Caudal con temperatura.**
+
+Tubos pesados, manómetros, flujo incandescente. El caudal deja de ser abstracto: tiene masa y
+tiene calor. Cuando el pipeline se satura, la línea se pone al rojo — literalmente. Es la que
+mejor comunica **presión**, que es justo lo que un pipeline de ingesta tiene y un dashboard
+normal no sabe mostrar.
+
+**Mundo:** esquemas de refinería, tableros SCADA, alto horno. Instrumentación industrial con
+décadas mostrando caudal y presión.
+
+| Token | Hex | Rol |
+|---|---|---|
+| hollín | `#100D0A` | fondo cálido |
+| incandescente | `#FF6B1A` | caudal alto |
+| latón | `#C9A227` | instrumentos, selección |
+| acero | `#8A929B` | estructura |
+
+**Tipografía** — Plex Sans Condensed para rótulos de planta, Mono para instrumentos. Nada
+redondeado.
+
+**Movimiento** — la temperatura del color sube con el caudal, agujas de manómetro que
+responden a la latencia, el lote viaja como colada por el tubo.
+
+**Costo** — **conflicto semántico a resolver.** En observabilidad el rojo es error, y acá el
+naranja intenso significa *mucho caudal*, que es bueno. O se resuelve con una segunda señal
+para el error, o confunde.
+
+---
+
+## Comparación rápida
+
+| | Impacto en demo | Legibilidad | Envejece bien | Riesgo |
+|---|---|---|---|---|
+| **Centro de mando** | alto | alta | bien | se vacía con pocos datos |
+| **Sustrato** | **el más alto** | media | **regular** | el glow se pasa de moda |
+| **Tránsito** | bajo | **la más alta** | **muy bien** | poco *wow* a oscuras |
+| **Observatorio** | alto | **baja** | **muy bien** | ilegible a distancia |
+| **Fundición** | alto | media | bien | rojo = caudal vs rojo = error |
+
+---
+
+## Bugs de geometría de la v0
+
+Van igual, sea cual sea la dirección. No son estilo.
+
+1. **ClickHouse cortado** — el nodo va de `x=894` a `1006` en un viewBox de `1000`.
+2. **Generador suelto** — su caja termina en `x=118`, los carriles arrancan en `192`.
+3. **Carriles bajo el collector** — se leen como tubos cortados flotando.
+4. **Curvas tapadas por el buffer** — ambas ocupan `x=698–802`; de ahí el blob raro.
+
+---
+
+## Datos que usan las maquetas
+
+Medidos el 2026-08-31 contra el pipeline real, no inventados.
+
+| | stream | backfill |
+|---|---|---|
+| señales/s | ~730 | ~18.000 |
+| flushes/s | **1,03** | **6,6** (min 4, max 8) |
+| registros por lote | 500–1.000 | ~2.534 |
+| latencia export | — | 45,3 ms |
+
+`bronze`: 764.568 filas · 7 servicios · `otel_logs` 132k · `otel_traces` 132k ·
+`otel_metrics_gauge` 274k · `otel_metrics_sum` 227k.
+
+---
+
+## Próximos pasos
+
+1. **Elegir una dirección** — o pedir un cruce entre dos, que también es respuesta válida.
+2. Arreglar los **cuatro bugs de geometría**.
+3. Construir el **DAG desplegable con inspector**, alimentado por el contrato.
+4. Recién ahí, **impeccable** sobre la dirección elegida: tokens, jerarquía,
+   micro-interacciones, y un `DESIGN.md` que deje el mundo por escrito.

--- a/services/flow-ui/DESIGN.md
+++ b/services/flow-ui/DESIGN.md
@@ -83,6 +83,16 @@ so more dots would be a lie dressed as detail.
 - **`.hit`** — a clickable node. `pointer-events` is `all` on the group and on the rect,
   and **`none` on every child**, so a click on a label can never land on a different target
   than a click on the box. Hover brightens the border and the fill; `:active` sinks it.
+  **Hover styling uses `>`, and an open container is exempt from it.** As a descendant
+  selector it matched every `.nd` inside a container, so pointing at one table lit that
+  table, its neighbours and the box around them at once. Worse, `.hit:hover .nd` sets
+  `fill: var(--panel)` and outranks `.nd.open{fill:none}` on specificity — so hovering
+  anywhere inside an open container re-filled it opaque and it painted over the pipes
+  running behind it, which is the exact thing `fill:none` is there to prevent.
+- **`.chrome`** — open, the clickable target is the header strip, not the whole interior.
+  The full-size rect covers everything drawn inside the container, so leaving it
+  hit-testable meant the pointer was over the container even while aiming at something
+  inside it. Closed, the box is a card and the card is the button.
 - **`.pw` / `.pb`** — a pipe: a casing, and inside it a bore painted darker than the stage
   so it reads as hollow. The bore also hides the grid, so the channel looks enclosed rather
   than drawn on top of the board. Signals travel the bore's centreline, which is why a dot
@@ -166,6 +176,13 @@ disturbing the ones already in flight.
 viewport queries — the stage is a component and should reflow by its own width. Tiles fall to
 `minmax(112px, 1fr)`. `prefers-reduced-motion` removes `animateMotion` entirely; the graph and
 every figure survive.
+
+**Height a box grows into is not height its contents may use.** Selecting a service grows
+ORIGIN by 138px to make room for the signal panel, and the node grid — sized as
+`(height − 56) / rows` — spread itself across the taller box and put its lower rows directly
+under the panel, which then covered the very nodes it describes. The grid now lays out in
+`gridH`, the height the container has *without* the panel; the extra belongs to the panel
+alone. Any future panel that grows a container needs the same separation.
 
 ## Assets
 

--- a/services/flow-ui/DESIGN.md
+++ b/services/flow-ui/DESIGN.md
@@ -176,10 +176,24 @@ disturbing the ones already in flight.
 
 ## Layout
 
-`aspect-ratio: 1000/440` on the stage, laid out with grid and `gap`. Container queries, not
-viewport queries — the stage is a component and should reflow by its own width. Tiles fall to
-`minmax(112px, 1fr)`. `prefers-reduced-motion` removes `animateMotion` entirely; the graph and
-every figure survive.
+**The drawing fits the window; the window does not fit the drawing.** The stage carried
+`aspect-ratio: 1000/440` with `height: auto`, so its height came from its WIDTH and the screen
+was never consulted: on a 32" monitor it asked for more height than the window had and the
+whole page scrolled, while half-width left the bottom half empty. The page is now a column
+filling `100dvh` and the canvas takes the remainder. Tiles fall to `minmax(112px, 1fr)`.
+`prefers-reduced-motion` removes `animateMotion` entirely; the graph and every figure survive.
+
+**`fit()` measures what is drawn, not the viewBox.** `layout()` reported a flat `height: 440`
+while the closed boxes occupy about 200 of it, so the graph sat small in the middle of empty
+space; and the datasheet, which is not a box, was missing from the bounds entirely and ran off
+the right edge whenever bronze was open. Bounds now come from the real extent, `fit()` centres
+on it, and it may scale UP to `FIT_MAX` — a graph capped at 1× leaves a large screen mostly
+empty.
+
+**It refits when the drawing changes SIZE, and only then.** On window resize, and on opening a
+box or selecting a service — deliberate acts, with an expectation of seeing the result. Not on
+every repaint: a mode change repaints too, and refitting there would throw away a pan the
+reader had just made.
 
 **Height a box grows into is not height its contents may use.** Selecting a service grows
 ORIGIN by 138px to make room for the signal panel, and the node grid — sized as

--- a/services/flow-ui/DESIGN.md
+++ b/services/flow-ui/DESIGN.md
@@ -89,6 +89,10 @@ so more dots would be a lie dressed as detail.
   `fill: var(--panel)` and outranks `.nd.open{fill:none}` on specificity — so hovering
   anywhere inside an open container re-filled it opaque and it painted over the pipes
   running behind it, which is the exact thing `fill:none` is there to prevent.
+- **One channel each.** The border is INTERACTION — hover and selection — and the mark beside
+  the name is STATE. They were briefly the same channel, in the same `--sec`, and a warning
+  node became indistinguishable from a pointed-at one, which is how a pointer stops meaning
+  anything.
 - **`.chrome`** — open, the clickable target is the header strip, not the whole interior.
   The full-size rect covers everything drawn inside the container, so leaving it
   hit-testable meant the pointer was over the container even while aiming at something

--- a/services/flow-ui/DESIGN.md
+++ b/services/flow-ui/DESIGN.md
@@ -1,0 +1,195 @@
+# Design system — flow UI
+
+> Recorded from the built world, not from intentions. Every value here is in
+> `src/flow_ui/static/app.css`; if the two disagree, the CSS is right and this file is stale.
+
+## The world
+
+**A flight-control console, etched onto a circuit board.**
+
+The ground is a mission-control readout: phosphor on near-black, scanlines, everything in one
+monospace, every figure a channel. Onto it is grafted the discipline of a printed board —
+traces routed at 45°, a via at every junction, and a bloom on whatever carries current.
+
+The bloom is not borrowed. **A real phosphor glows**; it is the one thing the board world
+lends that already lived in this one. Nothing else came across — not the cyan, not the
+magenta. Taking those would have made this the board world with a different name.
+
+**What it deliberately is not**: a dashboard of equal cards. Six tiles of the same weight say
+nothing about what to look at, which is what the first version did and why it was replaced.
+
+## Two palettes, one world
+
+Every rule reads a **role**, never a colour. `[data-world]` on the root swaps six values.
+This is the whole reason the switch costs one attribute instead of a second stylesheet.
+
+| Role | Command | Substrate | Job |
+|---|---|---|---|
+| `--bg` | `#080A07` | `#04060B` | the ground |
+| `--pri` | `#7FE04A` | `#22D3EE` | flow, alive, stored |
+| `--sec` | `#FFB000` | `#FFC53D` | attention, batch, selection |
+| `--ter` | `#CFE8C0` | `#F0ABFC` | the second lane |
+| `--alarm` | `#FF4A3D` | `#FF5C7A` | loss, and only loss |
+| `--txt` | `#CFE8C0` | `#C3D6E6` | reading |
+
+**The alarm is the one that does not port.** `#FF4A3D` interrupts against phosphor and amber;
+against cyan and magenta a pure red *competes* instead — magenta is already warm. Substrate
+shifts it toward pink. Same role, tuned value. A naive hue swap would have degraded one of the
+two palettes and nobody would have been able to say why.
+
+**Colour never carries a state alone.** Every status also has a word: the mode chip prints
+`stream`/`batch`/`idle`, the health boxes are labelled `STORED`/`REJECTED`/`DROPPED`, and the
+legend names every particle it colours.
+
+## The switch has no words
+
+Green to the left, blue to the right; the knob is `--knob`, which is `--pri`. **The colour is
+the label.** Naming the palettes in the control would have put two proper nouns in a header
+that is otherwise all data. The choice persists in `localStorage`, wrapped in try/catch — a
+private window that throws must not take the page down with it.
+
+## Type
+
+**IBM Plex Mono, one family, everywhere.** A console has one voice. Uppercase with
+`letter-spacing: .12–.15em` for labels; `font-variant-numeric: tabular-nums` on every figure
+that sits in a column, so a changing digit never reflows its neighbours.
+
+IBM Plex Sans appears only in prose that is not part of the instrument.
+
+## The bloom is exclusive to what is alive
+
+`filter: url(#bloom)` is applied to **one group**: the particles and the batch blocks. Nodes
+stay matte.
+
+If everything glows, the glow stops meaning anything. The eye goes to what moves because
+nothing else asks for it. With no traffic there are no haloes and the board reads as at rest —
+a state that needs no label.
+
+## Semantic zoom, and its one obligation
+
+Level 0 is three boxes. Opening one changes what a particle **means**: at the overview a dot
+is `QUANTUM = 100` signals; inside, it is one trace.
+
+That is a legitimate move, and it is only legitimate **because the legend is rebuilt on every
+level change**. The strip along the bottom is not decoration — it is the contract between the
+picture and the reader. Without it, someone counts dots at one level and quotes a figure from
+another.
+
+The overview caps at `MAX_DOTS = 14` per lane. Beyond that the eye reads a line, not a count,
+so more dots would be a lie dressed as detail.
+
+## Nodes
+
+- **`.hit`** — a clickable node. `pointer-events` is `all` on the group and on the rect,
+  and **`none` on every child**, so a click on a label can never land on a different target
+  than a click on the box. Hover brightens the border and the fill; `:active` sinks it.
+- **`.pw` / `.pb`** — a pipe: a casing, and inside it a bore painted darker than the stage
+  so it reads as hollow. The bore also hides the grid, so the channel looks enclosed rather
+  than drawn on top of the board. Signals travel the bore's centreline, which is why a dot
+  reads as moving *through* a channel instead of sliding along a wire.
+  **Only the flow is piped.** Every outcome tap stays a thin line, and that is the point:
+  if the pipe is the flow, then failing is falling OUT of it, so the two have to be
+  different objects rather than the same object at two weights.
+  Two gauges, both sized by what travels them, not by taste. **13/10** for signals: the
+  floor is the dot's 6.4px core, which scraped the walls at a 9px bore and reads as bursting
+  out; 10px leaves 1.8px a side, and the bloom halo may spill where the core may not.
+  **24/21** for the `buffer → bronze` trunk, because the thing travelling it is an 18px
+  batch sphere, not a dot. Wall thickness is `(casing - bore) / 2` — 1.5px in both, so only
+  the bore grows, because only the payload did. Wider than this was tried and cost two things: ORIGIN's
+  eight-edge topology read as tangled plumbing, and the collector's 32px internal hops
+  became plugs rather than runs.
+- **`.rim`** — a pipe mouth: a short lip ACROSS the run, wider than the casing it caps, and
+  rectangular. **One rule, no exceptions: a lip marks where a pipe meets a box, any box.**
+  It first appeared at only four of the twenty-odd junctions — the inter-container ones —
+  which read as arbitrary rather than as meaning anything. It was a circle first, which read as a bead threaded onto a wire — the one
+  shape that argues against the pipe it is supposed to cap. Every mouth on this board sits
+  where a horizontal run meets a box, so the lip is a tall narrow rect; it is derived from
+  the casing, so the trunk's lip is the bigger one for the same reason its bore is.
+  Replaces the old junction pad and keeps its job — you can see where a connection begins
+  and ends.
+- **45° routing** — edges turn at 45°, never on a Bézier. A diagram routed like a board reads
+  as something fabricated rather than sketched. Pipes inherit it, with round joins so a
+  corner does not open a seam in the casing.
+  **An elbow needs room to turn.** A 45° corner consumes `rise` worth of horizontal run on
+  top of its stubs; given less, it lands past the target and the last leg doubles back,
+  drawing a stray that runs out from under the node it was meant to reach. `route` now
+  falls through to the orthogonal `fan` shape whenever `rise > span - 48`. ORIGIN's columns
+  sit 52px apart, so every edge there that changes row was overshooting — one by 84px,
+  straight through `gcs-processed-bucket`. It had been invisible for as long as the edges
+  were hairlines.
+- **A fan's legs are one casing apart** — edges leaving a node share a port, so their
+  vertical legs must not share a column too. Staggered per source; the clamp that keeps the
+  last chamfer landable is also what caps a readable fan at about three legs per node.
+- **`.cue`** — `▸ OPEN` in `--sec`. A node that can be opened says so in words, not by
+  waiting for a hover that a touch device will never send.
+
+## What the picture refuses to say
+
+**Three lanes in, one lane out.** The graph narrows after the buffer because the metrics do:
+from there on the collector labels everything `signal="all"`, since one mixed batch is flushed
+and no per-type boundary survives. Drawing three lanes all the way to ClickHouse would be
+inventing a distinction the pipeline does not have.
+
+**Outcome is drawn per TYPE where the metric says so, and never per trace.** The line falls
+at the buffer, not at the collector: `signals_rejected_total{signal,reason}` does know which
+of the three types failed and how, so a contract rejection leaves `validate` in that type's
+own colour. `storage_signals_total` does not — it is `signal="all"` — so a dropped batch falls
+as the mixed sphere, ringed. Below type there is nothing: which *trace* was rejected is not
+measured anywhere, and colouring one red would be fabricating a fact.
+
+**Declared and observed sit side by side.** In the origin view the left of each node is Pod 1's
+`topology.yaml`; the right is what actually landed in bronze. They are drawn together on
+purpose — the two disagreeing is itself the finding.
+
+**Three tables are named as empty.** `otel_metrics_histogram`, `_exponential_histogram` and
+`_summary` are permanently zero under contract v1.0.0. Named, they read as a decision; unnamed,
+as a failure.
+
+## Figures before motion
+
+Every number is rendered into the HTML by the server before a script runs. The canvas
+illustrates figures the page already printed; a blocked or slow script costs the motion, never
+the reading. A test pins this.
+
+**Density is spread, not a prefix.** A lane allocates its dots once and afterwards only fades
+them in and out, and *which* ones it fades matters twice over. Lighting the first `n` puts
+every visible dot in the first `n / poolSize` of the cycle — one clump, then an empty stretch,
+so a steady lane reads as a burst and a gap. Lighting every `poolSize / n`-th fixes the spread
+but reshuffles the whole set whenever the rate wobbles, which it does every tick, so half the
+lane fades out and back once a second. The order is built by farthest-point insertion, whose
+prefixes are both evenly spread *and* nested: a rate change adds or removes dots without
+disturbing the ones already in flight.
+
+## Layout
+
+`aspect-ratio: 1000/440` on the stage, laid out with grid and `gap`. Container queries, not
+viewport queries — the stage is a component and should reflow by its own width. Tiles fall to
+`minmax(112px, 1fr)`. `prefers-reduced-motion` removes `animateMotion` entirely; the graph and
+every figure survive.
+
+## Assets
+
+The stylesheet is served as `/static/app.css?v=<mtime>`, stat-ed per render — no build step, no
+restart, and no way for two pages to disagree about which CSS they are wearing.
+
+Type comes from Google Fonts. **Without a network the fallback stack is real** and the page
+stays legible, but the console voice is lost. Self-host before showing this anywhere without
+internet.
+
+---
+
+## Provenance
+
+Direction chosen from five candidates rendered as live mockups, then narrowed through six
+variants of the winner and a navigable zoom prototype. The cross with the board world was the
+owner's call after seeing both. **Those mockups were deleted when V1 closed** — the decisions
+they carried, with palettes and trade-offs, survive in
+[`DESIGN-DIRECTIONS.md`](DESIGN-DIRECTIONS.md); the animated renderings do not.
+
+**No `impeccable` finish-review or documenter subagent was run**; this file was written
+in-thread from the built CSS.
+
+**Not yet verified visually by anyone but the owner in a browser.** Headless capture is
+unavailable here: the page holds an SSE connection open, so Chrome never reaches network-idle
+and `--screenshot` hangs. Structure, JS execution and served figures are verified by test; the
+*look* is not.

--- a/services/flow-ui/Dockerfile
+++ b/services/flow-ui/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN useradd --create-home --shell /bin/bash appuser
+WORKDIR /app
+
+COPY pyproject.toml ./
+COPY src/ ./src/
+
+RUN pip install --no-cache-dir .
+
+# Defaults for the compose network; the service names resolve inside it.
+ENV COLLECTOR_METRICS_URL=http://collector:9090/metrics \
+    CLICKHOUSE_URL=http://clickhouse:8123 \
+    CLICKHOUSE_DATABASE=bronze
+
+USER appuser
+EXPOSE 8080
+
+CMD ["uvicorn", "flow_ui.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -1,0 +1,132 @@
+# flow-ui — the pipeline watching itself
+
+A live picture of Sentinel's ingestion path: what is arriving, how the buffer is flushing it,
+and what is landing in `bronze.*`. Two boards — **Flow** (how data moves) and **Health**
+(what is breaking) — over one semantic zoom.
+
+```
+generator ──OTLP :4317──▶ collector-rust ──HTTP──▶ ClickHouse bronze.*
+                              │ :9090/metrics          │ :8123
+                              └──────────┬─────────────┘
+                                      flow-ui  ──SSE──▶ browser
+                                       :8080
+```
+
+## Run it
+
+```bash
+make up               # ClickHouse + collector
+make ui               # this service        → http://localhost:8080
+make generate-stream  # real-time telemetry, paced by the wall clock
+make generate         # a backfilled window, delivered as fast as it can
+```
+
+Watch the page while running each of the last two. It looks different, on purpose.
+
+## What it does
+
+**It works out the delivery mode on its own.** Nothing tells the page whether the generator is
+streaming or backfilling — the buffer's flush cadence is the tell, and the two do not overlap:
+
+| | `--mode stream` | `--mode backfill` |
+|---|---|---|
+| signals/s | ~730 | ~18,000 |
+| **flushes/s** | **1.03** | **6.6** (min 4, max 8) |
+| records per flush | 500–1,000 | ~2,534 |
+| export latency | — | 45.3 ms avg |
+
+**Semantic zoom.** Level 0 is three boxes. Click one and it opens:
+
+| Level | Shows | Source |
+|---|---|---|
+| **Pipeline** | origin → collector → bronze, three lanes in and one out | `/metrics` |
+| **Origin** | the seven services as a graph, **declared config beside observed row counts** | `topology.yaml` + bronze |
+| **Collector** | where a signal comes from and where it goes, with the three outcomes | `/metrics` |
+| **Bronze** | the tables, and the read contract as each one's datasheet | contract v1.0.0.1 |
+
+`Esc` returns to the overview. The legend at the bottom is rebuilt on every level change,
+because **a particle means something different at each one** — see [DESIGN.md](DESIGN.md).
+
+**Two palettes.** The switch in the header swaps Command (phosphor) for Substrate (cyan). Same
+roles, different values; the choice persists per browser.
+
+## Design rules this service holds to
+
+**The browser never talks to the collector or to ClickHouse.** Not a preference — a
+constraint. The collector's `/metrics` server sets exactly one response header
+(`Content-Type`; see `collector-rust/src/metrics_server.rs`) and ClickHouse has no CORS header
+configured in `infra/`, so a cross-origin fetch from the page is blocked with no visible
+error. This service is the only reader of either. A test pins it.
+
+**Every figure is in the HTML before any script runs.** The graph illustrates numbers the page
+already printed. A blocked or slow script costs the motion, never the reading.
+
+**An absent metric family is a normal state, not an error.** The collector's labelled counters
+are `IntCounterVec`s, and a `*Vec` exposes nothing until a label combination is instantiated.
+On a freshly started collector `/metrics` serves only three families; the other five appear
+when traffic does. `prom.Sample.value()` returns `0.0` for anything absent.
+
+**Bronze growth is measured with `count()` deltas, never a time window.** Bronze stores *event*
+time — the read contract (§2) defines `Timestamp` as the signal's own timestamp, and there is
+no ingest-time column. In backfill the generator writes five minutes of history in thirteen
+seconds, so `WHERE Timestamp > now() - INTERVAL 10 SECOND` answers "what *happened* recently",
+which is not the question. It is also 40,000× the rows: bare `count()` reads 1 row from part
+metadata (3.7 ms measured); the windowed form scans the table.
+
+**Where the per-type distinction dies, and where it does not.** At the gRPC boundary
+`signals_rejected_total` is labelled by both `signal` and `reason`, so a rejection knows which
+of the three types it was — that cross-product is what colours the dot leaving the chain. From
+the **buffer** onward every metric is labelled `signal="all"`, because one mixed batch is
+flushed and no per-type boundary survives; a dropped batch can therefore only be drawn as a
+mixed sphere, ringed to say it was lost. Neither is ever per *trace*: the counts are aggregate.
+
+## Configuration
+
+| Env | Default | |
+|---|---|---|
+| `COLLECTOR_METRICS_URL` | `http://localhost:9090/metrics` | compose sets `http://collector:9090/metrics` |
+| `CLICKHOUSE_URL` | `http://localhost:8123` | compose sets `http://clickhouse:8123` |
+| `CLICKHOUSE_DATABASE` | `bronze` | |
+| `GENERATOR_CONFIG_DIR` | `/app/generator-config` | Pod 1's config, mounted read-only |
+| `FLOW_UI_POLL_INTERVAL` | `1.0` | seconds; matches the stream-mode flush cadence |
+| `FLOW_UI_LINEAGE_INTERVAL` | `5.0` | the per-service `GROUP BY` runs on a slower lane |
+
+## Endpoints
+
+| | |
+|---|---|
+| `GET /` | the page, with the current snapshot rendered in |
+| `GET /stream` | SSE, one snapshot per tick |
+| `GET /api/graph` | the static half: declared topology + table datasheets. Fetched once |
+| `GET /api/snapshot` | the latest tick as JSON |
+| `GET /healthz` | liveness + whether each source is reachable |
+
+## Develop
+
+```bash
+cd services/flow-ui
+uv venv && uv pip install -e . && uv pip install pytest pytest-asyncio
+.venv/bin/python -m pytest tests -q
+.venv/bin/uvicorn flow_ui.main:app --reload --port 8080
+```
+
+## Contracts this reads
+
+- **`contracts/collector/v1/pod2-pod3-read-contract.md` v1.0.0.1** — the bronze semantics. Only
+  columns §2 guarantees are shown, absent optional IDs are `''` per §4, grouping is by
+  `ServiceName` because §5.6 makes that the one index-accelerated axis, and the unindexed
+  `ResourceAttributes` Map probes (§3, §6) stay off the per-tick path.
+- **`services/generator-python/config/topology/default.yaml`** — the declared service graph.
+  Read, not redrawn, so the picture cannot drift from what emits the telemetry. Edges point
+  the way data *flows*: `depends_on: [a]` on `b` means the edge is `a → b`.
+
+## Status
+
+**V1.** Pod 2 self-observability plus the bronze read side, two boards, four zoom levels, two
+palettes. 37 tests. Verified end to end against a live pipeline on 2026-09-01: mode detection
+correct across stream, batch and idle; 1,015,100 signals stored, 0 rejected, 0 export errors.
+
+**Known gaps, deliberate:** no language selector yet (V1 ships English; the selector lands with
+the demo) · the *observed* topology is not yet derived from `ParentSpanId` and compared against
+the declared one · the look has not been reviewed by anyone but the owner, because headless
+capture cannot hold an SSE page still.

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -14,14 +14,81 @@ generator ──OTLP :4317──▶ collector-rust ──HTTP──▶ ClickHous
 
 ## Run it
 
+Everything runs in Docker. No host toolchain is needed to bring the stack up.
+
 ```bash
-make up               # ClickHouse + collector
-make ui               # this service        → http://localhost:8080
-make generate-stream  # real-time telemetry, paced by the wall clock
-make generate         # a backfilled window, delivered as fast as it can
+make up                            # ClickHouse + the Rust collector
+make ui                            # this service → http://localhost:8080
+make generate-stream DURATION=10m  # real-time telemetry, paced by the wall clock
 ```
 
-Watch the page while running each of the last two. It looks different, on purpose.
+`make ui` builds and starts the container, so re-run it after changing anything under
+`src/`. Assets are cache-busted by mtime, so a plain reload is enough in the browser.
+
+`make generate` instead of `generate-stream` delivers a backfilled window as fast as it can.
+Watch the page while running each: it looks different, and working out which one is running
+is something the page does on its own — nothing tells it.
+
+**A first pass, in the order that makes the pipeline legible:**
+
+| | |
+|---|---|
+| **Flow**, closed | three lanes in, one trunk out. One dot is 100 signals of that type |
+| **Flow** → open `ORIGIN` | the declared service graph, each producer carrying its fused state; pipe width is what was actually traced on that edge |
+| **Flow** → open `COLLECTOR-RUST` | `receive → validate → buffer`, and the three ways a signal does not simply arrive |
+| **Flow** → open `BRONZE` | the four tables, each strand carrying the type that lands in it |
+| **Health** | the verdict and the sentence behind it, over a 120s window |
+| **Contract** | the receive boundary: what would be dropped under `strict`, and who is violating |
+| **Watchers** | rows per minute per producer against a band — and the band drawn *is* the alerting rule |
+
+The palette switch (top right) is not decoration: it re-tests every colour decision against a
+second ground. Nothing in the CSS names a colour.
+
+## See it fail
+
+A healthy pipeline shows every failure path at rest, which is correct and tells you nothing.
+Three ways to make them move, in increasing order of violence.
+
+**Contract violations — safe, loses nothing.** Sends foreign OTLP missing a required
+`sentinel.*` key. Under the default `warn` policy the collector counts it and exports it
+anyway, so it lands in bronze and the Contract board can name the producer.
+
+```bash
+docker compose run --rm --entrypoint python \
+  -v "$PWD/services/flow-ui/scripts/inject_contract_violations.py:/tmp/inject.py:ro" \
+  generator /tmp/inject.py 120 40 300
+```
+
+Watch the CONTRACT outcome row in the open collector: the falling dots are coloured by the
+type that failed, and the traces lane stays still because this sends none.
+
+**Backpressure — nothing is lost, the producer is told to retry.** Freeze ClickHouse so the
+buffer fills:
+
+```bash
+docker pause sentinel-clickhouse-1     # ~40s is enough
+docker unpause sentinel-clickhouse-1
+```
+
+**Dropped batches — this destroys data.** A *paused* container holds the connection open and
+the flush hangs, so retries never exhaust; a *stopped* one refuses immediately, the three
+attempts run out, and the batch is gone — there is no dead-letter queue.
+
+```bash
+docker stop sentinel-clickhouse-1      # ~30s
+docker start sentinel-clickhouse-1
+```
+
+## Test it
+
+```bash
+cd services/flow-ui
+uv venv && uv pip install -e . && uv pip install pytest pytest-asyncio
+.venv/bin/python -m pytest tests -q
+```
+
+The suite covers the parsing, the poller's inferences and the pure verdict logic. It does
+**not** cover SVG geometry — where things land on the canvas is checked by looking.
 
 ## What it does
 
@@ -98,7 +165,8 @@ mixed sphere, ringed to say it was lost. Neither is ever per *trace*: the counts
 | `GET /` | the page, with the current snapshot rendered in |
 | `GET /stream` | SSE, one snapshot per tick |
 | `GET /api/graph` | the static half: declared topology + table datasheets. Fetched once |
-| `GET /api/snapshot` | the latest tick as JSON |
+| `GET /api/snapshot` | the latest tick as JSON, including the per-producer verdicts |
+| `GET /api/history` | the server-side rolling window, so a page opened now is not empty |
 | `GET /healthz` | liveness + whether each source is reachable |
 
 ## Develop
@@ -122,7 +190,7 @@ uv venv && uv pip install -e . && uv pip install pytest pytest-asyncio
 
 ## Status
 
-**V1.** Pod 2 self-observability plus the bronze read side, two boards, four zoom levels, two
+**V2.3.** Pod 2 self-observability plus the bronze read side, four boards, four zoom levels, two
 palettes. 37 tests. Verified end to end against a live pipeline on 2026-09-01: mode detection
 correct across stream, batch and idle; 1,015,100 signals stored, 0 rejected, 0 export errors.
 

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -81,14 +81,30 @@ docker start sentinel-clickhouse-1
 
 ## Test it
 
+From the repo root, in Docker, with no host toolchain — and wired into the aggregate targets,
+so `make test` and `make lint` cover this service too:
+
+```bash
+make test-flow-ui     # 57 tests
+make lint-flow-ui     # ruff over src, tests and scripts
+```
+
+Or against a local venv, which is faster to iterate with:
+
 ```bash
 cd services/flow-ui
 uv venv && uv pip install -e . && uv pip install pytest pytest-asyncio
 .venv/bin/python -m pytest tests -q
 ```
 
-The suite covers the parsing, the poller's inferences and the pure verdict logic. It does
-**not** cover SVG geometry — where things land on the canvas is checked by looking.
+The suite covers the parsing, the poller's inferences and the pure verdict logic — including
+the cases that are easy to get confidently wrong: a band whose estimator collapses, a producer
+whose every row violates the contract, an estimator chosen by whether its band fits rather
+than by MAD being non-zero.
+
+It does **not** cover SVG geometry. Where things land on the canvas is checked by looking, and
+that gap has cost real defects: a detail panel drawn over the nodes it describes, two header
+collisions, and a pipe routed out from under the box it was meant to reach.
 
 ## What it does
 

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -218,6 +218,21 @@ dashed and dim — declared, never traced — rather than at a width that would 
 **Still not built:** the per-node state timeline needs per-service history, which nothing
 retains, and Grafana node-graph frames.
 
+## Two rules the review and the reader forced out
+
+**One channel each: the border is interaction, the mark is state.** Per-producer health took
+the node border, in the same `--sec` the hover uses, so a warning node and a pointed-at node
+were indistinguishable and the pointer stopped meaning anything. Hover and selection own the
+border; state lives in the mark beside the name.
+
+**Silence has to be material.** `absent > 0` raised every producer to warn, because a run's
+first and last minute are partial and everyone misses a bucket at the edges — seven of seven
+amber over 1 of 14. It now takes at least two buckets *and* 10% of the estate's.
+
+**Only the trunk is the widest thing on the canvas.** Measured edge widths scaled to 20
+against a 13px standard gauge, so a service dependency drew fatter than the feeders and the
+bronze fan. What those edges carry is relative, so the range tops out *at* the standard gauge.
+
 ## Next planned step
 
 Tier 1 is now closed to the limit of the data. What remains:

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -10,7 +10,7 @@ Working tree only. `git status`:
  M Makefile                    generate-stream + ui targets
  M docker-compose.yml          flow-ui service + generator-config mount
 ?? services/flow-ui/           the whole service
-?? docs/research/data-observability-competitive-landscape.md   (not to be committed yet)
+   docs/research/data-observability-competitive-landscape.md   (the V2 roadmap)
 ```
 
 Run: `make up` → `make ui` → `make generate-stream DURATION=20m`.
@@ -175,13 +175,49 @@ read contract that is Authoritative at `1.0.0.1` — an ADR, not a UI session.
 What landed instead is the half of Arrival that *is* answerable from this data: the absence
 signal above.
 
+## Shipped: V2.3 (partial) · the flow DAG carries health
+
+Contract and Watchers were separate boards, so the view people actually look at knew nothing
+about either. Every producer node in ORIGIN now carries a **fused state** — the worst of its
+volume verdict, the buckets it was silent for, and the rows it wrote missing a contract key —
+as a mark on the node and, when it has something to say, on its border. The reason travels in
+the `aria-label`, so it is not colour-only. The closed card carries the same answer, because
+state you can only reach by opening the box that contains it is not an answer.
+
+**A finding that changed what the feature is worth.** Building it surfaced that
+`legacy-billing-api` and `third-party-agent` — the only two producers with problems — are
+**not in Pod 1's declared topology at all**. The DAG draws what is declared, so no node exists
+to carry their state, and per-node health would have been structurally blind to exactly the
+producers that need it. Undeclared is now its own finding, reported apart from the graph
+because it has no position in the graph: nothing declared them, so nothing told them the
+contract, so they are missing required keys. The correlation is not a coincidence.
+
+**Two thirds of V2.3 are not buildable and were not faked.** It also asks for edge thickness
+by throughput and edge colour by violation rate. There is no per-edge measurement anywhere:
+ORIGIN's edges come from Pod 1's `topology.yaml` and are *declared dependencies, not measured
+flows*, and neither the collector nor bronze counts anything per edge. The per-node state
+timeline needs per-service history, which is not retained — the volume lane refreshes and
+keeps nothing.
+
 ## Next planned step
 
-**V2.4 · Freshness/arrival lag as a first-class signal**, which now has a prerequisite: an
-arrival timestamp at the collector's write path. Worth an ADR before any UI work.
-Alternatively **V2.5 · alert-noise budget**, which the shortlist flags as *not
-retrofittable*.
+Tier 1 is now closed to the limit of the data. What remains:
+
+* **V2.5 · alert-noise budget**, which the shortlist flags as *not retrofittable* — the
+  strongest remaining candidate for that reason alone.
+* **V2.6 · schema watcher** with ordinal-position awareness.
+* **V2.4 · freshness/arrival lag** and the **Arrival watcher**, both blocked on the same
+  prerequisite: an arrival timestamp at the collector's write path. Worth an ADR, not UI work.
+* A **geometry test**. Two layout collisions and one overlap reached the reader today; the
+  57 tests cover the backend and the pure logic and nothing about where things land.
+* **The rest of V2.3**, which is two pieces, not four: a per-node state timeline (needs
+  per-service history retained, which nothing does today) and Grafana node-graph frames.
+  Edge thickness by throughput and edge colour by violation rate are not pending — there is
+  no per-edge measurement to draw them from.
+* **V2.10 · language selector (PT-BR · ES · EN)**, a Crew decision rather than a survey
+  finding. Its real work is a reason-code refactor: `health_note`, `volume_state.why` and the
+  contract notes are composed server-side as finished English sentences, and the figures are
+  rendered before any script runs, so the locale has to be known at render time.
 
 Rationale and the rest of the shortlist are in
-`docs/research/data-observability-competitive-landscape.md`, which is **not to be committed
-yet**.
+[`docs/research/data-observability-competitive-landscape.md`](../../docs/research/data-observability-competitive-landscape.md).

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -175,7 +175,7 @@ read contract that is Authoritative at `1.0.0.1` — an ADR, not a UI session.
 What landed instead is the half of Arrival that *is* answerable from this data: the absence
 signal above.
 
-## Shipped: V2.3 (partial) · the flow DAG carries health
+## Shipped: V2.3 · the flow DAG carries health, on measured edges
 
 Contract and Watchers were separate boards, so the view people actually look at knew nothing
 about either. Every producer node in ORIGIN now carries a **fused state** — the worst of its
@@ -192,12 +192,31 @@ producers that need it. Undeclared is now its own finding, reported apart from t
 because it has no position in the graph: nothing declared them, so nothing told them the
 contract, so they are missing required keys. The correlation is not a coincidence.
 
-**Two thirds of V2.3 are not buildable and were not faked.** It also asks for edge thickness
-by throughput and edge colour by violation rate. There is no per-edge measurement anywhere:
-ORIGIN's edges come from Pod 1's `topology.yaml` and are *declared dependencies, not measured
-flows*, and neither the collector nor bronze counts anything per edge. The per-node state
-timeline needs per-service history, which is not retained — the volume lane refreshes and
-keeps nothing.
+**Edge thickness and colour are now measured, and getting there was a one-field fix in Pod 1.**
+The first pass reported them as unbuildable — "no per-edge measurement anywhere" — which was
+true of the data and wrong about why. The chain was intact end to end: `ScenarioEngine`
+assembles correlated traces by walking `depends_on`, the model carries `parent_span_id`,
+`otlp_output.schema.json` declares it, the read contract documents `ParentSpanId` as `''`
+*for root spans*, the collector parses it and its exporter writes it, both with tests. Only
+`generator-python/src/otelgen/exporters/otlp.py` built `ReadableSpan` with a context and no
+`parent`, so `trace_id` reached the wire and the parent did not — measured live, traces
+arrived correlated (8.5 spans each, 30k spanning more than one service) while 1,491,881 of
+1,491,881 landed as roots. A call graph that existed in the generator and nowhere downstream.
+Two regression tests in Pod 1 pin it; **that file wants Pod 1's review on the PR.**
+
+With the parent on the wire, `ClickHouse.call_edges()` joins child to parent and the two
+`ServiceName`s are the edge: pipe width from spans traced, casing colour from the error rate
+on that edge (≥1% / ≥5%, printed in the legend). The join needs `TraceId` as well as
+`ParentSpanId = SpanId` — a fixed `--seed` repeats span ids between runs, and the id alone
+invented eight edges the topology does not contain.
+
+**Declared and measured are drawn as different claims.** `spark_streaming → processed_bucket`
+and `spark_streaming → k8s-api-gateway` are declared and carry no span, because the engine
+parents every child to `depends_on[0]` and never to the second dependency. They are drawn
+dashed and dim — declared, never traced — rather than at a width that would imply traffic.
+
+**Still not built:** the per-node state timeline needs per-service history, which nothing
+retains, and Grafana node-graph frames.
 
 ## Next planned step
 

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -78,9 +78,110 @@ yet derived from `ParentSpanId` and compared against the declared one · a servi
 bronze but absent from `topology.yaml` would be invisible in ORIGIN · the look has been
 reviewed only by the owner, because headless capture cannot hold an SSE page still.
 
+## Shipped: V2.1 · Contract Health
+
+A third board, from two sources whose split is the design. The collector knows **how many**
+violated and **how** (`signals_rejected_total{signal,reason}`) but never **who** — its
+counters carry no service label. Bronze knows who, because under the default `warn` policy a
+violating signal is exported anyway and the evidence lands in the table.
+
+- **The counterfactual is the headline.** Under `warn` the collector counts what it would
+  have dropped and exports it anyway, so that number *is* the answer to "what happens if we
+  promote to strict" — measured, not modelled.
+  **Four ways that number can be zero, and only one is good news:** `off` (nothing is
+  checked), `unknown` (the policy could not be read), `idle` (nothing arrived to check), and
+  clean (traffic came through and passed). Each gets its own headline and its own tone;
+  collapsing them into one green all-clear is the failure this board exists to prevent, and
+  the first version did it — it showed "nothing failing the contract" over a dead pipeline.
+- **Violation rate per signal over the window**, because `signals_rejected_total` is labelled
+  by both `signal` and `reason` and a single total would hide which type is failing.
+- **Who is violating**, from bronze: rows missing a required key, per producer, per key.
+  `contract_violations()` counts with `countIf` per key rather than `ARRAY JOIN`-ing the five
+  names — the array form multiplies every row by five before filtering, measured 6.4s against
+  1.26s over the same ~6M rows. Its own 30s lane; it probes an unindexed Map.
+
+**Two things V2.1 asked for that are not here, on purpose:**
+
+- **Contract-version adoption per producer — impossible.** `collector-rust/src/otlp.rs`
+  injects `CONTRACT_VERSION` into every signal it builds ("OTLP carries no
+  `contract_version` field"), so every producer reads back the collector's own constant. The
+  panel would show `1.0.0` for everyone and mean nothing.
+- **A state timeline of validation mode — degenerate.** The policy is config read at
+  collector startup and is not exposed as a metric, so it cannot change mid-window. The board
+  states it and says why, instead of drawing a strip over a constant.
+
+**Bug this surfaced:** `topology.CONTRACT["validation"]` was hard-coded to the literal string
+`"grpc_validation"` — the config *key*, not its value — and every board rendered it where it
+meant the mode. It is now read from the collector's own config, mounted read-only, and
+reports `unknown` rather than guessing `warn` (the collector's default, and so exactly the
+wrong thing to assume). Two regression tests pin it.
+
+## Shipped: V2.2 · Volume watcher
+
+A fourth board. Rows per minute per producer, judged against a band — and **the band drawn
+is the alerting rule**, both from `pipeline.volume_state`, one place, one set of numbers.
+Metaplane shipped a version where they were computed separately and publicly called
+reconciling them a "simplification"; there was no reason to repeat it.
+
+**The method is published on the board**, because that is the differentiator the survey
+found: Acceldata discloses nothing, Bigeye names no model families, Metaplane publishes the
+reasoning but not the estimator. Threshold is Elementary's documented z = 3.0; the estimator
+is what changes — median and MAD × 1.4826, so one bad bucket cannot widen the band meant to
+catch it. Dual severity (3σ warn, 5σ fail). Sliding, not cumulative: theirs is cumulative, so
+*"a long problem covers its own tracks"*.
+
+**The bucket is a minute, not a day.** Elementary's documented baseline is a 1-day bucket
+over 14 days; at this pipeline's cadence that would hold one point. Same method, scaled to
+the data, and the board says which.
+
+**Four states, and grey is `not observed`, never `fine`** — and the two alerting severities
+are told apart by their labels (`alerting ≥3σ` / `≥5σ`), not by colour alone, which this
+repo's own rule forbids and the first version did. (Bigeye's distinction, and the
+same rule as the contract board's four zeros):
+
+- The current bucket is excluded — it is partial, and comparing a half-filled bucket to a
+  band built from full ones alarms every tick.
+- **The estimator is chosen by whether its band fits, not by MAD being non-zero.** The first
+  version used `mad * 1.4826 or sd`, which is a cliff: on a producer alternating full minutes
+  (2850 rows) with partial ones (600–1600) the median sits on the dominant mode, MAD measures
+  that mode against itself (50, against a true spread of 699), and the instant MAD crossed
+  zero σ moved 74 → 699 between two consecutive ticks — flipping all eight producers from
+  passing to alerting on one new bucket. Caught on screen, not in review.
+  Now a cascade with a validity test at each step: a band that rejects more than
+  `MAX_OOB_SHARE` of the window it was **built from** is describing one mode of it, not the
+  series. MAD is tried first, stddev next, and if neither fits the series is declared not
+  single-mode. On the measured data the MAD band excluded 14 of its own 31 buckets; stddev
+  excludes 3% and is used. Two regression tests pin it.
+- A perfectly regular producer has **MAD = 0 and a zero-width band** in which every value is
+  infinitely anomalous — the same conclusion by a different route, and the generator produces
+  exactly that case too.
+- Under `MIN_BUCKETS` there is no distribution and a band drawn from three points is
+  theatre.
+
+**Absence is its own axis**, not a band violation: buckets in which the estate received
+something and this producer did not. Computed against the estate rather than a clock, so it
+needs no schedule model. This is the survey's strongest idea — a tool reading a table at rest
+sees a stale table, never the write that failed to happen — and it falls out of being
+pipeline-centric.
+
+### The Arrival watcher is not here, and not because of effort
+
+**Bronze has no arrival timestamp.** `otel_logs` carries `Timestamp` (event time) and two
+columns derived from it, and nothing else; there is nowhere to read *when* a row showed up.
+Freshness over event time would answer a different question, and the backfill writes history,
+so it would answer it wrongly. Adding an ingestion column is a collector change against a
+read contract that is Authoritative at `1.0.0.1` — an ADR, not a UI session.
+
+What landed instead is the half of Arrival that *is* answerable from this data: the absence
+signal above.
+
 ## Next planned step
 
-**V2.1 · Contract Health** — the counters already exist (`signals_rejected_total{signal,reason}`,
-the `grpc_validation` policy) and nothing renders them as a board. Rationale and the rest of
-the shortlist are in `docs/research/data-observability-competitive-landscape.md`, which is
-**not to be committed yet**.
+**V2.4 · Freshness/arrival lag as a first-class signal**, which now has a prerequisite: an
+arrival timestamp at the collector's write path. Worth an ADR before any UI work.
+Alternatively **V2.5 · alert-noise budget**, which the shortlist flags as *not
+retrofittable*.
+
+Rationale and the rest of the shortlist are in
+`docs/research/data-observability-competitive-landscape.md`, which is **not to be committed
+yet**.

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -1,0 +1,86 @@
+# flow-ui — working state
+
+*2026-09-01 · branch `feat/flow-ui` · **nothing committed***
+
+## Where things are
+
+Working tree only. `git status`:
+
+```
+ M Makefile                    generate-stream + ui targets
+ M docker-compose.yml          flow-ui service + generator-config mount
+?? services/flow-ui/           the whole service
+?? docs/research/data-observability-competitive-landscape.md   (not to be committed yet)
+```
+
+Run: `make up` → `make ui` → `make generate-stream DURATION=20m`.
+Tests: `cd services/flow-ui && .venv/bin/python -m pytest tests -q` → 47 passing.
+
+## What V1 does
+
+**Flow** — one pan/zoom canvas. ORIGIN / COLLECTOR-RUST / BRONZE expand **in place**; the
+others stay put and the particles keep flowing. Selecting a service filters bronze figures to
+it and lists which metrics it emits. `⌂ + −` bottom right, wheel zooms on the cursor, drag
+pans, `Esc` resets.
+
+**Health** — a verdict (`ok/warn/fail/idle`) with the sentence behind it, four 120 s rolling
+series with avg and peak, export latency p50/p90/p99 against an 80 ms ceiling, a mode
+timeline, and rejections split by reason.
+
+Two palettes (command / substrate) switched by one attribute; nothing in the CSS names a
+colour. Design recorded in [`DESIGN.md`](DESIGN.md).
+
+## Solved: the outcome rows now read as coming from their stage
+
+The fifth attempt worked, and not by moving the rows. Two changes did it:
+
+1. **What falls down a tap is drawn as what failed.** `signals_rejected_total` carries BOTH a
+   `signal` and a `reason` label, so the `signal × reason` cross-product is measured data —
+   `prom.Sample.sum_over_pair` reads it into `Snapshot.reject_matrix`. A metrics rejection now
+   falls amber and a log rejection green. The previous version ran one hard-coded pool per
+   tap, which painted **every** rejection of every type amber: right by accident for metrics,
+   wrong for the other two.
+2. **Each outcome's RETURN is drawn, and the asymmetry is the content.** Under `warn` the
+   contract row sends a line back up into `buffer` — it really is exported anyway; under
+   `strict` that line is absent, which is the only place the policy difference is visible at
+   all. Backpressure sends a *control* line back into `receive` (dotted, no particles: what
+   travels back is a gRPC status, not the batch). Dropped has none, so `⊣` became information
+   rather than decoration.
+
+The open container widened 452 → 500 to open a 20px return channel down each margin, and the
+stage row centres itself inside it. Earlier attempts failed because three identical rows with
+three identical taps told one story three times; the fix was to make the three stories differ.
+
+Still not settled: opening a box does not refit the viewport, so collector + bronze + datasheet
+all open runs off the right edge until you pan or press ⌂. Pre-existing, and refitting would
+move the canvas under the reader mid-inspection.
+
+## Facts the drawing must not contradict
+
+Read from `collector-rust/src/`, not assumed:
+
+- Strict order `receive → validate → buffer`. Nothing enters mid-chain; only `buffer` writes.
+- `contract` rejection happens in `validate`. Under the default **`warn`** policy the signal
+  is counted and **exported anyway** — it still reaches bronze. Only `strict` discards it.
+- `backpressure` is `buffer.enqueue` refusing a full batch, answered with `resource_exhausted`.
+  Nothing is lost; the producer retries.
+- `dropped` is the flush loop after 3 retries. **No dead-letter queue, no disk spill, no
+  requeue.** The path ends.
+- Bronze routes on **data-point type**, never on producer, so every service reaches all four
+  tables. The metric *mix* is the only per-service difference.
+- Live rates carry a `signal` label and **no service label**, so per-service throughput does
+  not exist upstream of ClickHouse. Bronze figures can be filtered; rates cannot.
+
+## Known gaps, deliberate
+
+No language selector (V1 is English; it ships with the demo) · the *observed* topology is not
+yet derived from `ParentSpanId` and compared against the declared one · a service present in
+bronze but absent from `topology.yaml` would be invisible in ORIGIN · the look has been
+reviewed only by the owner, because headless capture cannot hold an SSE page still.
+
+## Next planned step
+
+**V2.1 · Contract Health** — the counters already exist (`signals_rejected_total{signal,reason}`,
+the `grpc_validation` policy) and nothing renders them as a board. Rationale and the rest of
+the shortlist are in `docs/research/data-observability-competitive-landscape.md`, which is
+**not to be committed yet**.

--- a/services/flow-ui/pyproject.toml
+++ b/services/flow-ui/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "sentinel-flow-ui"
+version = "0.1.0"
+description = "Sentinel pipeline flow visualizer — server-rendered, SSE-driven"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.32",
+    "jinja2>=3.1",
+    "httpx>=0.28",
+    "pyyaml>=6.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/flow_ui"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+asyncio_mode = "auto"

--- a/services/flow-ui/scripts/inject_contract_violations.py
+++ b/services/flow-ui/scripts/inject_contract_violations.py
@@ -1,0 +1,62 @@
+"""Send foreign OTLP — well-formed, but missing `sentinel.run_id`.
+
+The collector's default `warn` policy exists for exactly this: telemetry that did not come
+from Pod 1's generator legitimately lacks the five `sentinel.*` keys, so a `strict` default
+would reject valid traffic. Under `warn` these signals are counted as contract violations and
+**exported anyway**, which is why the evidence shows up in bronze and on the Contract board.
+
+Metrics and logs only, no spans, on purpose: the falling dot in the collector's OUTCOMES
+panel is coloured by the signal type that actually failed, so a run of this must leave the
+traces lane at zero. If a white dot falls, something is colouring by guess.
+
+Run it from the repo root, against the compose network:
+
+    docker compose run --rm --entrypoint python \
+      -v "$PWD/services/flow-ui/scripts/inject_contract_violations.py:/tmp/inject.py:ro" \
+      generator /tmp/inject.py <seconds> <logs-per-tick> <metrics-per-tick>
+
+    # 2 minutes of ~40 logs/s and ~300 metrics/s that fail the contract
+    ... generator /tmp/inject.py 120 40 300
+"""
+import sys
+import time
+
+import grpc
+from opentelemetry.proto.collector.logs.v1 import logs_service_pb2 as LS
+from opentelemetry.proto.collector.logs.v1 import logs_service_pb2_grpc as LSG
+from opentelemetry.proto.collector.metrics.v1 import metrics_service_pb2 as MS
+from opentelemetry.proto.collector.metrics.v1 import metrics_service_pb2_grpc as MSG
+from opentelemetry.proto.common.v1 import common_pb2 as C
+from opentelemetry.proto.logs.v1 import logs_pb2 as L
+from opentelemetry.proto.metrics.v1 import metrics_pb2 as M
+from opentelemetry.proto.resource.v1 import resource_pb2 as R
+
+kv = lambda k, v: C.KeyValue(key=k, value=C.AnyValue(string_value=v))
+# Four of the five required keys. `sentinel.run_id` is absent — one missing key is enough.
+RES = R.Resource(attributes=[
+    kv("service.name", "third-party-agent"),
+    kv("cloud.provider", "gcp"),
+    kv("sentinel.synthetic", "false"),
+    kv("sentinel.scenario", "foreign"),
+])
+
+ch = grpc.insecure_channel("collector:4317")
+logs, mets = LSG.LogsServiceStub(ch), MSG.MetricsServiceStub(ch)
+LOGS_PER_TICK, METRICS_PER_TICK = int(sys.argv[2]), int(sys.argv[3])
+deadline = time.time() + float(sys.argv[1])
+sent = 0
+while time.time() < deadline:
+    now = time.time_ns()
+    logs.Export(LS.ExportLogsServiceRequest(resource_logs=[L.ResourceLogs(
+        resource=RES, scope_logs=[L.ScopeLogs(log_records=[
+            L.LogRecord(time_unix_nano=now, severity_number=9, severity_text="INFO",
+                        body=C.AnyValue(string_value=f"foreign log {i}"))
+            for i in range(LOGS_PER_TICK)])])]))
+    mets.Export(MS.ExportMetricsServiceRequest(resource_metrics=[M.ResourceMetrics(
+        resource=RES, scope_metrics=[M.ScopeMetrics(metrics=[
+            M.Metric(name="agent.cpu_pct", gauge=M.Gauge(data_points=[
+                M.NumberDataPoint(time_unix_nano=now, as_double=float(i))
+                for i in range(METRICS_PER_TICK)]))])])]))
+    sent += LOGS_PER_TICK + METRICS_PER_TICK
+    time.sleep(1)
+print(f"sent {sent} foreign signals", flush=True)

--- a/services/flow-ui/src/flow_ui/__init__.py
+++ b/services/flow-ui/src/flow_ui/__init__.py
@@ -1,0 +1,1 @@
+"""Sentinel flow UI — the pipeline's own telemetry, rendered as a moving picture."""

--- a/services/flow-ui/src/flow_ui/clickhouse.py
+++ b/services/flow-ui/src/flow_ui/clickhouse.py
@@ -1,0 +1,182 @@
+"""Reading bronze — the Pod 2 → Pod 3 read contract, from the consumer side.
+
+Built against `contracts/collector/v1/pod2-pod3-read-contract.md` v1.0.0.1.
+
+**Row counts are read with bare `count()`, never with a time window, and that is a
+correctness decision before it is a performance one.** Bronze stores *event* time: the
+contract (§2) defines `Timestamp` / `TimeUnix` as the signal's own timestamp, and there is
+no ingest-time column anywhere in the schema. In backfill mode the generator writes a
+window of history — measured: five minutes of timestamps ingested in 13.5 seconds — so
+`WHERE Timestamp > now() - INTERVAL 10 SECOND` asks "which rows *happened* recently",
+which is not the question. "How many rows *arrived*" is a delta of `count()`.
+
+It is also far cheaper. Measured on 233k rows: bare `count()` reads 1 row (it comes from
+part metadata) in 3.7 ms; the same count with a 10-second predicate reads all 40,200 rows
+of the table. That gap widens with every row inserted.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+
+log = logging.getLogger("flow_ui.clickhouse")
+
+#: The tables Pod 2 actually writes. The bronze DDL also defines
+#: `otel_metrics_histogram`, `_exponential_histogram` and `_summary`; contract §2.3 and §5
+#: state they stay empty in this version because Pod 1's v1.0.0 emits gauge and sum only.
+#: They are listed separately so the UI can say "empty by contract" rather than draw four
+#: live tables and two dead ones with no explanation.
+LIVE_TABLES = ("otel_logs", "otel_traces", "otel_metrics_gauge", "otel_metrics_sum")
+EMPTY_BY_CONTRACT = (
+    "otel_metrics_histogram",
+    "otel_metrics_exponential_histogram",
+    "otel_metrics_summary",
+)
+
+
+class ClickHouse:
+    """A thin async client over the HTTP interface."""
+
+    def __init__(self, url: str, database: str, timeout: float = 4.0) -> None:
+        self._url = url.rstrip("/")
+        self._db = database
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def _query(self, sql: str) -> str:
+        """POST the SQL as the raw request body.
+
+        Not as a url-encoded ``query=`` form field: ClickHouse takes the whole body as the
+        statement, so a form encoding makes it try to parse the literal text ``query=SELECT
+        ...`` and fail with `Syntax error: failed at position 1 ('query')`.
+        """
+        resp = await self._client.post(self._url + "/", content=sql.encode())
+        resp.raise_for_status()
+        return resp.text
+
+    async def counts(self) -> dict[str, int]:
+        """Total rows per live table, in one round trip.
+
+        `ORDER BY` over a `UNION ALL` cannot see the branch aliases, so the union is
+        wrapped in a subquery — otherwise ClickHouse raises `UNKNOWN_IDENTIFIER`.
+        """
+        union = "\nUNION ALL ".join(
+            f"SELECT '{t}' AS tbl, count() AS n FROM {self._db}.{t}" for t in LIVE_TABLES
+        )
+        sql = f"SELECT * FROM (\n{union}\n) ORDER BY tbl FORMAT TSV"
+        out: dict[str, int] = {t: 0 for t in LIVE_TABLES}
+        try:
+            for line in (await self._query(sql)).splitlines():
+                if not line.strip():
+                    continue
+                tbl, n = line.split("\t")
+                out[tbl] = int(n)
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("bronze counts unavailable: %s", exc)
+        return out
+
+    async def lineage(self, limit: int = 12) -> list[dict]:
+        """Rows per service, split by destination table.
+
+        `ServiceName` is the leading `ORDER BY` key on every bronze table (contract §5.6),
+        so this grouping is index-accelerated. `sentinel.scenario` deliberately is *not*
+        used: it lives inside the `ResourceAttributes` Map and §3/§6 warn it is an
+        unindexed probe, which is not something to put on a polling path.
+
+        The four counts are kept apart rather than summed into "metrics" because that is
+        the only thing that distinguishes one service from another here — **every service
+        writes to all four tables**, so the shape of the split is the information, not the
+        set of destinations.
+        """
+        sql = f"""
+        SELECT ServiceName,
+               sum(n) AS total,
+               sumIf(n, t = 'logs')   AS logs,
+               sumIf(n, t = 'traces') AS traces,
+               sumIf(n, t = 'gauge')  AS gauge,
+               sumIf(n, t = 'sum')    AS sums
+        FROM (
+            SELECT ServiceName, 'logs' AS t, count() AS n
+              FROM {self._db}.otel_logs GROUP BY ServiceName
+            UNION ALL
+            SELECT ServiceName, 'traces', count() FROM {self._db}.otel_traces GROUP BY ServiceName
+            UNION ALL
+            SELECT ServiceName, 'gauge', count()
+              FROM {self._db}.otel_metrics_gauge GROUP BY ServiceName
+            UNION ALL
+            SELECT ServiceName, 'sum', count()
+              FROM {self._db}.otel_metrics_sum GROUP BY ServiceName
+        )
+        GROUP BY ServiceName ORDER BY total DESC LIMIT {int(limit)} FORMAT TSV
+        """
+        rows: list[dict] = []
+        try:
+            for line in (await self._query(sql)).splitlines():
+                if not line.strip():
+                    continue
+                name, total, logs, traces, gauge, sums = line.split("\t")
+                rows.append({
+                    "service": name, "total": int(total), "logs": int(logs),
+                    "traces": int(traces), "gauge": int(gauge), "sum": int(sums),
+                })
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("bronze lineage unavailable: %s", exc)
+        return rows
+
+    async def metric_inventory(self) -> dict[str, dict[str, list[str]]]:
+        """Which named metrics each service emits, and which table each lands in.
+
+        This is the answer to "what is *this* service's path", and it is the only place
+        the per-service question has a real answer: routing to a bronze table is decided
+        by the **data-point type**, never by the producer, so every service reaches every
+        table. What differs is *which metrics* it emits — and that is what makes one
+        service's split 3:1 gauge-to-sum and another's 1:2.
+
+        Grouping by name over both metric tables is heavier than the counters, so the
+        poller runs it on its own slow cadence. The inventory is effectively static.
+        """
+        sql = f"""
+        SELECT ServiceName, tbl, MetricName FROM (
+            SELECT ServiceName, 'gauge' AS tbl, MetricName
+              FROM {self._db}.otel_metrics_gauge GROUP BY ServiceName, MetricName
+            UNION ALL
+            SELECT ServiceName, 'sum', MetricName
+              FROM {self._db}.otel_metrics_sum GROUP BY ServiceName, MetricName
+        ) ORDER BY ServiceName, tbl, MetricName FORMAT TSV
+        """
+        out: dict[str, dict[str, list[str]]] = {}
+        try:
+            for line in (await self._query(sql)).splitlines():
+                if not line.strip():
+                    continue
+                svc, tbl, name = line.split("\t")
+                out.setdefault(svc, {"gauge": [], "sum": []})[tbl].append(name)
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("metric inventory unavailable: %s", exc)
+        return out
+
+    async def scenario(self) -> str:
+        """The most recent run's scenario, for the header.
+
+        This *does* probe the `ResourceAttributes` Map, which §3 flags as unindexed — which
+        is exactly why it is read on the slow lineage cadence and never per tick.
+        """
+        sql = (
+            f"SELECT ResourceAttributes['sentinel.scenario'] "
+            f"FROM {self._db}.otel_logs ORDER BY Timestamp DESC LIMIT 1 FORMAT TSV"
+        )
+        try:
+            return (await self._query(sql)).strip() or "—"
+        except httpx.HTTPError:
+            return "—"
+
+    async def ping(self) -> bool:
+        try:
+            await self._query("SELECT 1")
+            return True
+        except (httpx.HTTPError, asyncio.TimeoutError):
+            return False

--- a/services/flow-ui/src/flow_ui/clickhouse.py
+++ b/services/flow-ui/src/flow_ui/clickhouse.py
@@ -17,6 +17,7 @@ of the table. That gap widens with every row inserted.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 
 import httpx
@@ -29,6 +30,18 @@ log = logging.getLogger("flow_ui.clickhouse")
 #: They are listed separately so the UI can say "empty by contract" rather than draw four
 #: live tables and two dead ones with no explanation.
 LIVE_TABLES = ("otel_logs", "otel_traces", "otel_metrics_gauge", "otel_metrics_sum")
+
+#: The five keys Pod 1 guarantees on every signal, mirrored from the collector's
+#: `REQUIRED_RESOURCE_KEYS` (`collector-rust/src/contract.rs`). Duplicated deliberately:
+#: this is the *reader's* copy, and if the two ever disagree the board should show what
+#: the collector is actually enforcing — so the drift is visible rather than silent.
+REQUIRED_RESOURCE_KEYS = (
+    "sentinel.synthetic",
+    "sentinel.scenario",
+    "sentinel.run_id",
+    "cloud.provider",
+    "service.name",
+)
 EMPTY_BY_CONTRACT = (
     "otel_metrics_histogram",
     "otel_metrics_exponential_histogram",
@@ -157,6 +170,137 @@ class ClickHouse:
                 out.setdefault(svc, {"gauge": [], "sum": []})[tbl].append(name)
         except (httpx.HTTPError, ValueError) as exc:
             log.warning("metric inventory unavailable: %s", exc)
+        return out
+
+    async def contract_violations(self, limit: int = 10) -> list[dict]:
+        """Which producers wrote rows missing a required key, and which key.
+
+        **This is the only per-producer view of contract health that exists.** The
+        collector's `signals_rejected_total` carries `signal` and `reason` but no service
+        label, so it can say *how many* violated and *how*, never *who*. Bronze can,
+        because under the default `warn` policy a violating signal is exported anyway —
+        the evidence lands in the table.
+
+        Two things make it affordable. It probes `ResourceAttributes`, an unindexed Map
+        (§3), so it runs on its own slow cadence and never per tick. And it counts with
+        `countIf` per key rather than `ARRAY JOIN`-ing the five key names: the array form
+        multiplies every row by five *before* filtering, which measured 6.4s against
+        1.26s over the same ~6M rows.
+
+        `violating` counts ROWS missing at least one key, which is not the sum of the
+        per-key counts: a row missing four keys is one bad row, not four. Reporting the sum
+        as a share made a producer missing 4 of 5 keys on every row read "80%", which looks
+        like a row percentage and is not one.
+
+        Returns `[{service, rows, violating, missing: {key: n}, total_missing}]`, worst first.
+        """
+        keys = REQUIRED_RESOURCE_KEYS
+        cols = ",\n".join(
+            f"    countIf(NOT mapContains(ResourceAttributes, '{k}')) AS m{i}"
+            for i, k in enumerate(keys)
+        )
+        has_all = " AND ".join(
+            f"mapContains(ResourceAttributes, '{k}')" for k in keys
+        )
+        cols += f",\n    countIf(NOT ({has_all})) AS bad"
+        per_table = "\n  UNION ALL\n".join(
+            f"  SELECT ServiceName, count() AS rows,\n{cols}\n"
+            f"    FROM {self._db}.{t} GROUP BY ServiceName"
+            for t in LIVE_TABLES
+        )
+        sums = ", ".join(f"sum(m{i}) AS k{i}" for i in range(len(keys))) + ", sum(bad) AS bad"
+        having = " + ".join(f"k{i}" for i in range(len(keys)))
+        sql = f"""
+        SELECT ServiceName, sum(rows) AS rows, {sums}
+        FROM (
+{per_table}
+        )
+        GROUP BY ServiceName
+        HAVING {having} > 0
+        ORDER BY {having} DESC LIMIT {int(limit)} FORMAT TSV
+        """
+        out: list[dict] = []
+        try:
+            for line in (await self._query(sql)).splitlines():
+                if not line.strip():
+                    continue
+                parts = line.split("\t")
+                if len(parts) != 3 + len(keys):
+                    continue
+                missing = {k: int(v) for k, v in zip(keys, parts[2:-1]) if int(v) > 0}
+                out.append({
+                    "service": parts[0],
+                    "rows": int(parts[1]),
+                    "violating": int(parts[-1]),
+                    "missing": missing,
+                    "total_missing": sum(missing.values()),
+                })
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("contract violations unavailable: %s", exc)
+        return out
+
+    async def volume_band(self, minutes: int = 60, limit: int = 8) -> list[dict]:
+        """Per producer: the volume distribution over the window, and the latest bucket.
+
+        Returns the raw statistics, not a verdict — the band and the threshold are computed
+        in one place (`pipeline._volume_state`) so the drawn band and the alerting rule are
+        literally the same numbers. Metaplane shipped a version where they differed and
+        publicly called fixing it a "simplification"; there is no reason to repeat it.
+
+        Three deliberate choices, all cheap because `ServiceName, TimestampDate,
+        TimestampTime` is the sorting key, so the window filter is index-accelerated
+        (measured 0.135s):
+
+        * **The current bucket is excluded.** It is partial, and comparing a half-filled
+          bucket against a band built from full ones alarms on every tick.
+        * **`estate`** is the number of buckets in which *anything at all* landed. A
+          producer whose `seen` is below it was silent while the pipeline was not — which
+          is the one signal a tool that looks at tables at rest cannot produce: it sees a
+          stale table, not a write that failed to happen.
+        * **Both scale estimates are returned.** MAD is the robust one and the reason to
+          prefer this over a plain z-score, but a perfectly regular producer has MAD = 0 and
+          a band of zero width, where every tick is infinitely anomalous. The caller falls
+          back to stddev, and declares the series unmonitorable when both collapse.
+        """
+        win = int(minutes)
+        sql = f"""
+        WITH b AS (
+            SELECT ServiceName AS svc, toStartOfMinute(Timestamp) AS t, count() AS n
+            FROM {self._db}.otel_logs
+            WHERE Timestamp >= now() - INTERVAL {win} MINUTE
+              AND Timestamp < toStartOfMinute(now())
+            GROUP BY svc, t
+        ),
+        est AS (SELECT count(DISTINCT t) AS estate FROM b),
+        m AS (SELECT svc, quantileExact(0.5)(n) AS med, stddevPop(n) AS sd FROM b GROUP BY svc)
+        SELECT b.svc AS svc, m.med AS med,
+               quantileExact(0.5)(abs(b.n - m.med)) AS mad, any(m.sd) AS sd,
+               count() AS seen, any(est.estate) AS estate,
+               argMax(b.n, b.t) AS latest, toUnixTimestamp(max(b.t)) AS latest_t,
+               arraySort(x -> x.1, groupArray((toUnixTimestamp(b.t), b.n))) AS series
+        FROM b INNER JOIN m ON b.svc = m.svc CROSS JOIN est
+        GROUP BY b.svc, m.med
+        ORDER BY m.med DESC LIMIT {int(limit)} FORMAT JSONEachRow
+        """
+        out: list[dict] = []
+        try:
+            for line in (await self._query(sql)).splitlines():
+                if not line.strip():
+                    continue
+                r = json.loads(line)
+                out.append({
+                    "service": r["svc"],
+                    "median": float(r["med"]),
+                    "mad": float(r["mad"]),
+                    "sd": float(r["sd"]),
+                    "seen": int(r["seen"]),
+                    "estate": int(r["estate"]),
+                    "latest": int(r["latest"]),
+                    "latest_t": int(r["latest_t"]),
+                    "series": [[int(t), int(n)] for t, n in r["series"]],
+                })
+        except (httpx.HTTPError, ValueError, KeyError) as exc:
+            log.warning("volume band unavailable: %s", exc)
         return out
 
     async def scenario(self) -> str:

--- a/services/flow-ui/src/flow_ui/clickhouse.py
+++ b/services/flow-ui/src/flow_ui/clickhouse.py
@@ -303,6 +303,44 @@ class ClickHouse:
             log.warning("volume band unavailable: %s", exc)
         return out
 
+    async def call_edges(self, minutes: int = 15, limit: int = 24) -> list[dict]:
+        """The call graph as it was actually traced: `A -> B` with span counts and errors.
+
+        This is the only per-edge measurement that exists anywhere in the pipeline. Neither
+        the collector nor bronze counts anything per edge; what makes it possible is that a
+        child span carries its parent, so parent and child rows join and the two
+        `ServiceName`s are the edge.
+
+        **The join needs `TraceId` as well as `ParentSpanId = SpanId`.** The generator seeds
+        a deterministic RNG, so a fixed `--seed` repeats span ids across runs and the id
+        alone joined a child from one run onto a parent from another — which invented eight
+        edges the declared topology does not contain. `TraceId` removes all but a residue.
+
+        Cheap because both sides are narrowed by the same time window first (measured 0.53s
+        over a 15-minute window), but it is a self-join and belongs on the slow lane.
+        """
+        sql = f"""
+        SELECT p.ServiceName AS src, c.ServiceName AS dst,
+               count() AS spans, countIf(c.StatusCode = 'Error') AS errors
+        FROM {self._db}.otel_traces AS c
+        INNER JOIN {self._db}.otel_traces AS p
+          ON c.ParentSpanId = p.SpanId AND c.TraceId = p.TraceId
+        WHERE c.Timestamp > now() - INTERVAL {int(minutes)} MINUTE AND c.ParentSpanId != ''
+        GROUP BY src, dst HAVING src != dst
+        ORDER BY spans DESC LIMIT {int(limit)} FORMAT TSV
+        """
+        out: list[dict] = []
+        try:
+            for line in (await self._query(sql)).splitlines():
+                if not line.strip():
+                    continue
+                src, dst, spans, errors = line.split("\t")
+                out.append({"src": src, "dst": dst,
+                            "spans": int(spans), "errors": int(errors)})
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("call edges unavailable: %s", exc)
+        return out
+
     async def scenario(self) -> str:
         """The most recent run's scenario, for the header.
 

--- a/services/flow-ui/src/flow_ui/clickhouse.py
+++ b/services/flow-ui/src/flow_ui/clickhouse.py
@@ -16,7 +16,6 @@ of the table. That gap widens with every row inserted.
 """
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 
@@ -90,6 +89,10 @@ class ClickHouse:
                 out[tbl] = int(n)
         except (httpx.HTTPError, ValueError) as exc:
             log.warning("bronze counts unavailable: %s", exc)
+            # `{}`, not a dict of zeros. Zeros are a claim — "the tables are empty" — and the
+            # caller stores whatever it gets as the previous reading, so on the recovering
+            # tick the whole table read as one second of growth.
+            return {}
         return out
 
     async def lineage(self, limit: int = 12) -> list[dict]:
@@ -311,19 +314,29 @@ class ClickHouse:
         child span carries its parent, so parent and child rows join and the two
         `ServiceName`s are the edge.
 
-        **The join needs `TraceId` as well as `ParentSpanId = SpanId`.** The generator seeds
-        a deterministic RNG, so a fixed `--seed` repeats span ids across runs and the id
-        alone joined a child from one run onto a parent from another — which invented eight
-        edges the declared topology does not contain. `TraceId` removes all but a residue.
+        **The parent side must be deduplicated, and `TraceId` alone is not enough.** The
+        generator seeds a deterministic RNG, so a fixed `--seed` repeats *both* ids across
+        runs: joining on `SpanId` alone invented eight edges the topology does not contain,
+        and adding `TraceId` removed those while still fanning out — measured on a live
+        table, 16,154 children in the window produced 445,229 joined rows, a 27.6x
+        multiplication, because each child matched every historical copy of its parent. Edge
+        widths then encoded run history rather than traffic.
 
-        Cheap because both sides are narrowed by the same time window first (measured 0.53s
-        over a 15-minute window), but it is a self-join and belongs on the slow lane.
+        Collapsing parents to one row per `(TraceId, SpanId)` first makes the join
+        one-to-at-most-one, so a child is counted exactly once. Both sides are still bounded
+        by the same window, and it stays on the slow lane because it remains a self-join.
         """
         sql = f"""
-        SELECT p.ServiceName AS src, c.ServiceName AS dst,
+        WITH parents AS (
+            SELECT TraceId, SpanId, any(ServiceName) AS svc
+            FROM {self._db}.otel_traces
+            WHERE Timestamp > now() - INTERVAL {int(minutes)} MINUTE
+            GROUP BY TraceId, SpanId
+        )
+        SELECT p.svc AS src, c.ServiceName AS dst,
                count() AS spans, countIf(c.StatusCode = 'Error') AS errors
         FROM {self._db}.otel_traces AS c
-        INNER JOIN {self._db}.otel_traces AS p
+        INNER JOIN parents AS p
           ON c.ParentSpanId = p.SpanId AND c.TraceId = p.TraceId
         WHERE c.Timestamp > now() - INTERVAL {int(minutes)} MINUTE AND c.ParentSpanId != ''
         GROUP BY src, dst HAVING src != dst
@@ -360,5 +373,5 @@ class ClickHouse:
         try:
             await self._query("SELECT 1")
             return True
-        except (httpx.HTTPError, asyncio.TimeoutError):
+        except (TimeoutError, httpx.HTTPError):
             return False

--- a/services/flow-ui/src/flow_ui/config.py
+++ b/services/flow-ui/src/flow_ui/config.py
@@ -1,0 +1,40 @@
+"""Runtime configuration, read from the environment.
+
+Every default points at the root `docker-compose.yml` topology, so the app runs with no
+configuration at all next to a `make up` pipeline.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Settings:
+    #: The collector's Prometheus endpoint. The browser never talks to this — it has no
+    #: CORS headers (see `collector-rust/src/metrics_server.rs`, which sets only
+    #: Content-Type), so a cross-origin fetch from the page would be blocked. This
+    #: service is the only thing that reads it.
+    collector_metrics_url: str = os.getenv(
+        "COLLECTOR_METRICS_URL", "http://localhost:9090/metrics"
+    )
+
+    #: ClickHouse HTTP. Queries are POSTed with the SQL as the raw body — passing it as a
+    #: url-encoded `query=` parameter makes ClickHouse parse the literal string `query=`
+    #: as the statement and fail with a syntax error.
+    clickhouse_url: str = os.getenv("CLICKHOUSE_URL", "http://localhost:8123")
+    clickhouse_database: str = os.getenv("CLICKHOUSE_DATABASE", "bronze")
+
+    #: Poll cadence. 1s matches the collector's own flush cadence in stream mode
+    #: (measured: 1.03 flushes/s), so one tick carries roughly one flush event.
+    poll_interval_s: float = float(os.getenv("FLOW_UI_POLL_INTERVAL", "1.0"))
+
+    #: The service/table breakdown is a GROUP BY over the whole table, so it runs on a
+    #: slower cadence than the counters.
+    lineage_interval_s: float = float(os.getenv("FLOW_UI_LINEAGE_INTERVAL", "5.0"))
+
+    #: Samples kept for mode detection and the sparklines.
+    history: int = int(os.getenv("FLOW_UI_HISTORY", "60"))
+
+
+settings = Settings()

--- a/services/flow-ui/src/flow_ui/config.py
+++ b/services/flow-ui/src/flow_ui/config.py
@@ -32,6 +32,15 @@ class Settings:
     #: The service/table breakdown is a GROUP BY over the whole table, so it runs on a
     #: slower cadence than the counters.
     lineage_interval_s: float = float(os.getenv("FLOW_UI_LINEAGE_INTERVAL", "5.0"))
+    #: Contract health gets a slower lane of its own. It probes an unindexed Map across
+    #: every live table — measured 1.26s over ~6M rows — so at the 5s lineage cadence it
+    #: would hold ClickHouse a quarter of the time, and the cost grows with bronze.
+    contract_interval_s: float = float(os.getenv("FLOW_UI_CONTRACT_INTERVAL", "30.0"))
+    #: Training window for the volume band, in minutes. Elementary's documented baseline is
+    #: a 1-day bucket over 14 days; the bucket here is a minute because that is this
+    #: pipeline's cadence, and a day-wide bucket over a stream measured in minutes would
+    #: hold exactly one point. Same method, scaled to the data.
+    volume_window_min: int = int(os.getenv("FLOW_UI_VOLUME_WINDOW_MIN", "60"))
 
     #: Samples kept for mode detection and the sparklines.
     history: int = int(os.getenv("FLOW_UI_HISTORY", "60"))

--- a/services/flow-ui/src/flow_ui/main.py
+++ b/services/flow-ui/src/flow_ui/main.py
@@ -30,10 +30,10 @@ from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from flow_ui import topology
 from flow_ui.clickhouse import EMPTY_BY_CONTRACT
 from flow_ui.config import settings
 from flow_ui.pipeline import Poller
-from flow_ui import topology
 
 logging.basicConfig(
     level=logging.INFO,
@@ -101,6 +101,9 @@ def index(request: Request):
         "ingest_total": sum(snap.ingest_rate.values()),
         "reject_total": sum(snap.reject_rate.values()),
         "poll_ms": int(settings.poll_interval_s * 1000),
+        # Server-rendered like every other figure, so the policy is right with JavaScript
+        # disabled too — and it is read from the collector's config, never assumed.
+        "contract": topology.CONTRACT,
     })
 
 
@@ -122,7 +125,7 @@ async def stream(request: Request):
                     break
                 try:
                     snap = await asyncio.wait_for(queue.get(), timeout=15.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     yield ": keepalive\n\n"   # keeps proxies from reaping an idle stream
                     continue
                 yield f"data: {json.dumps(snap.as_dict())}\n\n"

--- a/services/flow-ui/src/flow_ui/main.py
+++ b/services/flow-ui/src/flow_ui/main.py
@@ -1,0 +1,176 @@
+"""Sentinel flow UI — the pipeline watching itself.
+
+Server-rendered HTML with an SSE channel on top, in the shape this monorepo's other
+Python service already uses. Two things about the layering are deliberate:
+
+**The browser never talks to the collector or to ClickHouse.** Not a style preference — a
+constraint. The collector's `/metrics` server sets exactly one response header
+(`Content-Type`; see `collector-rust/src/metrics_server.rs`) and ClickHouse has no CORS
+header configured in `infra/`, so a cross-origin fetch from the page is blocked by the
+browser with no visible error. This service is the only reader; it also means the page
+works unchanged whatever host those two move to.
+
+**The figures are in the HTML before any script runs.** The animation is an illustration
+of numbers the page already printed — a blocked or slow script costs the motion, never the
+reading. Borrowed from a sibling project's design rule: charts illustrate, they never
+carry.
+
+Run:  ``uv run uvicorn flow_ui.main:app --host 0.0.0.0 --port 8080``
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from flow_ui.clickhouse import EMPTY_BY_CONTRACT
+from flow_ui.config import settings
+from flow_ui.pipeline import Poller
+from flow_ui import topology
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='{"time": "%(asctime)s", "level": "%(levelname)s", "msg": "%(message)s"}',
+)
+# httpx logs one INFO line per request; at one poll a second against two sources that is
+# 172,800 lines a day saying the pipeline is fine.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+log = logging.getLogger("flow_ui")
+
+BASE = Path(__file__).parent
+templates = Jinja2Templates(directory=str(BASE / "templates"))
+
+poller = Poller(settings)
+
+
+@contextlib.asynccontextmanager
+async def lifespan(_: FastAPI):
+    await poller.start()
+    try:
+        yield
+    finally:
+        await poller.stop()
+
+
+app = FastAPI(title="Sentinel flow", docs_url=None, redoc_url=None, lifespan=lifespan)
+app.mount("/static", StaticFiles(directory=str(BASE / "static")), name="static")
+
+
+def asset_v() -> str:
+    """Cache-buster keyed to the NEWEST asset's mtime — no build step, no restart.
+
+    Both files, not just the stylesheet: keyed to `app.css` alone, a change that touched
+    only `app.js` left the script URL identical and the browser kept the old one.
+    """
+    newest = 0.0
+    for name in ("app.css", "app.js"):
+        try:
+            newest = max(newest, (BASE / "static" / name).stat().st_mtime)
+        except OSError:
+            continue
+    return str(int(newest))
+
+
+def fmt(n: float) -> str:
+    """Compact figures: a rate of 18,334/s has to fit a tile."""
+    n = float(n)
+    for unit, div in (("M", 1e6), ("k", 1e3)):
+        if abs(n) >= div:
+            return f"{n / div:.1f}{unit}"
+    return f"{n:.0f}" if abs(n) >= 10 or n == int(n) else f"{n:.1f}"
+
+
+templates.env.filters["fmt"] = fmt
+templates.env.globals["asset_v"] = asset_v
+templates.env.globals["EMPTY_BY_CONTRACT"] = EMPTY_BY_CONTRACT
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request):
+    """The page, with the current snapshot already rendered into it."""
+    snap = poller.latest
+    return templates.TemplateResponse(request, "index.html", {
+        "s": snap,
+        "ingest_total": sum(snap.ingest_rate.values()),
+        "reject_total": sum(snap.reject_rate.values()),
+        "poll_ms": int(settings.poll_interval_s * 1000),
+    })
+
+
+@app.get("/stream")
+async def stream(request: Request):
+    """Server-sent events: one snapshot per poll tick.
+
+    SSE rather than a WebSocket because the traffic is one-way and SSE reconnects on its
+    own — a dropped connection costs a gap in the animation, not a dead page.
+    """
+    async def events():
+        queue = poller.broadcaster.subscribe()
+        try:
+            # Send the current state immediately so a page that connects between ticks
+            # is not blank until the next one.
+            yield f"data: {json.dumps(poller.latest.as_dict())}\n\n"
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    snap = await asyncio.wait_for(queue.get(), timeout=15.0)
+                except asyncio.TimeoutError:
+                    yield ": keepalive\n\n"   # keeps proxies from reaping an idle stream
+                    continue
+                yield f"data: {json.dumps(snap.as_dict())}\n\n"
+        finally:
+            poller.broadcaster.unsubscribe(queue)
+
+    return StreamingResponse(events(), media_type="text/event-stream", headers={
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",           # nginx would otherwise buffer the stream
+    })
+
+
+@app.get("/api/snapshot")
+def snapshot() -> dict:
+    """The latest tick as JSON — for debugging, and for anything that is not this page."""
+    return poller.latest.as_dict()
+
+
+@app.get("/api/graph")
+def graph() -> dict:
+    """The static half of the picture: the producer's declared topology and what each
+    bronze table holds. Cheap and unchanging, so the page fetches it once at load and the
+    SSE stream carries only the numbers that move."""
+    return {
+        "topology": topology.service_graph(),
+        "tables": topology.TABLE_DOCS,
+        "empty_by_contract": topology.EMPTY_BY_CONTRACT,
+        "derived": topology.DERIVED,
+        "contract": topology.CONTRACT,
+    }
+
+
+@app.get("/api/history")
+def history() -> dict:
+    """The rolling window behind the health sparklines.
+
+    Served separately from the SSE snapshot because the window is the same few hundred
+    points on every tick — pushing it once a second would send the same data 300 times.
+    The page fetches it once and appends each incoming snapshot itself.
+    """
+    return {"points": list(poller.history), "ceiling_ms": Poller.LATENCY_CEILING_MS}
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {
+        "ok": True,
+        "collector": poller.latest.collector_up,
+        "clickhouse": poller.latest.clickhouse_up,
+        "subscribers": poller.broadcaster.subscribers,
+    }

--- a/services/flow-ui/src/flow_ui/pipeline.py
+++ b/services/flow-ui/src/flow_ui/pipeline.py
@@ -1,0 +1,367 @@
+"""The poller: one background task that turns two data sources into a stream of snapshots.
+
+The browser never polls anything. This task scrapes the collector and ClickHouse on a
+fixed cadence, derives per-second rates, and pushes a snapshot to every open SSE
+subscriber. One poller regardless of how many people have the page open.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field, asdict
+
+import httpx
+
+from flow_ui import prom
+from flow_ui.clickhouse import ClickHouse, EMPTY_BY_CONTRACT, LIVE_TABLES
+from flow_ui.config import Settings
+
+log = logging.getLogger("flow_ui.pipeline")
+
+M_INGESTED = "sentinel_signals_ingested_total"
+M_ACCEPTED = "sentinel_signals_accepted_total"
+M_REJECTED = "sentinel_signals_rejected_total"
+M_STORAGE = "sentinel_storage_signals_total"
+M_FLUSH = "sentinel_batch_flush_total"
+M_FLUSH_COUNT = "sentinel_batch_flush_size_count"
+M_FLUSH_SUM = "sentinel_batch_flush_size_sum"
+M_ERRORS = "sentinel_export_errors_total"
+M_LAT_COUNT = "sentinel_export_latency_seconds_count"
+M_LAT_SUM = "sentinel_export_latency_seconds_sum"
+
+#: Flush cadence that separates the two delivery shapes. Measured on this pipeline:
+#: `--mode stream` settles at 1.03 flushes/s carrying 500–1000 records each, while
+#: `--mode backfill` runs at 6.6 flushes/s (min 4, max 8) carrying ~2534. Three sits in
+#: the empty gap between the two distributions rather than at either edge.
+BATCH_FLUSH_RATE = 3.0
+
+#: A batch that big never appears in stream mode — it is the second, independent tell, so
+#: a burst is still read as batch even if a poll lands mid-cadence.
+BATCH_RECORDS_PER_FLUSH = 1500.0
+
+MODE_IDLE, MODE_STREAM, MODE_BATCH = "idle", "stream", "batch"
+
+
+@dataclass
+class Snapshot:
+    """One tick. Everything the page needs, already reduced to numbers it can draw."""
+
+    ts: float = 0.0
+    mode: str = MODE_IDLE
+    collector_up: bool = False
+    clickhouse_up: bool = False
+
+    #: Per-second rates at the gRPC receive boundary, by signal type. The three types are
+    #: distinguishable *only* here — see `flushes` below.
+    ingest_rate: dict[str, float] = field(default_factory=dict)
+    accept_rate: dict[str, float] = field(default_factory=dict)
+    reject_rate: dict[str, float] = field(default_factory=dict)
+
+    #: Rejections split by *reason*, which the per-signal view loses. The collector emits
+    #: two and they are different problems with different destinations:
+    #:   `contract`     — validation failed. Under `warn` the signal is counted and
+    #:                    **exported anyway**, so it still reaches bronze. Only `strict`
+    #:                    discards it.
+    #:   `backpressure` — the buffer was full, so the whole batch was refused and the
+    #:                    producer told (`resource_exhausted`). It can retry; nothing is
+    #:                    lost yet.
+    reject_by_reason: dict[str, float] = field(default_factory=dict)
+
+    #: The cross-product the two views above each throw away: ``{reason: {signal: rate}}``.
+    #: `signals_rejected_total` is labelled with BOTH `signal` and `reason` at the
+    #: increment site, so *which* signal type failed *which* way is measured, not guessed
+    #: — and it is the only place upstream of the buffer where that stays true. The page
+    #: draws the falling dot in that type's colour off the back of this.
+    reject_matrix: dict[str, dict[str, float]] = field(default_factory=dict)
+
+    #: From the buffer onward the collector labels everything `signal="all"`: the
+    #: `BufferedExporter` enqueues every signal variant into one combined channel and
+    #: flushes a mixed batch, so no per-type flush boundary exists to label. This is
+    #: documented as deliberate in `collector-rust/src/metrics.rs`, not a gap to fill —
+    #: which is why the page draws three lanes into the buffer and one lane out of it.
+    flush_rate: float = 0.0
+    records_per_flush: float = 0.0
+
+    #: Mean, and the tail the mean hides. Measured on this pipeline: a 24.5 ms average
+    #: sits over a 79 ms p99 — three times higher — so a single number cannot answer
+    #: whether export is healthy.
+    export_latency_ms: float = 0.0
+    export_latency_p50: float = 0.0
+    export_latency_p90: float = 0.0
+    export_latency_p99: float = 0.0
+
+    #: A verdict with the evidence behind it, decided in one place so the rule is testable
+    #: rather than scattered through the page.
+    health: str = "idle"
+    health_note: str = "no traffic"
+    persist_rate: float = 0.0
+    drop_rate: float = 0.0
+
+    #: Cumulative, for the ledger lines.
+    totals: dict[str, float] = field(default_factory=dict)
+    export_errors: float = 0.0
+
+    #: Bronze — row counts and their per-second growth (deltas of `count()`).
+    bronze: dict[str, int] = field(default_factory=dict)
+    bronze_rate: dict[str, float] = field(default_factory=dict)
+    bronze_empty: list[str] = field(default_factory=lambda: list(EMPTY_BY_CONTRACT))
+    lineage: list[dict] = field(default_factory=list)
+
+    #: Which named metrics each service emits, keyed by destination table. This is the
+    #: only per-service distinction that exists downstream: bronze routes by data-point
+    #: type, never by producer, so every service reaches every table. What differs is the
+    #: metric mix — and that is what makes one service's gauge:sum split 3:1 and another's
+    #: 1:2. Refreshed on the slow lane; the inventory is effectively static.
+    metrics_by_service: dict = field(default_factory=dict)
+    scenario: str = "—"
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+class Broadcaster:
+    """Fan one snapshot out to every open SSE connection.
+
+    Each subscriber gets its own bounded queue: a slow reader drops its own frames rather
+    than stalling the poller or any other viewer.
+    """
+
+    def __init__(self) -> None:
+        self._subs: set[asyncio.Queue] = set()
+
+    def subscribe(self) -> asyncio.Queue:
+        q: asyncio.Queue = asyncio.Queue(maxsize=2)
+        self._subs.add(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue) -> None:
+        self._subs.discard(q)
+
+    def publish(self, snap: Snapshot) -> None:
+        for q in list(self._subs):
+            if q.full():
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    q.get_nowait()
+            with contextlib.suppress(asyncio.QueueFull):
+                q.put_nowait(snap)
+
+    @property
+    def subscribers(self) -> int:
+        return len(self._subs)
+
+
+class Poller:
+    """Scrapes both sources on a cadence and publishes snapshots."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._s = settings
+        self._ch = ClickHouse(settings.clickhouse_url, settings.clickhouse_database)
+        self._http = httpx.AsyncClient(timeout=3.0)
+        self.broadcaster = Broadcaster()
+        self.latest = Snapshot()
+        self._prev: prom.Sample | None = None
+        self._prev_t: float = 0.0
+        self._prev_bronze: dict[str, int] = {}
+        self._prev_bronze_t: float = 0.0
+        self._flush_rates: deque[float] = deque(maxlen=5)
+        #: A rolling window of what each tick looked like. Kept on the server so a page
+        #: opened now still gets the last few minutes instead of an empty chart, and so
+        #: two viewers see the same history.
+        self.history: deque[dict] = deque(maxlen=settings.history)
+        self._errors_seen: float = 0.0
+        self._policy: str = "warn"
+        self._task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        await self._ch.aclose()
+        await self._http.aclose()
+
+    async def _scrape(self) -> prom.Sample | None:
+        try:
+            resp = await self._http.get(self._s.collector_metrics_url)
+            resp.raise_for_status()
+            return prom.parse(resp.text)
+        except httpx.HTTPError as exc:
+            log.debug("collector scrape failed: %s", exc)
+            return None
+
+    def _detect_mode(self, flush_rate: float, per_flush: float, ingest: float) -> str:
+        """Which delivery shape the pipeline is running, inferred from the buffer.
+
+        Nobody tells this app whether the generator was started in stream or backfill
+        mode — the flush cadence is the tell, and it is unambiguous because the two modes
+        differ by ~6x in rate and ~3x in batch size at the same time.
+        """
+        if ingest <= 0 and flush_rate <= 0:
+            return MODE_IDLE
+        smoothed = max(self._flush_rates) if self._flush_rates else flush_rate
+        if smoothed >= BATCH_FLUSH_RATE or per_flush >= BATCH_RECORDS_PER_FLUSH:
+            return MODE_BATCH
+        return MODE_STREAM
+
+    async def _tick(self) -> None:
+        now = time.monotonic()
+        sample = await self._scrape()
+        snap = Snapshot(ts=time.time(), collector_up=sample is not None)
+
+        if sample is not None and self._prev is not None:
+            dt = now - self._prev_t
+            prev = self._prev
+
+            def by_signal(metric: str) -> dict[str, float]:
+                cur = sample.sum_over(metric, "signal")
+                old = prev.sum_over(metric, "signal")
+                # Union of both scrapes' keys: a family that only just appeared has no
+                # previous entry, and one that vanished should still report zero.
+                return {
+                    k: round(prom.rate(cur.get(k, 0.0), old.get(k, 0.0), dt), 1)
+                    for k in set(cur) | set(old)
+                }
+
+            snap.ingest_rate = by_signal(M_INGESTED)
+            snap.accept_rate = by_signal(M_ACCEPTED)
+            snap.reject_rate = by_signal(M_REJECTED)
+            cur_r, old_r = sample.sum_over(M_REJECTED, "reason"), prev.sum_over(M_REJECTED, "reason")
+            snap.reject_by_reason = {
+                k: round(prom.rate(cur_r.get(k, 0.0), old_r.get(k, 0.0), dt), 2)
+                for k in set(cur_r) | set(old_r)
+            }
+            cur_m = sample.sum_over_pair(M_REJECTED, "reason", "signal")
+            old_m = prev.sum_over_pair(M_REJECTED, "reason", "signal")
+            snap.reject_matrix = {
+                reason: {
+                    sig: round(prom.rate(cur_m.get(reason, {}).get(sig, 0.0),
+                                         old_m.get(reason, {}).get(sig, 0.0), dt), 2)
+                    for sig in set(cur_m.get(reason, {})) | set(old_m.get(reason, {}))
+                }
+                for reason in set(cur_m) | set(old_m)
+            }
+
+            fc, fc0 = sample.value(M_FLUSH_COUNT), prev.value(M_FLUSH_COUNT)
+            fs, fs0 = sample.value(M_FLUSH_SUM), prev.value(M_FLUSH_SUM)
+            snap.flush_rate = round(prom.rate(fc, fc0, dt), 2)
+            d_flush, d_recs = fc - fc0, fs - fs0
+            snap.records_per_flush = round(d_recs / d_flush, 0) if d_flush > 0 else 0.0
+
+            lc, lc0 = sample.value(M_LAT_COUNT), prev.value(M_LAT_COUNT)
+            ls, ls0 = sample.value(M_LAT_SUM), prev.value(M_LAT_SUM)
+            snap.export_latency_ms = round((ls - ls0) / (lc - lc0) * 1000, 1) if lc > lc0 else 0.0
+            for q, attr in ((0.5, "p50"), (0.9, "p90"), (0.99, "p99")):
+                setattr(snap, f"export_latency_{attr}",
+                        round(prom.quantile(sample, "sentinel_export_latency_seconds", q) * 1000, 1))
+
+            storage_now = sample.sum_over(M_STORAGE, "outcome")
+            storage_old = prev.sum_over(M_STORAGE, "outcome")
+            snap.persist_rate = round(prom.rate(
+                storage_now.get("persisted", 0.0), storage_old.get("persisted", 0.0), dt), 1)
+            snap.drop_rate = round(prom.rate(
+                storage_now.get("dropped", 0.0), storage_old.get("dropped", 0.0), dt), 1)
+
+            self._flush_rates.append(snap.flush_rate)
+            snap.mode = self._detect_mode(
+                snap.flush_rate, snap.records_per_flush, sum(snap.ingest_rate.values()))
+
+        if sample is not None:
+            snap.totals = {
+                "ingested": sample.value(M_INGESTED),
+                "accepted": sample.value(M_ACCEPTED),
+                "rejected": sample.value(M_REJECTED),
+                "flushes": sample.value(M_FLUSH_COUNT),
+                "records": sample.value(M_FLUSH_SUM),
+                "persisted": sample.sum_over(M_STORAGE, "outcome").get("persisted", 0.0),
+            }
+            snap.export_errors = sample.value(M_ERRORS)
+            self._prev, self._prev_t = sample, now
+
+        # Bronze counts every tick (metadata-only, ~4ms); lineage on the slow cadence.
+        counts = await self._ch.counts()
+        snap.clickhouse_up = any(counts.values()) or await self._ch.ping()
+        snap.bronze = counts
+        if self._prev_bronze:
+            dtb = now - self._prev_bronze_t
+            snap.bronze_rate = {
+                t: round(prom.rate(counts.get(t, 0), self._prev_bronze.get(t, 0), dtb), 1)
+                for t in LIVE_TABLES
+            }
+        self._prev_bronze, self._prev_bronze_t = counts, now
+
+        snap.health, snap.health_note = self._verdict(snap)
+        self.history.append({
+            "t": round(snap.ts, 1),
+            "in": round(sum(snap.ingest_rate.values()), 1),
+            "fl": snap.flush_rate,
+            "lat": snap.export_latency_ms,
+            "st": snap.persist_rate,
+            "rj": round(sum(snap.reject_rate.values()), 2),
+            "dr": snap.drop_rate,
+            "m": snap.mode,
+        })
+        snap.lineage = self.latest.lineage
+        snap.metrics_by_service = self.latest.metrics_by_service
+        snap.scenario = self.latest.scenario
+        self.latest = snap
+        self.broadcaster.publish(snap)
+
+    #: The measured ceiling for this pipeline: every flush attempt landed at or under
+    #: 80 ms in the reference run, so a p99 above it means the tail has changed shape.
+    LATENCY_CEILING_MS = 80.0
+
+    def _verdict(self, snap: Snapshot) -> tuple[str, str]:
+        """One state and the reason for it. Colour is never the only carrier — the note is
+        the sentence a reader acts on."""
+        if not snap.collector_up:
+            return "fail", "collector unreachable"
+        if not snap.clickhouse_up:
+            return "fail", "clickhouse unreachable"
+        lost = snap.export_errors - self._errors_seen
+        self._errors_seen = snap.export_errors
+        if snap.drop_rate > 0 or lost > 0:
+            return "fail", f"{snap.drop_rate:.2g}/s dropped · {snap.export_errors:.0f} batches lost"
+        back = snap.reject_by_reason.get("backpressure", 0.0)
+        if back > 0:
+            # Not data loss: the producer was refused and can retry. But it means the
+            # collector could not keep up, which is a different alarm from a bad payload.
+            return "warn", f"{back:.2g}/s refused — buffer saturated, producer told to retry"
+        contract = snap.reject_by_reason.get("contract", 0.0)
+        if contract > 0:
+            policy = "exported anyway" if self._policy == "warn" else "discarded"
+            return "warn", f"{contract:.2g}/s failing the contract · {policy}"
+        if snap.export_latency_p99 > self.LATENCY_CEILING_MS:
+            return "warn", f"export p99 {snap.export_latency_p99:.0f} ms over {self.LATENCY_CEILING_MS:.0f} ms"
+        if sum(snap.ingest_rate.values()) <= 0:
+            return "idle", "no traffic"
+        return "ok", "flowing, nothing rejected or lost"
+
+    async def _refresh_lineage(self) -> None:
+        while True:
+            try:
+                lineage = await self._ch.lineage()
+                scenario = await self._ch.scenario()
+                inventory = await self._ch.metric_inventory()
+                self.latest.lineage = lineage
+                self.latest.scenario = scenario
+                self.latest.metrics_by_service = inventory
+            except Exception as exc:                      # noqa: BLE001 — never kill the loop
+                log.debug("lineage refresh failed: %s", exc)
+            await asyncio.sleep(self._s.lineage_interval_s)
+
+    async def _run(self) -> None:
+        asyncio.create_task(self._refresh_lineage())
+        while True:
+            try:
+                await self._tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:                      # noqa: BLE001
+                log.warning("poll tick failed: %s", exc)
+            await asyncio.sleep(self._s.poll_interval_s)

--- a/services/flow-ui/src/flow_ui/pipeline.py
+++ b/services/flow-ui/src/flow_ui/pipeline.py
@@ -206,6 +206,12 @@ class Snapshot:
     metrics_by_service: dict = field(default_factory=dict)
     scenario: str = "—"
 
+    #: The call graph as traced: `{src, dst, spans, errors}`. The only per-edge measurement
+    #: in the pipeline — it exists because a child span carries its parent, so the two rows
+    #: join and the two `ServiceName`s are the edge. Compared against the *declared* topology
+    #: in the UI, because the two disagreeing is itself the finding.
+    call_edges: list[dict] = field(default_factory=list)
+
     #: Volume watcher, per producer: the band and the verdict it was judged against.
     volume: list[dict] = field(default_factory=list)
 
@@ -415,6 +421,7 @@ class Poller:
         snap.scenario = self.latest.scenario
         snap.contract_violations = self.latest.contract_violations
         snap.volume = self.latest.volume
+        snap.call_edges = self.latest.call_edges
         self.latest = snap
         self.broadcaster.publish(snap)
 
@@ -455,10 +462,12 @@ class Poller:
                 scenario = await self._ch.scenario()
                 inventory = await self._ch.metric_inventory()
                 band = await self._ch.volume_band(self._s.volume_window_min)
+                edges = await self._ch.call_edges()
                 self.latest.lineage = lineage
                 self.latest.scenario = scenario
                 self.latest.metrics_by_service = inventory
                 self.latest.volume = [volume_state(r) for r in band]
+                self.latest.call_edges = edges
             except Exception as exc:                      # noqa: BLE001 — never kill the loop
                 log.debug("lineage refresh failed: %s", exc)
             await asyncio.sleep(self._s.lineage_interval_s)

--- a/services/flow-ui/src/flow_ui/pipeline.py
+++ b/services/flow-ui/src/flow_ui/pipeline.py
@@ -44,6 +44,94 @@ BATCH_RECORDS_PER_FLUSH = 1500.0
 
 MODE_IDLE, MODE_STREAM, MODE_BATCH = "idle", "stream", "batch"
 
+#: Volume watcher. The threshold is Elementary's documented one — plain z-score at 3.0 — and
+#: the *estimator* is what changes: median and MAD rather than mean and stddev, so a single
+#: bad bucket does not widen the band that is supposed to catch it. Dual severity, because
+#: one number cannot both page someone and merely be noted.
+Z_WARN, Z_ERROR = 3.0, 5.0
+
+#: Scales MAD into a stddev-equivalent for normally distributed data, so `Z_WARN` keeps its
+#: usual meaning instead of being a magic number tied to a different estimator.
+MAD_TO_SIGMA = 1.4826
+
+#: Below this many buckets there is no distribution to speak of, and a band drawn from three
+#: points is theatre. Reported as unmonitored — Bigeye's grey — never as healthy.
+MIN_BUCKETS = 8
+
+#: A band that rejects more than this share of the window it was BUILT FROM is not describing
+#: the data; it is describing one mode of it. Measured here: a producer alternating between
+#: full minutes (2850 rows) and partial ones (600–1600) has a median on the dominant mode and
+#: a MAD of 50 against a true spread of 699, so the 3σ band excluded 14 of its own 31
+#: training buckets — and then alerted. Three-sigma on a series this estimator actually fits
+#: excludes a few percent; 15% means the model is wrong, not the data.
+MAX_OOB_SHARE = 0.15
+
+
+def _oob_share(series: list, med: float, scale: float) -> float:
+    """Share of the training window that falls outside the band built from it."""
+    if not series:
+        return 0.0
+    lo, hi = med - Z_WARN * scale, med + Z_WARN * scale
+    return sum(1 for _, n in series if n < lo or n > hi) / len(series)
+
+
+def volume_state(row: dict) -> dict:
+    """One producer's volume verdict, and the band it was judged against.
+
+    **The band returned here is the threshold.** Metaplane shipped a version where the drawn
+    area and the alerting rule were computed separately, then publicly called reconciling
+    them a "simplification": *"if you see a value outside the green area, Metaplane sent an
+    alert."* Computing both in one place is how that stays true.
+
+    Four states, not two — the distinction most health widgets lose:
+
+    * `passing`     — inside the band.
+    * `warn`/`fail` — outside it, at 3σ and 5σ.
+    * `unmonitored` — too few buckets, or no dispersion to model at all. A perfectly regular
+      producer has MAD = 0 and a zero-width band in which every value is infinitely
+      anomalous; stddev is tried next, and if that is also flat the series is declared
+      unmodellable rather than alarmed on. Grey means *not observed*, never *fine*.
+
+    `absent` is a separate axis, not a band violation: buckets in which the estate received
+    something and this producer did not. A tool reading a table at rest sees a stale table;
+    only a pipeline-centric one can see the write that never happened.
+    """
+    med, mad, sd = row["median"], row["mad"], row["sd"]
+    seen, estate, latest = row["seen"], row["estate"], row["latest"]
+    series = row.get("series") or []
+    absent = max(0, estate - seen)
+    base = {**row, "absent": absent}
+    grey = {**base, "scale": 0.0, "estimator": "none", "lo": med, "hi": med, "z": 0.0,
+            "state": "unmonitored"}
+
+    if estate < MIN_BUCKETS:
+        return {**grey, "why": f"only {estate} buckets in the window"}
+
+    # A cascade with a validity test at each step, not a switch on `mad > 0`. The switch was
+    # a cliff: MAD crossing zero moved σ from 74 to 699 between two consecutive ticks and
+    # flipped every producer from passing to alerting on one new bucket. Which estimator to
+    # use is not a property of MAD being non-zero — it is whether the band it produces
+    # actually contains the window.
+    for name, scale in (("mad", mad * MAD_TO_SIGMA), ("stddev", sd)):
+        if scale <= 0:
+            continue
+        share = _oob_share(series, med, scale)
+        if share > MAX_OOB_SHARE:
+            continue
+        z = abs(latest - med) / scale
+        state = "fail" if z >= Z_ERROR else "warn" if z >= Z_WARN else "passing"
+        return {**base, "estimator": name, "scale": round(scale, 2), "state": state,
+                "z": round(z, 2), "oob": round(share, 3),
+                "lo": round(med - Z_WARN * scale, 1), "hi": round(med + Z_WARN * scale, 1),
+                "why": f"{z:.1f}σ from a median of {med:.0f}"}
+
+    if mad <= 0 and sd <= 0:
+        return {**grey, "why": "no dispersion to model"}
+    # Both estimators produced a band that rejects its own window. That is a multi-modal
+    # series — here, full minutes and partial ones — which no single band describes. Saying
+    # so is the honest output; alerting eight producers at once is not.
+    return {**grey, "why": "no band fits this window — the series is not single-mode"}
+
 
 @dataclass
 class Snapshot:
@@ -118,6 +206,16 @@ class Snapshot:
     metrics_by_service: dict = field(default_factory=dict)
     scenario: str = "—"
 
+    #: Volume watcher, per producer: the band and the verdict it was judged against.
+    volume: list[dict] = field(default_factory=list)
+
+    #: Contract health, per producer — the one thing the receive boundary cannot answer.
+    #: `signals_rejected_total` has `signal` and `reason` but no service label, so it says
+    #: how many violated and how, never *who*. Bronze can, because under `warn` a violating
+    #: signal is exported anyway and the evidence lands in the table. Slow lane; see
+    #: `Settings.contract_interval_s`.
+    contract_violations: list[dict] = field(default_factory=list)
+
     def as_dict(self) -> dict:
         return asdict(self)
 
@@ -171,6 +269,7 @@ class Poller:
         #: opened now still gets the last few minutes instead of an empty chart, and so
         #: two viewers see the same history.
         self.history: deque[dict] = deque(maxlen=settings.history)
+        self._signals = ("logs", "trace", "metrics")
         self._errors_seen: float = 0.0
         self._policy: str = "warn"
         self._task: asyncio.Task | None = None
@@ -303,12 +402,19 @@ class Poller:
             "lat": snap.export_latency_ms,
             "st": snap.persist_rate,
             "rj": round(sum(snap.reject_rate.values()), 2),
+            # Rejections split by reason AND signal, so the contract board can chart which
+            # type was failing which way over the window. The aggregate `rj` above cannot
+            # be decomposed after the fact.
+            "rc": [snap.reject_matrix.get("contract", {}).get(k, 0.0) for k in self._signals],
+            "rb": [snap.reject_matrix.get("backpressure", {}).get(k, 0.0) for k in self._signals],
             "dr": snap.drop_rate,
             "m": snap.mode,
         })
         snap.lineage = self.latest.lineage
         snap.metrics_by_service = self.latest.metrics_by_service
         snap.scenario = self.latest.scenario
+        snap.contract_violations = self.latest.contract_violations
+        snap.volume = self.latest.volume
         self.latest = snap
         self.broadcaster.publish(snap)
 
@@ -348,15 +454,28 @@ class Poller:
                 lineage = await self._ch.lineage()
                 scenario = await self._ch.scenario()
                 inventory = await self._ch.metric_inventory()
+                band = await self._ch.volume_band(self._s.volume_window_min)
                 self.latest.lineage = lineage
                 self.latest.scenario = scenario
                 self.latest.metrics_by_service = inventory
+                self.latest.volume = [volume_state(r) for r in band]
             except Exception as exc:                      # noqa: BLE001 — never kill the loop
                 log.debug("lineage refresh failed: %s", exc)
             await asyncio.sleep(self._s.lineage_interval_s)
 
+    async def _refresh_contract(self) -> None:
+        """Contract health on its own, slower lane — it scans an unindexed Map across every
+        live table, so it must not share the lineage cadence."""
+        while True:
+            try:
+                self.latest.contract_violations = await self._ch.contract_violations()
+            except Exception as exc:                      # noqa: BLE001 — never kill the loop
+                log.debug("contract refresh failed: %s", exc)
+            await asyncio.sleep(self._s.contract_interval_s)
+
     async def _run(self) -> None:
         asyncio.create_task(self._refresh_lineage())
+        asyncio.create_task(self._refresh_contract())
         while True:
             try:
                 await self._tick()

--- a/services/flow-ui/src/flow_ui/pipeline.py
+++ b/services/flow-ui/src/flow_ui/pipeline.py
@@ -11,12 +11,12 @@ import contextlib
 import logging
 import time
 from collections import deque
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 
 import httpx
 
-from flow_ui import prom
-from flow_ui.clickhouse import ClickHouse, EMPTY_BY_CONTRACT, LIVE_TABLES
+from flow_ui import prom, topology
+from flow_ui.clickhouse import EMPTY_BY_CONTRACT, LIVE_TABLES, ClickHouse
 from flow_ui.config import Settings
 
 log = logging.getLogger("flow_ui.pipeline")
@@ -276,14 +276,29 @@ class Poller:
         #: two viewers see the same history.
         self.history: deque[dict] = deque(maxlen=settings.history)
         self._signals = ("logs", "trace", "metrics")
-        self._errors_seen: float = 0.0
-        self._policy: str = "warn"
+        #: `None` until the first scrape, because the collector's `export_errors_total` is
+        #: cumulative over its whole life: treating 0 as the baseline made every batch it had
+        #: ever lost look like a fresh loss, and the page opened on FAIL.
+        self._errors_seen: float | None = None
+        #: Read from the collector's own config rather than assumed. It was hard-coded to
+        #: `warn`, so under `strict` the health note said contract failures were "exported
+        #: anyway" when they had been discarded at the boundary.
+        self._policy: str = topology.grpc_validation()
         self._task: asyncio.Task | None = None
+        #: Retained so `stop()` can cancel them. Unheld, they outlived the poller and went on
+        #: querying an httpx client that had already been closed.
+        self._slow: list[asyncio.Task] = []
 
     async def start(self) -> None:
         self._task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
+        for task in self._slow:
+            task.cancel()
+        for task in self._slow:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        self._slow.clear()
         if self._task:
             self._task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -391,14 +406,15 @@ class Poller:
         # Bronze counts every tick (metadata-only, ~4ms); lineage on the slow cadence.
         counts = await self._ch.counts()
         snap.clickhouse_up = any(counts.values()) or await self._ch.ping()
-        snap.bronze = counts
-        if self._prev_bronze:
+        snap.bronze = counts or dict.fromkeys(LIVE_TABLES, 0)
+        if self._prev_bronze and counts:
             dtb = now - self._prev_bronze_t
             snap.bronze_rate = {
                 t: round(prom.rate(counts.get(t, 0), self._prev_bronze.get(t, 0), dtb), 1)
                 for t in LIVE_TABLES
             }
-        self._prev_bronze, self._prev_bronze_t = counts, now
+        if counts:
+            self._prev_bronze, self._prev_bronze_t = counts, now
 
         snap.health, snap.health_note = self._verdict(snap)
         self.history.append({
@@ -436,7 +452,8 @@ class Poller:
             return "fail", "collector unreachable"
         if not snap.clickhouse_up:
             return "fail", "clickhouse unreachable"
-        lost = snap.export_errors - self._errors_seen
+        # First scrape establishes the baseline; a lifetime total is not a fresh loss.
+        lost = 0.0 if self._errors_seen is None else snap.export_errors - self._errors_seen
         self._errors_seen = snap.export_errors
         if snap.drop_rate > 0 or lost > 0:
             return "fail", f"{snap.drop_rate:.2g}/s dropped · {snap.export_errors:.0f} batches lost"
@@ -483,8 +500,8 @@ class Poller:
             await asyncio.sleep(self._s.contract_interval_s)
 
     async def _run(self) -> None:
-        asyncio.create_task(self._refresh_lineage())
-        asyncio.create_task(self._refresh_contract())
+        self._slow = [asyncio.create_task(self._refresh_lineage()),
+                      asyncio.create_task(self._refresh_contract())]
         while True:
             try:
                 await self._tick()

--- a/services/flow-ui/src/flow_ui/prom.py
+++ b/services/flow-ui/src/flow_ui/prom.py
@@ -1,0 +1,171 @@
+"""Prometheus text-exposition parsing, and rates derived from it.
+
+**The whole reason this module is careful: a metric family that has never been touched is
+absent from `/metrics` entirely, not present with a zero.** The collector's five labelled
+counters (`signals_ingested_total`, `signals_accepted_total`, `signals_rejected_total`,
+`storage_signals_total`, `batch_flush_total`) are `IntCounterVec`s, and a `*Vec` exposes
+nothing until some code path instantiates a label combination. Measured on a freshly
+started collector: `/metrics` served only `batch_flush_size`, `export_errors_total` and
+`export_latency_seconds` — the other five appeared only once traffic arrived.
+
+So every read here goes through :func:`Sample.value`, which returns ``0.0`` for a family
+that is not there. An absent family is a normal state, not an error.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+#: `name{label="v",other="w"} 12.5` or `name 12.5`. The value may be an integer, a float,
+#: `+Inf`/`-Inf`/`NaN` (histogram buckets use `+Inf`).
+_LINE = re.compile(
+    r"^(?P<name>[a-zA-Z_:][a-zA-Z0-9_:]*)"
+    r"(?:\{(?P<labels>[^}]*)\})?"
+    r"\s+(?P<value>[^\s]+)"
+)
+_LABEL = re.compile(r'([a-zA-Z_][a-zA-Z0-9_]*)="((?:[^"\\]|\\.)*)"')
+
+
+def _to_float(raw: str) -> float | None:
+    """Prometheus spells infinity and NaN in words; Python's float() agrees on all three."""
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class Sample:
+    """One scrape, flattened to ``{name: {labelkey: value}}``."""
+
+    #: `{"sentinel_batch_flush_total": {'signal="all",status="success"': 92.0}}`
+    series: dict[str, dict[str, float]] = field(default_factory=dict)
+
+    def value(self, name: str, **labels: str) -> float:
+        """The value of one series, or ``0.0`` if the family or the label set is absent.
+
+        Absent is the normal cold-start state — see the module docstring.
+        """
+        family = self.series.get(name)
+        if not family:
+            return 0.0
+        if not labels:
+            # No labels asked for: sum the family. For an unlabelled metric this is the
+            # single value; for a labelled one it is the family total, which is what a
+            # caller that did not name a label wants.
+            return sum(family.values())
+        key = _label_key(labels)
+        return family.get(key, 0.0)
+
+    def sum_over(self, name: str, label: str) -> dict[str, float]:
+        """Every value of `name`, keyed by one label's value (e.g. by ``signal``)."""
+        out: dict[str, float] = {}
+        for key, val in self.series.get(name, {}).items():
+            parsed = dict(_LABEL.findall(key))
+            if label in parsed:
+                out[parsed[label]] = out.get(parsed[label], 0.0) + val
+        return out
+
+    def sum_over_pair(self, name: str, first: str, second: str) -> dict[str, dict[str, float]]:
+        """Every value of `name`, keyed by TWO labels — ``{first: {second: value}}``.
+
+        :meth:`sum_over` collapses one label at a time, and reading the same family twice
+        (once by `signal`, once by `reason`) cannot recover the cross-product: it says
+        *three metrics were rejected* and *four rejections were contract failures*, never
+        which of the two. `sentinel_signals_rejected_total` carries both labels at the
+        increment site (`collector-rust/src/grpc.rs`), so the cross-product is real data,
+        not an inference — this reads it.
+        """
+        out: dict[str, dict[str, float]] = {}
+        for key, val in self.series.get(name, {}).items():
+            parsed = dict(_LABEL.findall(key))
+            if first in parsed and second in parsed:
+                bucket = out.setdefault(parsed[first], {})
+                bucket[parsed[second]] = bucket.get(parsed[second], 0.0) + val
+        return out
+
+    def has(self, name: str) -> bool:
+        """Whether the family was present in the scrape at all."""
+        return name in self.series
+
+
+def _label_key(labels: dict[str, str]) -> str:
+    """Canonical label key: sorted by name, so lookups do not depend on scrape order."""
+    return ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
+
+
+def parse(text: str) -> Sample:
+    """Parse the Prometheus text exposition format into a :class:`Sample`."""
+    series: dict[str, dict[str, float]] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _LINE.match(line)
+        if not m:
+            continue
+        value = _to_float(m.group("value"))
+        if value is None:
+            continue
+        raw_labels = m.group("labels") or ""
+        key = _label_key(dict(_LABEL.findall(raw_labels))) if raw_labels else ""
+        series.setdefault(m.group("name"), {})[key] = value
+    return Sample(series=series)
+
+
+def quantile(sample: "Sample", name: str, q: float) -> float:
+    """Approximate a quantile from a Prometheus histogram's cumulative buckets.
+
+    The collector already publishes `export_latency_seconds` as a histogram, and reducing
+    it to `sum/count` throws away the only thing that matters for health: a mean of 16 ms
+    reads identically whether every flush took 16 ms or nine took 4 ms and one took 130.
+
+    Buckets are cumulative and `le` is an upper bound, so the true value sits somewhere
+    inside the bucket that first crosses the target rank. We interpolate linearly across
+    that bucket, which is what Prometheus' own `histogram_quantile` does — and inherits the
+    same caveat: the answer can only be as precise as the bucket edges, and a value in the
+    `+Inf` bucket can only be reported as "at least the last finite edge".
+    """
+    family = sample.series.get(f"{name}_bucket")
+    if not family:
+        return 0.0
+    buckets: list[tuple[float, float]] = []
+    for key, count in family.items():
+        parsed = dict(_LABEL.findall(key))
+        le = _to_float(parsed.get("le", ""))
+        if le is not None:
+            buckets.append((le, count))
+    if not buckets:
+        return 0.0
+    buckets.sort(key=lambda b: b[0])
+    total = buckets[-1][1]
+    if total <= 0:
+        return 0.0
+    target = q * total
+    prev_le, prev_count = 0.0, 0.0
+    for le, count in buckets:
+        if count >= target:
+            if le == float("inf"):
+                return prev_le
+            span = count - prev_count
+            if span <= 0:
+                return le
+            return prev_le + (le - prev_le) * ((target - prev_count) / span)
+        prev_le, prev_count = le, count
+    return buckets[-1][0]
+
+
+def rate(current: float, previous: float, dt: float) -> float:
+    """Per-second rate between two counter reads.
+
+    A counter that went *backwards* means the collector restarted and its registry is
+    fresh — the process builds an independent `Registry` per run, so there is no
+    continuity across restarts. Treat the current value as the delta rather than
+    reporting a large negative rate.
+    """
+    if dt <= 0:
+        return 0.0
+    delta = current - previous
+    if delta < 0:
+        delta = current
+    return delta / dt

--- a/services/flow-ui/src/flow_ui/prom.py
+++ b/services/flow-ui/src/flow_ui/prom.py
@@ -113,7 +113,7 @@ def parse(text: str) -> Sample:
     return Sample(series=series)
 
 
-def quantile(sample: "Sample", name: str, q: float) -> float:
+def quantile(sample: Sample, name: str, q: float) -> float:
     """Approximate a quantile from a Prometheus histogram's cumulative buckets.
 
     The collector already publishes `export_latency_seconds` as a histogram, and reducing

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -1,0 +1,239 @@
+/* Sentinel flow — one world, two palettes.
+ *
+ * Nothing here names a colour. Every rule reads a ROLE (--pri, --sec, --alarm), and the
+ * two palettes below assign different values to the same roles. That is the whole reason
+ * the palette switch costs one attribute on <html> instead of a second stylesheet.
+ *
+ * The alarm colour is the one that does not survive a naive port: #FF4A3D reads clearly
+ * against phosphor green and amber, but against cyan and magenta a pure red competes
+ * rather than interrupts, so substrate shifts it toward pink. Same role, tuned value.
+ *
+ * `--ter` (traces) follows a rule rather than a taste: it is the palette's own TEXT tone,
+ * near-neutral, so the three signal lanes read as "two saturated hues plus a white". In
+ * command that is literally `--txt`. Substrate used to break the rule with a magenta,
+ * which made traces the loudest lane on screen and left the alarm pink competing with it
+ * for the same register — two pinks, one of which means "lost". It is now the cool
+ * near-white, one step brighter than `--txt` so it separates from the cyan `--pri` by
+ * SATURATION, which is what separates the green and the pale green in command.
+ */
+:root, :root[data-world="command"]{
+  --bg:#080A07; --panel:#0B0E09; --raise:#0C1009; --sunk:#060805;
+  --pri:#7FE04A; --sec:#FFB000; --ter:#CFE8C0; --alarm:#FF4A3D;
+  --txt:#CFE8C0; --dim:#5F7A4E; --dim2:#7C9668;
+  --rule:#24331A; --rule2:#16200F; --via:#1A2612; --viaS:#3B5229;
+  --rule-arrow:#4E6B39;
+  --grid:rgba(127,224,74,.045); --scan:rgba(127,224,74,.03);
+  --knob:#7FE04A;
+}
+:root[data-world="substrate"]{
+  --bg:#04060B; --panel:#070B12; --raise:#091019; --sunk:#03050A;
+  --pri:#22D3EE; --sec:#FFC53D; --ter:#DCE9F5; --alarm:#FF5C7A;
+  --txt:#C3D6E6; --dim:#3D5A72; --dim2:#6C8AA6;
+  --rule:#153446; --rule2:#0E2230; --via:#0B1B26; --viaS:#1E5468;
+  --rule-arrow:#2E6E88;
+  --grid:rgba(34,211,238,.05); --scan:rgba(34,211,238,.014);
+  --knob:#22D3EE;
+}
+/* The two reachability LEDs are a semaphore, and a semaphore is not part of a palette.
+   Green means reachable and red means not, in BOTH worlds — that convention is older and
+   stronger than this design system. Substrate painted "up" with `--pri`, which is also the
+   colour of logs, so the dot said "accent" rather than "healthy". These are the only two
+   values in the file deliberately shared across palettes; the rules still read roles. */
+:root{ --up:#3ECF6E; --down:#FF4A3D; }
+*{box-sizing:border-box}
+html{color-scheme:dark}
+body{margin:0;background:var(--sunk);color:var(--txt);
+  font:14px/1.55 "IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  -webkit-font-smoothing:antialiased;transition:background .3s}
+.sans{font-family:"IBM Plex Sans",system-ui,-apple-system,sans-serif}
+
+/* ── header ── */
+.top{display:flex;align-items:center;gap:16px;padding:0 16px;height:46px;
+  background:var(--panel);border-bottom:1px solid var(--rule);transition:background .3s}
+.brand{display:flex;align-items:center;gap:9px;font-size:13px;letter-spacing:.02em;color:var(--txt)}
+.brand .led{width:8px;height:8px;border-radius:50%;background:var(--pri);
+  box-shadow:0 0 9px var(--pri);animation:led 2s ease-in-out infinite}
+.brand em{font-style:normal;color:var(--dim)}
+@keyframes led{0%,100%{opacity:1}50%{opacity:.35}}
+
+.dash{display:flex;gap:1px;margin-left:8px}
+.dash button{appearance:none;border:0;background:none;cursor:pointer;color:var(--dim);
+  font:500 11px/1 inherit;letter-spacing:.13em;text-transform:uppercase;padding:9px 13px;
+  border-radius:4px}
+.dash button:hover{color:var(--dim2)}
+.dash button[aria-selected="true"]{color:var(--txt);background:var(--raise)}
+.dash button:focus-visible{outline:2px solid var(--sec);outline-offset:-2px}
+
+.meta{margin-left:auto;display:flex;align-items:center;gap:14px;
+  font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--dim)}
+.meta b{color:var(--sec);font-weight:500}
+.st{display:flex;align-items:center;gap:5px}
+/* Down glows too. A failure that is quieter than the success beside it is backwards. */
+.st::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--down);
+  box-shadow:0 0 7px var(--down)}
+.st[data-up="y"]::before{background:var(--up);box-shadow:0 0 7px var(--up)}
+
+/* palette switch — no words, the colour is the label */
+.pal{appearance:none;border:1px solid var(--rule);background:var(--sunk);cursor:pointer;
+  width:44px;height:24px;border-radius:99px;position:relative;padding:0;flex:none;
+  transition:border-color .3s,background .3s}
+.pal:focus-visible{outline:2px solid var(--sec);outline-offset:2px}
+.pal::after{content:"";position:absolute;top:2px;left:2px;width:18px;height:18px;
+  border-radius:50%;background:var(--knob);box-shadow:0 0 10px var(--knob);
+  transition:transform .28s cubic-bezier(.3,.7,.3,1),background .3s}
+:root[data-world="substrate"] .pal::after{transform:translateX(20px)}
+
+/* ── tiles ── */
+.tiles{display:grid;gap:1px;background:var(--rule2);border-bottom:1px solid var(--rule);
+  grid-template-columns:repeat(auto-fit,minmax(112px,1fr))}
+.tile{background:var(--panel);padding:9px 13px 10px;transition:background .3s}
+.tile b{display:block;font-size:21px;font-weight:500;line-height:1.15;letter-spacing:-.02em;
+  font-variant-numeric:tabular-nums;color:var(--txt)}
+.tile b u{text-decoration:none;font-size:10px;color:var(--dim);margin-left:2px}
+.tile i{display:block;font-style:normal;font-size:8.5px;letter-spacing:.13em;
+  text-transform:uppercase;color:var(--dim);margin-top:2px}
+.tile.hot b{color:var(--sec)}
+.tile.bad b{color:var(--alarm)}
+
+/* ── stage ── */
+.crumb{display:flex;align-items:center;gap:8px;padding:6px 16px;background:var(--panel);
+  border-bottom:1px solid var(--rule2);font-size:9.5px;letter-spacing:.12em;text-transform:uppercase}
+.crumb button{appearance:none;border:0;background:none;cursor:pointer;color:var(--dim2);
+  font:inherit;padding:2px 0;border-bottom:1px solid transparent}
+.crumb button:hover{color:var(--txt);border-bottom-color:var(--rule)}
+.crumb button:focus-visible{outline:2px solid var(--sec);outline-offset:2px}
+.crumb .now{color:var(--sec)}
+.crumb .sep{color:var(--dim)}
+.crumb .esc{margin-left:auto;color:var(--dim);font-size:9px;letter-spacing:.1em}
+
+.stage{position:relative;background:var(--bg);transition:background .3s;
+  background-image:linear-gradient(var(--grid) 1px,transparent 1px),
+    linear-gradient(90deg,var(--grid) 1px,transparent 1px),
+    repeating-linear-gradient(0deg,var(--scan) 0 1px,transparent 1px 3px);
+  background-size:26px 26px,26px 26px,auto}
+.stage svg{display:block;width:100%;height:auto;aspect-ratio:1000/440}
+.stage{cursor:grab;touch-action:none}
+.stage.grabbing{cursor:grabbing}
+
+/* The canvas controls sit over the stage, outside the pan/zoom transform, so they never
+   move with the graph. */
+.canvas{position:relative}
+.zoom{position:absolute;right:12px;bottom:12px;display:flex;flex-direction:column;gap:1px;
+  border:1px solid var(--rule);border-radius:6px;overflow:hidden;background:var(--rule2)}
+.zoom button{appearance:none;border:0;cursor:pointer;background:var(--panel);color:var(--dim2);
+  font:400 15px/1 inherit;width:28px;height:28px;display:grid;place-items:center;padding:0}
+.zoom button:hover{background:var(--raise);color:var(--txt)}
+.zoom button:focus-visible{outline:2px solid var(--sec);outline-offset:-2px}
+
+
+.legend{display:flex;align-items:center;gap:15px;flex-wrap:wrap;padding:8px 16px;
+  background:var(--panel);border-top:1px solid var(--rule);min-height:34px;
+  font-size:9px;letter-spacing:.11em;text-transform:uppercase;color:var(--dim);transition:background .3s}
+.legend b{color:var(--txt);font-weight:500}
+.legend .gl{width:8px;height:8px;border-radius:50%;display:inline-block;margin-right:6px;
+  vertical-align:-1px}
+.legend .tri{width:10px;height:10px;border-radius:50%;display:inline-block;margin-right:6px;
+  vertical-align:-2px;background:conic-gradient(var(--pri) 0 33.3%,var(--ter) 0 66.6%,var(--sec) 0)}
+.legend .tri.ring{box-shadow:0 0 0 1.5px var(--alarm);margin-right:8px}
+.legend .sp{margin-left:auto}
+.legend .on{color:var(--sec)}
+.legend .on b{color:var(--sec)}
+
+/* ── svg vocabulary ── */
+.nd{fill:var(--raise);stroke:var(--rule);stroke-width:1;transition:stroke .16s,fill .16s}
+.hit{cursor:pointer;pointer-events:all}
+.hit *{pointer-events:none}
+.hit rect{pointer-events:all}
+.hit:hover .nd{stroke:var(--sec);fill:var(--panel)}
+.hit:active .nd{fill:var(--sunk)}
+.hit:focus{outline:none}
+.hit:focus-visible .nd{stroke:var(--sec);stroke-width:2}
+.nd.sel{stroke:var(--sec)}
+/* An open container is a REGION, not a card: with an opaque fill it painted over the
+   last stretch of every lane arriving at `receive`, which made the data look as though it
+   entered the box anywhere. `.hit rect{pointer-events:all}` keeps it clickable. */
+.nd.open{fill:none}
+.sub-nd{fill:var(--panel)}
+.sheet{fill:var(--panel)}
+.node > rect{transition:stroke .16s,fill .16s}
+.lbl{fill:var(--dim);font-size:8px;letter-spacing:.13em}
+.txt{fill:var(--txt);font-size:10px}
+.val{fill:var(--pri);font-size:10px;text-anchor:end;font-variant-numeric:tabular-nums}
+.sub{fill:var(--dim);font-size:7.5px}
+.vtitle{fill:var(--txt);font-size:15px;letter-spacing:.16em}
+.big{fill:var(--txt);font-size:21px;letter-spacing:-.02em;font-variant-numeric:tabular-nums}
+.cue{fill:var(--sec);font-size:7.5px;letter-spacing:.1em}
+.cue.end{text-anchor:end}
+.ed{fill:none;stroke:var(--rule);stroke-width:1.6;stroke-linejoin:round}
+/* ── pipes ──
+   The main flow runs THROUGH a channel, not along a wire: a casing, and inside it a bore
+   painted darker than the stage so it reads as hollow — which also hides the grid, so the
+   channel looks enclosed rather than drawn on top of the board.
+
+   Only the flow gets a pipe. Every outcome tap stays a thin line on purpose: if the pipe
+   is the flow, then failing is FALLING OUT of it, and "inside the pipe" and "out of the
+   pipe" have to be different objects, not the same object at two weights. */
+/* The bore is sized from what travels it, not from taste. The floor is the dot's CORE,
+   6.4px: at a 9px bore it scraped the walls and read as bursting out. 10px leaves 1.8px a
+   side, which is enough — the bloom halo may spill, the core may not. Going wider than
+   that bought nothing and cost two things: ORIGIN's eight-edge topology read as tangled
+   plumbing, and the collector's 32px internal hops became plugs rather than runs. */
+/* Wall thickness is (casing - bore) / 2, so it is set by the pair, not by a third number.
+   1.5px: enough to read as a wall at every zoom the viewport reaches, thin enough that the
+   pipe stays a channel rather than a bar. */
+.pw{fill:none;stroke:var(--rule);stroke-width:13;stroke-linejoin:round;stroke-linecap:butt}
+.pb{fill:none;stroke:var(--sunk);stroke-width:10;stroke-linejoin:round;stroke-linecap:butt}
+/* The trunk carries whole batches rather than signals, so it is visibly the bigger pipe.
+   Not decoration: an 18px batch sphere cannot travel a 9px bore. */
+/* Same 1.5px wall. Only the bore grows, because only the payload did. */
+.pw.trunk{stroke-width:24}
+.pb.trunk{stroke-width:21}
+/* A mouth is a LIP, and a lip is pipe-shaped: a short section perpendicular to the run,
+   wider than the casing it caps. It was a circle, which read as a bead threaded onto the
+   line — the one shape that says "not a pipe". Sized to the casing at each site, so the
+   trunk's mouth is visibly the bigger one. */
+.rim{fill:var(--sunk);stroke:var(--rule);stroke-width:1.5}
+/* A dependency between stages is brighter than a pipe: at 32px in the dimmest colour on
+   the palette, the arrows between receive/validate/buffer were invisible, and the graph
+   read as three unconnected boxes. */
+.ed.step{stroke:var(--rule-arrow);stroke-width:1.8}
+/* A tap leaves the main chain: dimmer and dashed, so it never competes with the path a
+   signal normally takes. */
+.ed.tap{stroke:var(--rule-arrow);stroke-width:1;stroke-dasharray:3 4;opacity:.45;
+  transition:opacity .3s,stroke .3s}
+/* A tap that is actually carrying something stops whispering. It brightens to a NEUTRAL
+   tone, not to amber: the dot falling down it now carries the signal type's own colour,
+   and an amber line under a green dot said two different things about the same event. */
+.ed.tap.live{stroke:var(--dim2);opacity:1;stroke-dasharray:none;stroke-width:1.4}
+/* The exception, because it is not a type but a severity: nothing comes back from here. */
+.ed.tap.live.alarm{stroke:var(--alarm)}
+.tap-via{opacity:.55;transition:opacity .3s,fill .3s,stroke .3s}
+.tap-via.live{opacity:1;fill:var(--dim2);stroke:var(--dim2)}
+.tap-via.live.alarm{fill:var(--alarm);stroke:var(--alarm)}
+/* A RETURN: what an outcome sends back into the chain. Idle it whispers like a tap, so
+   three quiet outcomes stay three quiet lines. */
+.ed.ret{stroke:var(--rule-arrow);stroke-width:1;stroke-dasharray:3 4;opacity:.45;
+  transition:opacity .3s,stroke .3s,stroke-width .3s}
+.ed.ret.live{stroke:var(--dim2);opacity:1;stroke-dasharray:none;stroke-width:1.4}
+/* A control return carries a gRPC STATUS, not the batch — the producer still holds the
+   data. It stays dotted even when live, and never gets particles, so it cannot be read as
+   telemetry travelling backwards. */
+.ed.ret.ctl{stroke-dasharray:1 3}
+.ed.ret.ctl.live{stroke:var(--rule-arrow);stroke-dasharray:1 3;stroke-width:1.1;opacity:.9}
+/* The batch that did not make it. The sectors keep saying "mixed"; the ring says "lost". */
+.lost-ring{stroke:var(--alarm);stroke-width:1.6}
+.via{fill:var(--via);stroke:var(--viaS);stroke-width:1}
+/* Particles fade rather than pop: a lane that gains throughput reveals dots already in
+   flight, so the flow never appears to restart. */
+.dot,.p1,.p2,.p3,.pa,.blk{transition:opacity .45s ease}
+.p1{fill:var(--pri)}.p2{fill:var(--ter)}.p3{fill:var(--sec)}.pa{fill:var(--alarm)}
+/* A batch is drawn as its contents, not as a colour it does not have. */
+.batch path{stroke:none}
+.batch{transition:opacity .45s ease}
+.burst{transition:opacity .3s ease}
+.blk{fill:var(--sec)}
+
+.empty{padding:44px 16px;text-align:center;color:var(--dim);font-size:12px}
+.empty code{color:var(--sec)}
+@media(prefers-reduced-motion:reduce){animateMotion,animate{display:none}}
+@media(max-width:620px){.tile b{font-size:17px}.meta .hide{display:none}}

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -144,15 +144,28 @@ body{margin:0;background:var(--sunk);color:var(--txt);
 .hit{cursor:pointer;pointer-events:all}
 .hit *{pointer-events:none}
 .hit rect{pointer-events:all}
-.hit:hover .nd{stroke:var(--sec);fill:var(--panel)}
-.hit:active .nd{fill:var(--sunk)}
+/* `>`, not a descendant selector. Without it, hovering anywhere inside a container matched
+   every `.nd` it contains, so aiming at one table lit up the table, its neighbours and the
+   box around them at once. The pointer highlights what it is actually over. */
+.hit:hover > .nd{stroke:var(--sec);fill:var(--panel)}
+.hit:active > .nd{fill:var(--sunk)}
 .hit:focus{outline:none}
-.hit:focus-visible .nd{stroke:var(--sec);stroke-width:2}
+.hit:focus-visible > .nd{stroke:var(--sec);stroke-width:2}
 .nd.sel{stroke:var(--sec)}
 /* An open container is a REGION, not a card: with an opaque fill it painted over the
    last stretch of every lane arriving at `receive`, which made the data look as though it
    entered the box anywhere. `.hit rect{pointer-events:all}` keeps it clickable. */
-.nd.open{fill:none}
+.nd.open{fill:none;pointer-events:none}
+/* ...and it stays a region under the pointer. `.hit:hover > .nd` sets `fill:var(--panel)`
+   and outranks `.nd.open` on specificity, so hovering re-filled the open box opaque and it
+   painted over the pipes running behind it — the whole reason `fill:none` is here. An open
+   container neither fills nor lights: it is not the thing being pointed at. */
+.hit:hover > .nd.open,.hit:active > .nd.open,.hit:focus-visible > .nd.open{
+  fill:none;stroke:var(--rule);stroke-width:1}
+/* Open, the clickable target is the header strip, not the whole interior — the interior
+   belongs to whatever is drawn in it. Closed, the box is a card and the card is the button. */
+.chrome{fill:transparent;transition:fill .16s}
+.chrome:hover{fill:var(--raise)}
 .sub-nd{fill:var(--panel)}
 .sheet{fill:var(--panel)}
 .node > rect{transition:stroke .16s,fill .16s}

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -152,6 +152,9 @@ body{margin:0;background:var(--sunk);color:var(--txt);
 .hit:focus{outline:none}
 .hit:focus-visible > .nd{stroke:var(--sec);stroke-width:2}
 .nd.sel{stroke:var(--sec)}
+/* A status mark on every producer, healthy ones included: a dot that only appears when
+   something is wrong cannot be told apart from a node nobody is watching. */
+.hmark{transition:fill .3s}
 /* An open container is a REGION, not a card: with an opaque fill it painted over the
    last stretch of every lane arriving at `receive`, which made the data look as though it
    entered the box anywhere. `.hit rect{pointer-events:all}` keeps it clickable. */

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -201,6 +201,10 @@ body{margin:0;background:var(--sunk);color:var(--txt);
 .pb{fill:none;stroke:var(--sunk);stroke-width:10;stroke-linejoin:round;stroke-linecap:butt}
 /* The trunk carries whole batches rather than signals, so it is visibly the bigger pipe.
    Not decoration: an 18px batch sphere cannot travel a 9px bore. */
+/* A declared edge nothing was ever traced on. Dashed and dim: the dependency is claimed,
+   the traffic is not observed — and grey means not observed, never fine. */
+.pw.declared{stroke:var(--dim);stroke-dasharray:4 5;opacity:.55}
+.pb.declared{opacity:.55}
 /* Same 1.5px wall. Only the bore grows, because only the payload did. */
 .pw.trunk{stroke-width:24}
 .pb.trunk{stroke-width:21}

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -42,7 +42,14 @@
 :root{ --up:#3ECF6E; --down:#FF4A3D; }
 *{box-sizing:border-box}
 html{color-scheme:dark}
-body{margin:0;background:var(--sunk);color:var(--txt);
+/* The page owns the viewport and the canvas fills what is left of it. The stage used to
+   carry `aspect-ratio:1000/440` with `height:auto`, so its height was derived from its WIDTH
+   and the screen was never consulted: on a wide monitor it asked for more height than the
+   window had and the whole page scrolled, while half-width left the bottom half empty. A
+   column that fills `100dvh` and a canvas that takes the remainder inverts that — the
+   drawing fits the window instead of the window fitting the drawing. */
+body{margin:0;height:100dvh;display:flex;flex-direction:column;overflow:hidden;
+  background:var(--sunk);color:var(--txt);
   font:14px/1.55 "IBM Plex Mono",ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
   -webkit-font-smoothing:antialiased;transition:background .3s}
 .sans{font-family:"IBM Plex Sans",system-ui,-apple-system,sans-serif}
@@ -111,13 +118,23 @@ body{margin:0;background:var(--sunk);color:var(--txt);
     linear-gradient(90deg,var(--grid) 1px,transparent 1px),
     repeating-linear-gradient(0deg,var(--scan) 0 1px,transparent 1px 3px);
   background-size:26px 26px,26px 26px,auto}
-.stage svg{display:block;width:100%;height:auto;aspect-ratio:1000/440}
-.stage{cursor:grab;touch-action:none}
+/* `meet` keeps the whole viewBox visible at whatever aspect the box happens to have, so
+   nothing is ever cropped — the cost is margin on the short axis, which `fit()` minimises by
+   scaling the graph into the space it actually gets. */
+.stage svg{display:block;width:100%;height:100%}
+.stage{cursor:grab;touch-action:none;height:100%}
+/* `min-height:0` on both, or a flex child refuses to shrink below its content and the
+   overflow reappears one level up. */
+/* `:not([hidden])`, or `display:flex` overrides the `hidden` attribute's own `display:none`
+   and all four boards stay in the flex flow — each taking a quarter of the height while only
+   one is on screen. Measured: a 1440px viewport gave the stage 266px. */
+main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;min-height:0}
+.top,.tiles,.crumb,.legend{flex:none}
 .stage.grabbing{cursor:grabbing}
 
 /* The canvas controls sit over the stage, outside the pan/zoom transform, so they never
    move with the graph. */
-.canvas{position:relative}
+.canvas{position:relative;flex:1;min-height:0}
 .zoom{position:absolute;right:12px;bottom:12px;display:flex;flex-direction:column;gap:1px;
   border:1px solid var(--rule);border-radius:6px;overflow:hidden;background:var(--rule2)}
 .zoom button{appearance:none;border:0;cursor:pointer;background:var(--panel);color:var(--dim2);

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -199,7 +199,16 @@
       c.out = [c.x + c.w, c.y + c.h * 0.5];
     }
     b.in = [b.x, b.y + b.h * 0.5];
-    return { boxes, width: x - GAP + 40, height: 440 };
+    // The real extent of what gets drawn, not the viewBox. `height: 440` was reported flat,
+    // so `fit()` scaled the graph against the whole canvas while the closed boxes occupy
+    // about 200 of it — on a tall window the graph sat small in the middle of empty space.
+    const bs = Object.values(boxes);
+    const y0 = Math.min(...bs.map((b) => b.y)), y1 = Math.max(...bs.map((b) => b.y + b.h));
+    // The datasheet is drawn 40px past BRONZE and is 320 wide. It is not a box, so it was
+    // absent from these bounds and `fit()` scaled to a width that did not include it — the
+    // sheet ran off the right edge of the canvas whenever bronze was open.
+    const x1 = (x - GAP) + (open.bronze ? 40 + 320 : 0);
+    return { boxes, x0: 40, y0, width: x1 - 40, height: y1 - y0 };
   }
 
   /* ── particle pools ────────────────────────────────────────── */
@@ -853,8 +862,15 @@
         if (e.key === "Enter" || e.key === " ") { e.preventDefault(); pick(e); }
       });
     });
-    L.content = { w: L.width, h: L.height };
+    L.content = { w: L.width, h: L.height, x0: L.x0, y0: L.y0 };
+    // Refit when the drawing actually changed SIZE — opening a box, or selecting a service
+    // and growing ORIGIN for its panel. Not on every repaint: a mode change repaints too and
+    // would throw away a pan the reader had just made. Opening a box is a deliberate act
+    // with an expectation of seeing what is inside; a data tick is not.
+    const prev = lastLayout?.content;
+    const resized = !prev || prev.w !== L.content.w || prev.h !== L.content.h;
     lastLayout = L;
+    if (resized) fit();
     applyView();
     $("legend").innerHTML = legend();
     if (snap) density(snap);
@@ -897,12 +913,20 @@
     if (root) root.setAttribute("transform",
       `translate(${view.x.toFixed(2)} ${view.y.toFixed(2)}) scale(${view.k.toFixed(3)})`);
   }
+  //: How far `fit` may scale UP. A graph that never exceeds 1 leaves a 32" screen mostly
+  //: empty; one with no ceiling turns three boxes into wall art. 1.8 fills a tall window and
+  //: still looks like a diagram.
+  const FIT_MAX = 1.8;
+
   function fit() {
     if (!lastLayout) return;
-    const { w, h } = lastLayout.content;
-    view.k = Math.min(1, Math.min((VW - 20) / w, (VH - 20) / h));
-    view.x = (VW - w * view.k) / 2;
-    view.y = (VH - h * view.k) / 2;
+    const { w, h, x0, y0 } = lastLayout.content;
+    if (!(w > 0 && h > 0)) return;
+    view.k = clampK(Math.min(FIT_MAX, (VW - 24) / w, (VH - 24) / h));
+    // Centre the CONTENT, not the origin: the boxes start at x0/y0, and centring `w × h` as
+    // though it began at 0,0 offset the graph by exactly that margin.
+    view.x = (VW - w * view.k) / 2 - x0 * view.k;
+    view.y = (VH - h * view.k) / 2 - y0 * view.k;
     applyView();
   }
   const clampK = (k) => Math.max(0.3, Math.min(3, k));
@@ -1463,9 +1487,8 @@
     if (key === painted) return false;
     const first = painted === "";
     painted = key;
-    render();
+    render();          // refits itself when the drawing changed size
     renderHealth();
-    if (first) fit();
     return true;
   }
 
@@ -1524,6 +1547,13 @@
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape") $("z-home").click();
   });
+
+  // Re-fit when the box changes size — maximising, splitting the screen, switching tabs.
+  // `fit()` scales the graph into the viewBox it is given, and the viewBox now tracks the
+  // window, so without this the graph kept the scale it was given at load.
+  const refit = () => requestAnimationFrame(() => { if (lastLayout) fit(); });
+  addEventListener("resize", refit);
+  if (window.ResizeObserver) new ResizeObserver(refit).observe($("stage"));
 
   wireViewport();
   render(); fit();

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -120,7 +120,10 @@
     // presentation attribute loses to it, so the widths were computed correctly and every
     // pipe still rendered at its CSS gauge.
     const pw = w ? { style: `stroke-width:${w.toFixed(1)}` + (tone ? `;stroke:${tone}` : "") } : {};
-    const pb = w ? { style: `stroke-width:${Math.max(4, w - 3).toFixed(1)}` } : {};
+    // The floor is on the WALL, never on the bore: `max(4, w - 3)` let the bore reach the
+    // casing at w = 4, so the wall went to zero and the pipe rendered as a plain dark line.
+    // Every gauge keeps the same 1.5px wall a pipe needs to read as one.
+    const pb = w ? { style: `stroke-width:${Math.max(2, w - 3).toFixed(1)}` } : {};
     parent.append(el("path", { class: "pw " + gauge, d, ...pw }),
                   el("path", { class: "pb " + gauge, id, d, ...attrs, ...pb }));
   };
@@ -450,7 +453,10 @@
       // so the board read as though a service call outweighed the pipeline it feeds. Only
       // the trunk is allowed to be the widest thing on the canvas, because only it carries
       // whole batches.
-      const w = m ? 6 + Math.sqrt(m.spans / peak) * 7 : 4;
+      // Bottom of the range is 8, not 6: at 6 the wall is all there is left and the thinnest
+      // measured edge stopped looking like a pipe. Declared-but-never-traced sits below it at
+      // 7 — still a pipe, visibly the slightest one, and dashed.
+      const w = m ? 8 + Math.sqrt(m.spans / peak) * 5 : 7;
       const err = m && m.spans ? m.errors / m.spans : 0;
       const tone = !m ? "var(--dim)"
         : err >= 0.05 ? "var(--alarm)" : err >= 0.01 ? "var(--sec)" : null;

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -1099,6 +1099,10 @@
         `${fmt(r.export_errors)} batches lost · no dead-letter queue`));
 
     $("stage-h").replaceChildren(svg);
+    // The crumb says "validation ·" so it has to carry the validation policy. It was
+    // rendered once from `s.mode` — the delivery mode — and never updated, so the live page
+    // read "validation · idle".
+    set("h-pol", `validation · ${policyOf()}`);
     $("legend-h").innerHTML = `<span class="on" style="color:${tone}">● ${state}</span>
       <span>${r.health_note || ""}</span>
       <span class="sp">series are a <b>${Math.min(hist.length, 120)}s window</b></span>
@@ -1462,8 +1466,17 @@
     $("tile-rj")?.classList.toggle("bad", rej > 0);
     $("m-col")?.setAttribute("data-up", s.collector_up ? "y" : "n");
     $("m-ch")?.setAttribute("data-up", s.clickhouse_up ? "y" : "n");
+    // `rc`/`rb` must be pushed here too, not only served by `/api/history`. The client keeps
+    // its own window, so ~120 ticks after load every visible point is one of these — and
+    // without the per-signal reject arrays the Contract board's sparklines flatlined to zero
+    // while violations were happening. Same shape the server writes, so the two are one
+    // series; `LANES` fixes the order.
+    const cm = s.reject_matrix || {};
+    const bySignal = (reason) => LANES.map(([n]) => (cm[reason] || {})[n] || 0);
     hist.push({ t: s.ts, in: sum2(s.ingest_rate), fl: s.flush_rate, lat: s.export_latency_ms,
-      st: s.persist_rate, rj: sum2(s.reject_rate), dr: s.drop_rate, m: s.mode });
+      st: s.persist_rate, rj: sum2(s.reject_rate),
+      rc: bySignal("contract"), rb: bySignal("backpressure"),
+      dr: s.drop_rate, m: s.mode });
     if (hist.length > HIST_MAX) hist.shift();
     // A board only draws when it is on screen. Neither has animation to preserve, but
     // rebuilding a chart nobody is looking at, once a second, is work for nothing.

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -301,6 +301,60 @@
   const dots = (rate) => rate <= 0 ? 0
     : Math.max(1, Math.min(MAX_DOTS, Math.round(Math.pow(rate / QUANTUM, .62) * 2.6)));
 
+  /* ── per-service health, fused ─────────────────────────────
+   *
+   * V2.3. Contract and Watchers are separate boards, so the view people actually look at
+   * knew nothing about either. This fuses every per-service source that exists into the
+   * node itself.
+   *
+   * There are exactly two such sources and no more: `volume` (band verdict, plus the
+   * buckets a producer was silent for while the estate kept receiving) and
+   * `contract_violations` (rows it wrote missing a required key). Both keyed by service.
+   *
+   * What V2.3 also asks for and is NOT here: edge thickness by throughput and edge colour
+   * by violation rate. Neither is measurable. ORIGIN's edges come from Pod 1's
+   * `topology.yaml` — they are DECLARED dependencies, not measured flows — and nothing in
+   * the collector or in bronze counts anything per edge. Drawing them would be inventing
+   * the one thing the picture would then be asserting.
+   */
+  /** Producers writing into bronze that Pod 1 never declared.
+   *
+   *  Found while building the per-node health and it changes what that health is worth: the
+   *  DAG draws the DECLARED topology, so a producer nobody declared has no node to carry a
+   *  state — and here the only two producers with problems were exactly those. Undeclared is
+   *  itself the finding, and it correlates: nothing declared it, so nothing told it the
+   *  contract, so it is missing required keys. Reported apart from the graph because it has
+   *  no position in the graph. */
+  const undeclared = () => {
+    const declared = new Set((graph?.topology?.nodes || []).map((n) => n.service));
+    const seen = new Set([...(snap?.lineage || []).map((r) => r.service),
+                          ...(snap?.volume || []).map((r) => r.service),
+                          ...(snap?.contract_violations || []).map((r) => r.service)]);
+    return [...seen].filter((n) => n && !declared.has(n)).sort();
+  };
+
+  const HRANK = { fail: 0, warn: 1, unmonitored: 2, unknown: 3, passing: 4 };
+  const HTONE = { fail: "var(--alarm)", warn: "var(--sec)", unmonitored: "var(--dim2)",
+                  unknown: "var(--dim)", passing: "var(--pri)" };
+
+  function serviceHealth(name) {
+    const v = (snap?.volume || []).find((r) => r.service === name);
+    const c = (snap?.contract_violations || []).find((r) => r.service === name);
+    let state = v ? v.state : "unknown";
+    const worse = (s) => { if (HRANK[s] < HRANK[state]) state = s; };
+    const why = [];
+    if (v && (v.state === "warn" || v.state === "fail")) why.push(`volume ${v.z}σ off median`);
+    // Silence is not a band violation — a producer sitting at its median while writing
+    // nothing at all would read as passing — so it raises the state on its own axis.
+    if (v && v.absent > 0) { worse("warn"); why.push(`silent in ${v.absent} of ${v.estate} buckets`); }
+    if (c && c.violating > 0) {
+      worse("warn");
+      why.push(`${fmt(c.violating)} rows missing ${Object.keys(c.missing).length} of 5 contract keys`);
+    }
+    if (!why.length) why.push(v ? v.why : "no volume data for this producer");
+    return { state, tone: HTONE[state] || HTONE.unknown, why: why.join(" · ") };
+  }
+
   /* ── node bodies ───────────────────────────────────────────── */
   function originBody(g, b, edges, fx) {
     const r = snap || {}, ing = r.ingest_rate || {};
@@ -309,8 +363,20 @@
       rows.forEach(([name, v], i) => g.append(
         el("text", { class: "txt", x: b.x + 18, y: b.y + 66 + i * 26 }, name),
         el("text", { class: "val", x: b.x + b.w - 18, y: b.y + 66 + i * 26 }, fmt(v))));
+      // Closed, the card still has to answer "is anything wrong" — otherwise the fused
+      // state is information you can only get by opening the box that contains it.
+      const names = (graph?.topology?.nodes || []).map((n) => n.service);
+      const bad = names.filter((n) => ["warn", "fail"].includes(serviceHealth(n).state));
+      const off = undeclared();
       g.append(el("text", { class: "sub", x: b.x + 18, y: b.y + 158 },
-        `${graph?.topology?.nodes?.length || 0} services · ${graph?.topology?.edges?.length || 0} edges`));
+        `${names.length} declared · ${graph?.topology?.edges?.length || 0} edges`),
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 174,
+            style: bad.length ? "fill:var(--sec)" : null },
+          bad.length ? `${bad.length} needing attention` : "all declared producers in band"),
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 190,
+            style: off.length ? "fill:var(--alarm)" : null },
+          off.length ? `${off.length} undeclared producer${off.length > 1 ? "s" : ""} writing`
+                     : "no undeclared producers"));
       return;
     }
     const t = graph?.topology;
@@ -351,22 +417,40 @@
     const byName = Object.fromEntries((r.lineage || []).map((z) => [z.service, z]));
     t.nodes.forEach((n) => {
       const p = pos[n.id], row = byName[n.service], sel = n.service === service;
+      const h = serviceHealth(n.service);
       const node = el("g", { class: "hit", tabindex: "0", role: "button",
-        "aria-pressed": String(sel), "aria-label": `Trace ${n.service} through the pipeline` });
+        "aria-pressed": String(sel),
+        // The reason travels with the node for anyone not reading colour.
+        "aria-label": `Trace ${n.service} through the pipeline — ${h.state}: ${h.why}` });
       node.dataset.service = n.service;
       // Name on its own line, figure on the next: at 196px a 24-character service name
       // and a right-aligned count were landing on the same pixels.
       node.append(
         el("rect", { class: "nd sub-nd" + (sel ? " sel" : ""), x: p.x, y: p.y,
-          width: NW, height: NH, rx: 3 }),
-        el("text", { class: "txt", x: p.x + 12, y: p.y + 17 },
-          clip(n.service, n.roots ? 22 : 27)),
-        el("text", { class: "sub", x: p.x + 12, y: p.y + 33 },
+          width: NW, height: NH, rx: 3,
+          // Selection wins the border — it is a thing the reader just did. Health takes the
+          // border only when it has something to say and the node is not selected.
+          style: !sel && h.state !== "passing" && h.state !== "unknown"
+            ? `stroke:${h.tone}` : null }),
+        // A status mark on every node, including the healthy ones: a dot that appears only
+        // when something is wrong cannot be told from a node nobody is watching.
+        el("circle", { class: "hmark", cx: p.x + 6, cy: p.y + NH / 2, r: 3, fill: h.tone }),
+        el("text", { class: "txt", x: p.x + 16, y: p.y + 17 },
+          clip(n.service, n.roots ? 21 : 26)),
+        el("text", { class: "sub", x: p.x + 16, y: p.y + 33 },
           `${n.kind} · ${n.latency_ms ?? "?"} ms`),
         el("text", { class: "val", x: p.x + NW - 12, y: p.y + 33 }, row ? fmt(row.total) : "—"));
       if (n.roots) node.append(el("text", { class: "cue end", x: p.x + NW - 12, y: p.y + 17 }, "ROOT"));
       g.append(node);
     });
+    // Above the panel band, so it survives a service being selected. These have no node
+    // because they are in no declared topology — which is the point being made.
+    const off = undeclared();
+    if (off.length) g.append(
+      el("text", { class: "lbl", x: b.x + 20, y: b.y + 240, style: "fill:var(--alarm)" },
+        "UNDECLARED"),
+      el("text", { class: "sub", x: b.x + 104, y: b.y + 240 },
+        `writing into bronze, in no topology: ${off.map((n) => clip(n, 24)).join(" · ")}`));
     if (service) signalPanel(g, b, byName[service]);
   }
 
@@ -756,6 +840,8 @@
       <span><span class="tri"></span>= <b>one batch</b>, all three mixed</span>`;
     // With the collector open the same three colours take on a second job — they name
     // which type FAILED — so that rule is spelled out only where falling dots exist.
+    if (open.origin) return base
+      + `<span>every producer carries its <b>fused state</b> — volume band, silence, contract keys</span>`;
     return open.collector ? base
       + `<span>leaving the chain = <b>what failed</b></span>
          <span><span class="tri ring"></span>= a <b>lost batch</b>, type unknowable</span>`

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -1,0 +1,1106 @@
+/* Sentinel flow — one canvas, expanded in place.
+ *
+ * The pipeline is a single graph that never gets replaced. Opening a box grows it and
+ * reveals its internals; the boxes beside it stay where they are and the particles keep
+ * flowing through. An earlier version swapped the whole stage for a detail view, which
+ * threw away the context at exactly the moment it was needed.
+ *
+ * Two invariants hold the motion together:
+ *
+ *   1. Particles are allocated ONCE per structural render and afterwards only faded in
+ *      and out. Throughput changes on nearly every tick — a steady 730/s samples as 171,
+ *      85, 166… because the poll interval drifts against the producer's — so rebuilding on
+ *      rate would restart the animation once a second.
+ *   2. Pan and zoom write a transform attribute. They never re-render, so dragging the
+ *      canvas cannot interrupt anything in flight.
+ *
+ * What the collector can and cannot tell us, and where the line falls: at the gRPC
+ * boundary `signals_rejected_total` is labelled by BOTH `signal` and `reason`, so a
+ * rejection knows which of the three types it was — that is why a contract failure falls
+ * in its own colour. From the BUFFER onward every metric is labelled signal="all", because
+ * the exporter merges the three types into one batch, so a dropped batch can only be drawn
+ * as what it is: a mixed sphere, ringed to say it was lost. Colouring that one would
+ * invent a fact.
+ */
+(() => {
+  "use strict";
+  const $ = (id) => document.getElementById(id);
+  const NS = "http://www.w3.org/2000/svg";
+  const VW = 1000, VH = 440;      // viewBox — the window, not the canvas
+  const QUANTUM = 100;            // signals per dot at the overview
+  const MAX_DOTS = 14;            // per lane; beyond this the eye reads a line, not a count
+  const GAP = 110;                // between columns
+
+  //: Collapsed and expanded footprints. Layout is computed from these, so a box growing
+  //: pushes its neighbours rather than overlapping them.
+  const SIZE = {
+    origin:    { closed: [212, 196], open: [742, 248], openSel: [742, 386] },
+    collector: { closed: [252, 152], open: [500, 344] },
+    bronze:    { closed: [176, 136], open: [318, 252] },
+  };
+
+  let graph = null, snap = null, table = "otel_logs";
+  //: A selected service filters what the graph reports about bronze. It cannot filter the
+  //: live rates: `sentinel_signals_ingested_total` carries a `signal` label and no service
+  //: label, so per-service throughput simply does not exist upstream of ClickHouse. The
+  //: legend says so rather than letting the lanes imply otherwise.
+  let service = null;
+  const open = { origin: false, collector: false, bronze: false };
+  let painted = "", pools = {};
+  const view = { k: 1, x: 0, y: 0 };   // viewport transform
+  let root = null;                      // the <g> everything pans inside
+  let vias = null;                      // the layer mouths are drawn into
+
+  /* ── helpers ───────────────────────────────────────────────── */
+  const fmt = (n) => {
+    n = Number(n) || 0;
+    if (Math.abs(n) >= 1e6) return (n / 1e6).toFixed(1) + "M";
+    if (Math.abs(n) >= 1e3) return (n / 1e3).toFixed(1) + "k";
+    return Math.abs(n) >= 10 || n === Math.trunc(n) ? String(Math.round(n)) : n.toFixed(1);
+  };
+  const el = (tag, attrs = {}, text) => {
+    const n = document.createElementNS(NS, tag);
+    for (const [k, v] of Object.entries(attrs)) if (v != null) n.setAttribute(k, v);
+    if (text != null) n.textContent = text;
+    return n;
+  };
+  /** A branch leaving a stage downward. Kept separate from `route` because a branch
+   *  target often sits to the LEFT of its source, and a left-to-right router asked to go
+   *  backwards folds its elbow over itself — which drew a stray triangle under the
+   *  collector. This one descends first, then turns once at 45°. */
+  const branch = (x1, y1, x2, y2) => {
+    const dx = x2 - x1, turn = y2 - Math.abs(dx);
+    if (turn <= y1) return `M${x1} ${y1} L${x2} ${y2}`;
+    return `M${x1} ${y1} L${x1} ${turn} L${x2} ${y2}`;
+  };
+  /** Truncate to a monospace column budget, so a long name cannot run into a figure. */
+  const clip = (t, n) => (t.length > n ? t.slice(0, n - 1) + "…" : t);
+  /** A fan from one entry point to several rows stacked above and below it.
+   *
+   *  `route` cannot do this: it assumes the run is longer than the rise, and with a 20px
+   *  channel and a 100px drop its elbow overshot the target and doubled back — which is
+   *  what drew lines behind the table boxes. A fan needs a bus: a short stub, one vertical
+   *  leg, then straight in. Corners are chamfered to keep the board language. */
+  const fan = (x1, y1, x2, y2, stub = 26) => {
+    const bx = x1 + stub, dy = y2 - y1;
+    if (Math.abs(dy) < 2) return `M${x1} ${y1} L${x2} ${y2}`;
+    const c = Math.min(9, Math.abs(dy) / 2, Math.max(0, x2 - bx));
+    const dir = Math.sign(dy);
+    return `M${x1} ${y1} L${bx - c} ${y1} L${bx} ${y1 + c * dir} `
+         + `L${bx} ${y2 - c * dir} L${bx + c} ${y2} L${x2} ${y2}`;
+  };
+  /** An axis-aligned polyline with chamfered corners. `route`, `fan` and `branch` each
+   *  bake in one shape; a return climbs a margin channel and turns three or four times,
+   *  so it needs the legs stated outright. Corners are cut at 45° like everything else. */
+  const poly = (pts, c = 8) => {
+    let d = `M${pts[0][0]} ${pts[0][1]}`;
+    for (let i = 1; i < pts.length - 1; i++) {
+      const [px, py] = pts[i - 1], [x, y] = pts[i], [nx, ny] = pts[i + 1];
+      const a = Math.min(c, Math.hypot(x - px, y - py) / 2);
+      const bq = Math.min(c, Math.hypot(nx - x, ny - y) / 2);
+      const ax = x === px ? x : x - Math.sign(x - px) * a;
+      const ay = y === py ? y : y - Math.sign(y - py) * a;
+      const bx = nx === x ? x : x + Math.sign(nx - x) * bq;
+      const by = ny === y ? y : y + Math.sign(ny - y) * bq;
+      d += ` L${ax.toFixed(1)} ${ay.toFixed(1)} L${bx.toFixed(1)} ${by.toFixed(1)}`;
+    }
+    const last = pts[pts.length - 1];
+    return d + ` L${last[0].toFixed(1)} ${last[1].toFixed(1)}`;
+  };
+  /** A run of pipe: two strokes over one geometry — a casing, and a bore inside it. The
+   *  BORE carries the id, so `animateMotion` puts the dots on its centreline and they read
+   *  as travelling through the channel rather than along a wire. `extra` selects the gauge
+   *  ("trunk") and any marker the run needs. */
+  const pipe = (parent, id, d, gauge = "", attrs = {}) => {
+    parent.append(el("path", { class: "pw " + gauge, d }),
+                  el("path", { class: "pb " + gauge, id, d, ...attrs }));
+  };
+  /** A pipe mouth: a short lip ACROSS the run, wider than the casing it caps. Every mouth
+   *  on this board sits where a horizontal run meets a box, so the lip is a tall, narrow
+   *  rectangle. It used to be a circle, which read as a bead threaded on a wire — the one
+   *  shape that argues against the whole pipe. Derived from the casing, so the trunk's lip
+   *  is the bigger one for the same reason its bore is. */
+  const mouth = (x, y, casing = 13) => {
+    const h = casing + 7, w = casing >= 20 ? 8 : 6;
+    vias?.append(el("rect", { class: "rim", x: x - w / 2, y: y - h / 2,
+      width: w, height: h, rx: 2 }));
+  };
+  /** 45° routing: a board turns at an angle, never on a Bézier.
+   *
+   *  A 45° elbow needs `run` worth of horizontal room to make its turn, on top of the 24px
+   *  stubs either side. Given less, the elbow lands PAST `x2` and the final leg doubles
+   *  back — a stray line running out from under the node it was meant to reach. `fan`
+   *  already documents this defect and routes around it locally; leaving `route` itself
+   *  trapped meant the next caller walked into it, and ORIGIN did: its columns are 52px
+   *  apart, so every edge that changes row overshot, one of them by 84px, straight through
+   *  `gcs-processed-bucket`. Invisible as a hairline. Not invisible as a pipe. */
+  const route = (x1, y1, x2, y2) => {
+    const dy = y2 - y1, run = Math.abs(dy), span = x2 - x1;
+    if (run < 1) return `M${x1} ${y1} L${x2} ${y2}`;
+    if (run > span - 48) return fan(x1, y1, x2, y2, Math.max(18, span / 2));
+    return `M${x1} ${y1} L${x1 + (span - run) / 2} ${y1} `
+         + `L${x1 + (span + run) / 2} ${y2} L${x2} ${y2}`;
+  };
+
+  //: Where the three feeders land on whatever they enter. Spread wider than the old
+  //: 0.28/0.5/0.72 because a pipe has width: on the 54px `receive` stage these sit 19px
+  //: apart, which is one casing plus a hair. Tightening either number re-merges them.
+  const ENTRY = [0.14, 0.5, 0.86];
+
+  /* ── layout ────────────────────────────────────────────────── */
+  function layout() {
+    const CY = 220;
+    const boxes = {};
+    let x = 40;
+    for (const id of ["origin", "collector", "bronze"]) {
+      const key = !open[id] ? "closed"
+        : (id === "origin" && service && SIZE[id].openSel) ? "openSel" : "open";
+      const [w, h] = SIZE[id][key];
+      boxes[id] = { id, x, y: CY - h / 2, w, h };
+      x += w + GAP;
+    }
+    // Signal lanes leave the origin container's right edge, not individual services: the
+    // three types are a property of every service, not of any one of them.
+    const o = boxes.origin, c = boxes.collector, b = boxes.bronze;
+    o.out = [0.28, 0.5, 0.72].map((f) => [o.x + o.w, o.y + o.h * f]);
+
+    // Stage geometry lives in the layout, not in the body renderer, so the lanes coming
+    // from ORIGIN can land on `receive` and the lane leaving for BRONZE can start at
+    // `buffer`. Terminating them on the container's edge was what made it look as though
+    // data could enter any stage and any stage could write to bronze.
+    const SW = 116, SH = 54, SGAP = 32;
+    // Centred rather than left-anchored: the open box carries a return channel down each
+    // margin, and a left-anchored row put 20px on one side and 68 on the other.
+    const row = 3 * SW + 2 * SGAP;
+    const sx = c.x + Math.max(20, (c.w - row) / 2);
+    c.stages = ["receive", "validate", "buffer"].map((name, i) => ({
+      name, x: sx + i * (SW + SGAP), y: c.y + 66, w: SW, h: SH,
+    }));
+    if (open.collector) {
+      const first = c.stages[0], last = c.stages[2];
+      c.in = ENTRY.map((f) => [first.x, first.y + first.h * f]);
+      c.out = [last.x + last.w, last.y + last.h / 2];
+    } else {
+      c.in = ENTRY.map((f) => [c.x, c.y + c.h * f]);
+      c.out = [c.x + c.w, c.y + c.h * 0.5];
+    }
+    b.in = [b.x, b.y + b.h * 0.5];
+    return { boxes, width: x - GAP + 40, height: 440 };
+  }
+
+  /* ── particle pools ────────────────────────────────────────── */
+  const flow = (parent, pathId, key, cls, dur = 2.4, r = 3.2, n = MAX_DOTS) => {
+    const pool = [];
+    for (let i = 0; i < n; i++) {
+      const c = el("circle", { class: cls, r, opacity: 0 });
+      const a = el("animateMotion", { dur: `${dur}s`, repeatCount: "indefinite",
+        begin: `${((dur / n) * i).toFixed(2)}s` });
+      a.append(el("mpath", { href: `#${pathId}` }));
+      c.append(a); parent.append(c); pool.push(c);
+    }
+    pools[key] = pool;
+  };
+  //: The order in which a pool's dots light up, and it has to satisfy two things at once.
+  //:
+  //: `flow` staggers dot `i` by `(dur / poolSize) * i`, so lighting the FIRST `n` puts
+  //: every visible dot in the first `n / poolSize` of the cycle: one clump, then an empty
+  //: stretch. A steady 5-of-14 lane read as a burst, a gap, then the burst again — a
+  //: rhythm the pipeline does not have. (Invisible while the lanes were hairlines; the
+  //: bore made it plain.)
+  //:
+  //: But a modular stride, which does spread them, reshuffles the whole set when `n`
+  //: changes — 5→6 shares only two of six indices — and the rate wobbles every tick, so
+  //: half the lane faded out and back once a second.
+  //:
+  //: Farthest-point insertion gives both: every prefix is evenly spread around the cycle
+  //: AND is a subset of the next, so a rate change adds or removes dots without
+  //: disturbing the ones already in flight. Computed once per pool size.
+  const ORDERS = {};
+  const order = (p) => (ORDERS[p] ||= (() => {
+    const out = [0];
+    while (out.length < p) {
+      let best = -1, bestGap = -1;
+      for (let i = 1; i < p; i++) {
+        if (out.includes(i)) continue;
+        let d = p;
+        for (const j of out) {
+          const raw = Math.abs(i - j);
+          d = Math.min(d, raw, p - raw);
+        }
+        if (d > bestGap) { bestGap = d; best = i; }
+      }
+      out.push(best);
+    }
+    return out;
+  })());
+  const show = (key, n) => {
+    const pool = pools[key] || [], p = pool.length;
+    if (!p) return;
+    const on = new Set(order(p).slice(0, Math.max(0, Math.min(n, p))));
+    pool.forEach((c, i) => c.setAttribute("opacity", on.has(i) ? 1 : 0));
+  };
+
+  //: The three signal types, in draw order. Every service emits all three and every
+  //: internal hop carries all three, so an edge painted in one colour was saying that
+  //: only logs travel it.
+  const LANES = [["logs", "p1"], ["trace", "p2"], ["metrics", "p3"]];
+  /** One pool per signal type on the same path, offset so the colours interleave rather
+   *  than moving in lockstep. */
+  const flow3 = (parent, pathId, keyBase, dur = 2.4, r = 3.2, n = 2) =>
+    LANES.forEach(([name, cls], k) => {
+      flow(parent, pathId, `${keyBase}-${name}`, cls, dur, r, n);
+      // stagger each colour by a third of a slot so they do not overlap exactly
+      (pools[`${keyBase}-${name}`] || []).forEach((c, i) => {
+        const a = c.querySelector("animateMotion");
+        if (a) a.setAttribute("begin", `${((dur / n) * i + (dur / n / 3) * k).toFixed(2)}s`);
+      });
+    });
+  /** A batch, drawn as what it contains. The buffer flushes ONE mixed batch — the
+   *  collector labels it `signal="all"` for exactly this reason — so an amber rectangle
+   *  was naming a colour the payload does not have. Three sectors, one per signal type. */
+  const batchBall = (r = 9, spin = 2.6, lost = false) => {
+    // Two nested groups: `animateMotion` writes a transform on the outer one, so the spin
+    // has to live on an inner group or the two would overwrite each other.
+    const g = el("g", { class: "batch" });
+    const inner = el("g");
+    inner.append(el("animateTransform", { attributeName: "transform", type: "rotate",
+      from: "0 0 0", to: "360 0 0", dur: `${spin}s`, repeatCount: "indefinite" }));
+    g.append(inner);
+    LANES.forEach(([, cls], i) => {
+      const a1 = (i * 120 - 90) * Math.PI / 180, a2 = ((i + 1) * 120 - 90) * Math.PI / 180;
+      inner.append(el("path", { class: cls,
+        d: `M0 0 L${(r * Math.cos(a1)).toFixed(2)} ${(r * Math.sin(a1)).toFixed(2)} `
+         + `A${r} ${r} 0 0 1 ${(r * Math.cos(a2)).toFixed(2)} ${(r * Math.sin(a2)).toFixed(2)} Z` }));
+    });
+    inner.append(el("circle", { r: r * .34, fill: "var(--bg)", opacity: .55 }));
+    // A lost batch is still a batch. The ring says what happened to it without recolouring
+    // what it contained — which is unknowable here, and the whole reason this shape exists.
+    if (lost) g.append(el("circle", { class: "lost-ring", r: r + 3, fill: "none" }));
+    return g;
+  };
+  /** A pool of mixed batches travelling a path, for the one outcome whose payload is a
+   *  batch rather than a signal. Same fade-in contract as `flow`, so `show` drives it. */
+  const flowBatch = (parent, pathId, key, dur = 1.8, r = 6, n = 2) => {
+    const pool = [];
+    for (let i = 0; i < n; i++) {
+      const ball = batchBall(r, 2.2, true);
+      ball.setAttribute("opacity", 0);
+      const a = el("animateMotion", { dur: `${dur}s`, repeatCount: "indefinite",
+        begin: `${((dur / n) * i).toFixed(2)}s` });
+      a.append(el("mpath", { href: `#${pathId}` }));
+      ball.append(a); parent.append(ball); pool.push(ball);
+    }
+    pools[key] = pool;
+  };
+
+  const dots = (rate) => rate <= 0 ? 0
+    : Math.max(1, Math.min(MAX_DOTS, Math.round(Math.pow(rate / QUANTUM, .62) * 2.6)));
+
+  /* ── node bodies ───────────────────────────────────────────── */
+  function originBody(g, b, edges, fx) {
+    const r = snap || {}, ing = r.ingest_rate || {};
+    if (!open.origin) {
+      const rows = [["logs", ing.logs], ["traces", ing.trace], ["metrics", ing.metrics]];
+      rows.forEach(([name, v], i) => g.append(
+        el("text", { class: "txt", x: b.x + 18, y: b.y + 66 + i * 26 }, name),
+        el("text", { class: "val", x: b.x + b.w - 18, y: b.y + 66 + i * 26 }, fmt(v))));
+      g.append(el("text", { class: "sub", x: b.x + 18, y: b.y + 158 },
+        `${graph?.topology?.nodes?.length || 0} services · ${graph?.topology?.edges?.length || 0} edges`));
+      return;
+    }
+    const t = graph?.topology;
+    if (!t?.nodes?.length) return;
+    const depth = {};
+    t.nodes.forEach((n) => { if (n.roots) depth[n.id] = 0; });
+    for (let pass = 0; pass < t.nodes.length; pass++)
+      t.edges.forEach((e) => {
+        if (depth[e.from] != null) depth[e.to] = Math.max(depth[e.to] ?? 0, depth[e.from] + 1);
+      });
+    const cols = {};
+    t.nodes.forEach((n) => (cols[depth[n.id] ?? 0] ||= []).push(n));
+    const NW = 196, NH = 42, pos = {};
+    Object.entries(cols).forEach(([d, list]) => list.forEach((n, i) => {
+      const step = (b.h - 56) / list.length;
+      pos[n.id] = { x: b.x + 20 + (+d) * (NW + 52), y: b.y + 44 + step * i + (step - NH) / 2 };
+    }));
+    // Internal edges first, so nodes paint over them.
+    //
+    // Routed by `fan` rather than `route`: with 52px between columns there is no room for
+    // a 45° elbow, and every edge that changes row would overshoot. The stub is staggered
+    // per source, because edges leaving one node share a PORT and would otherwise share a
+    // vertical column too — three 13px casings on one x is a blob, not a fan.
+    const legs = {};
+    t.edges.forEach((e, i) => {
+      const a = pos[e.from], z = pos[e.to];
+      if (!a || !z) return;
+      // One casing apart, so three legs from one node stay three legs. Clamped to leave
+      // the last chamfer room to land, which is what caps the fan at ~3 legs per node.
+      const k = (legs[e.from] = (legs[e.from] ?? -1) + 1);
+      const gap = z.x - (a.x + NW);
+      pipe(edges, `oe${i}`, fan(a.x + NW, a.y + NH / 2, z.x, z.y + NH / 2,
+        Math.min(gap - 12, 14 + k * 14)));
+      mouth(a.x + NW, a.y + NH / 2);
+      mouth(z.x, z.y + NH / 2);
+      flow3(fx, `oe${i}`, `oe${i}`, 2.6 + (i % 3) * .4, 3.2, 2);
+    });
+    const byName = Object.fromEntries((r.lineage || []).map((z) => [z.service, z]));
+    t.nodes.forEach((n) => {
+      const p = pos[n.id], row = byName[n.service], sel = n.service === service;
+      const node = el("g", { class: "hit", tabindex: "0", role: "button",
+        "aria-pressed": String(sel), "aria-label": `Trace ${n.service} through the pipeline` });
+      node.dataset.service = n.service;
+      // Name on its own line, figure on the next: at 196px a 24-character service name
+      // and a right-aligned count were landing on the same pixels.
+      node.append(
+        el("rect", { class: "nd sub-nd" + (sel ? " sel" : ""), x: p.x, y: p.y,
+          width: NW, height: NH, rx: 3 }),
+        el("text", { class: "txt", x: p.x + 12, y: p.y + 17 },
+          clip(n.service, n.roots ? 22 : 27)),
+        el("text", { class: "sub", x: p.x + 12, y: p.y + 33 },
+          `${n.kind} · ${n.latency_ms ?? "?"} ms`),
+        el("text", { class: "val", x: p.x + NW - 12, y: p.y + 33 }, row ? fmt(row.total) : "—"));
+      if (n.roots) node.append(el("text", { class: "cue end", x: p.x + NW - 12, y: p.y + 17 }, "ROOT"));
+      g.append(node);
+    });
+    if (service) signalPanel(g, b, byName[service]);
+  }
+
+  /** What one service actually sends, and where each part of it lands.
+   *
+   *  This is the honest form of "show me this service's path". The path everyone pictures
+   *  — this service feeds these two tables — does not exist: bronze routes on the
+   *  data-point type, so every service reaches all four. What differs is the metric mix,
+   *  which is exactly why one service's gauge:sum split is 3:1 and another's is 1:2. */
+  function signalPanel(g, b, row) {
+    const inv = (snap?.metrics_by_service || {})[service] || { gauge: [], sum: [] };
+    const y = b.y + 260, x = b.x + 20, w = b.w - 40;
+    g.append(el("rect", { class: "nd sheet", x, y, width: w, height: 106, rx: 4 }),
+      el("text", { class: "lbl", x: x + 14, y: y + 22, style: "fill:var(--sec)" },
+        service.toUpperCase() + " → BRONZE"));
+    const cols = [
+      ["otel_logs", "every log record", row?.logs, []],
+      ["otel_traces", "every span", row?.traces, []],
+      ["otel_metrics_gauge", `${inv.gauge.length} gauge metrics`, row?.gauge, inv.gauge],
+      ["otel_metrics_sum", `${inv.sum.length} sum metrics`, row?.sum, inv.sum],
+    ];
+    const cw = (w - 28) / 4;
+    cols.forEach(([tbl, note, n, names], i) => {
+      const cx = x + 14 + i * cw;
+      g.append(el("text", { class: "txt", x: cx, y: y + 46 }, tbl.replace("otel_", "")),
+        el("text", { class: "val", x: cx + cw - 18, y: y + 46 }, n == null ? "—" : fmt(n)),
+        el("text", { class: "sub", x: cx, y: y + 61 }, note));
+      names.slice(0, 3).forEach((nm, k) => g.append(
+        el("text", { class: "sub", x: cx, y: y + 76 + k * 11 },
+          "· " + nm.replace(/^.*\//, "").slice(0, 26))));
+    });
+  }
+
+  function collectorBody(g, b, edges, fx) {
+    const r = snap || {};
+    const policy = graph?.contract?.validation || "warn";
+    const byReason = r.reject_by_reason || {};
+    if (!open.collector) {
+      g.append(
+        el("text", { class: "txt", x: b.x + 18, y: b.y + 70 }, "buffer"),
+        el("text", { class: "val", x: b.x + b.w - 18, y: b.y + 70 }, fmt(r.records_per_flush)),
+        el("text", { class: "txt", x: b.x + 18, y: b.y + 96 }, "export"),
+        el("text", { class: "val", x: b.x + b.w - 18, y: b.y + 96 }, fmt(r.export_latency_ms) + " ms"),
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 124 }, `validate · ${policy}`));
+      return;
+    }
+    const st = b.stages;
+    const note = { receive: "gRPC :4317", validate: policy, buffer: fmt(r.records_per_flush) };
+    st.forEach((sg, i) => {
+      g.append(el("rect", { class: "nd sub-nd", x: sg.x, y: sg.y, width: sg.w, height: sg.h, rx: 3 }),
+        el("text", { class: "txt", x: sg.x + 10, y: sg.y + 19 }, sg.name),
+        el("text", { class: "sub", x: sg.x + 10, y: sg.y + 34 }, note[sg.name]));
+      if (i < 2) {
+        // An explicit, arrow-headed dependency. Every signal goes receive → validate →
+        // buffer in that order; nothing enters in the middle and nothing leaves early.
+        const id = `ce${i}`;
+        pipe(edges, id, `M${sg.x + sg.w} ${sg.y + sg.h / 2} L${st[i + 1].x - 3} ${sg.y + sg.h / 2}`);
+        mouth(sg.x + sg.w, sg.y + sg.h / 2);
+        mouth(st[i + 1].x, sg.y + sg.h / 2);
+        flow3(fx, id, id, 1.3, 2.8, 2);
+      }
+    });
+
+    // ── the three ways a signal does not simply arrive ──
+    //
+    // Each outcome taps off the stage that decides it, and what tells the three apart is
+    // its RETURN — or the absence of one. Under `warn` a contract failure is flagged and
+    // still reaches the buffer; a refused batch sends a status back and the producer
+    // re-enters through `receive`; a dropped batch has nowhere to go. Three identical rows
+    // with no returns said all three were the same event, and the fate was left to a
+    // 7.5px caption nobody reads.
+    const contract = byReason.contract || 0, back = byReason.backpressure || 0;
+    const warnMode = policy !== "strict";
+    // Outcomes are inset from BOTH container edges: the two margins are the channels the
+    // returns climb. Without them a return had to cross the rows it came from.
+    const ox = b.x + 50, ow = b.w - 100;
+    const chL = b.x + 30, chR = b.x + b.w - 30;
+    g.append(el("text", { class: "lbl", x: ox, y: b.y + 168 }, "OUTCOMES"));
+    // Each tap leaves a real point on a real object — the place in the code where that
+    // outcome is decided. An earlier version started the backpressure tap in the empty gap
+    // below the arrow, anchored to nothing, and it read as invented.
+    const mid = (st[1].x + st[1].w + st[2].x) / 2;
+    const outcomes = [
+      {
+        label: "CONTRACT", v: contract, where: "at validate",
+        // validated inside `validate`, so it leaves validate's own bottom edge
+        from: [st[1].x + st[1].w / 2, st[1].y + st[1].h],
+        what: warnMode ? "flagged · exported anyway" : "discarded at the boundary",
+        colour: "var(--sec)", fate: warnMode ? "rejoins the flow" : "ends here",
+        // Under `warn` the flagged signal really does continue into the buffer, so the
+        // return is drawn and carries the same colours that fell. Under `strict` it does
+        // not, and the missing line IS the difference between the two policies — the
+        // single most consequential setting in the collector, previously invisible.
+        ret: warnMode
+          ? { via: chR, band: b.y + 140, side: 1,
+              to: [st[2].x + st[2].w * 0.72, st[2].y + st[2].h], carries: true }
+          : null,
+      },
+      {
+        label: "BACKPRESSURE", v: back, where: "entering buffer",
+        // `buffer.enqueue` refuses on the hop INTO the buffer, so it branches off that arrow
+        from: [mid, st[1].y + st[1].h / 2],
+        what: "batch refused · resource_exhausted",
+        colour: "var(--sec)", fate: "back to the producer",
+        // What travels back is a gRPC status, not the batch: the producer still holds the
+        // data, and its retry arrives at `receive` like any other export. So the loop
+        // closes inside the container, and the line carries no particles — dots on it
+        // would claim telemetry moved backwards, which never happens.
+        ret: { via: chL, band: b.y + 150, side: -1,
+               to: [st[0].x + st[0].w / 2, st[0].y + st[0].h], carries: false },
+      },
+      {
+        label: "DROPPED", v: r.drop_rate || 0, where: "flushing to bronze",
+        // the flush loop fails after the buffer, on the way out to ClickHouse. Offset from
+        // buffer's centre so the contract return can land on the same edge without a clash.
+        from: [st[2].x + st[2].w * 0.35, st[2].y + st[2].h],
+        what: "after 3 retries · no dead-letter queue",
+        colour: "var(--alarm)", fate: "ends here", ret: null,
+      },
+    ];
+    outcomes.forEach((o, i) => {
+      const y = b.y + 178 + i * 46;
+      const [fromX, fromY] = o.from, live = o.v > 0, alarm = o.colour.includes("alarm");
+      const mark = (live ? " live" : "") + (alarm ? " alarm" : "");
+      // One line, straight down from the stage it leaves. Routing it around the side
+      // produced three long horizontals sweeping under the whole chain, which read as a
+      // bus rather than as "this outcome comes from that box". The drop passes BEHIND the
+      // rows above it — edges are painted before nodes — so only the gaps show, and the
+      // arrowhead names the row it actually lands on.
+      const tapId = `tap${i}`;
+      edges.append(el("path", { class: "ed tap" + mark, id: tapId,
+        "marker-end": "url(#arrow-tap)",
+        d: `M${fromX} ${fromY} L${fromX} ${y - 3}` }));
+      // A pad where the branch begins — the same mark every other connection on the board
+      // uses to say "this joins here".
+      g.append(el("circle", { class: "via tap-via" + mark, id: `tapv${i}`,
+        cx: fromX, cy: fromY, r: 3.4 }));
+      // What falls out is drawn as WHAT FAILED. `signals_rejected_total` is labelled by
+      // both `signal` and `reason`, so a metrics rejection falls amber and a log rejection
+      // falls green — the page is not choosing a colour, it is reading one. The drop alone
+      // cannot say: `storage_signals_total` is `signal="all"` there because the buffer
+      // flushes one mixed batch, so it falls as the mixed sphere, ringed.
+      if (alarm) flowBatch(fx, tapId, tapId, 1.7, 4.5, 2);
+      else flow3(fx, tapId, tapId, 1.5, 3, 2);
+      g.append(el("rect", { class: "nd sub-nd", x: ox, y, width: ow, height: 34, rx: 3,
+          style: live ? `stroke:${o.colour}` : null }),
+        el("text", { class: "lbl", x: ox + 12, y: y + 14, style: `fill:${o.colour}` }, o.label),
+        el("text", { class: "txt", x: ox + 12, y: y + 28 }, fmt(o.v) + "/s"),
+        el("text", { class: "sub", x: ox + 106, y: y + 14 }, o.where + " · " + o.what),
+        el("text", { class: "sub", x: ox + 106, y: y + 28, style: `fill:${o.colour}` },
+          (o.fate === "ends here" ? "⊣ " : "↩ ") + o.fate));
+      if (!o.ret) return;
+      // Out of the row sideways, up its margin channel, across the band between the chain
+      // and the OUTCOMES label, and into the stage it rejoins from below. Nothing else
+      // occupies that band, and the two returns use different heights in it so they never
+      // share a line.
+      const { via, band, side, to, carries } = o.ret;
+      const retId = `ret${i}`;
+      edges.append(el("path", {
+        class: "ed ret" + (carries ? "" : " ctl") + (live ? " live" : ""),
+        id: retId, "marker-end": "url(#arrow-tap)",
+        d: poly([[side > 0 ? ox + ow : ox, y + 17], [via, y + 17],
+                 [via, band], [to[0], band], [to[0], to[1] + 3]]) }));
+      if (carries) flow3(fx, retId, retId, 2.2, 3, 2);
+    });
+  }
+
+  function bronzeBody(g, b, edges, fx) {
+    const r = snap || {}, tables = graph?.tables || {};
+    const total = Object.values(r.bronze || {}).reduce((a, z) => a + z, 0);
+    if (!open.bronze) {
+      g.append(el("text", { class: "txt", x: b.x + 18, y: b.y + 66 }, fmt(total) + " rows"),
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 88 },
+          `${Object.keys(tables).length} tables`),
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 106 },
+          `${Object.keys(graph?.empty_by_contract || {}).length} empty by contract`));
+      return;
+    }
+    const names = Object.keys(tables), TW = 228, TH = 40;
+    // When a service is selected the tables report that service's rows, not the estate's.
+    const row = (r.lineage || []).find((z) => z.service === service);
+    const KEY = { otel_logs: "logs", otel_traces: "traces",
+                  otel_metrics_gauge: "gauge", otel_metrics_sum: "sum" };
+    names.forEach((n, i) => {
+      // Tables sit right of the fan channel so the bus has room to reach every row
+      // without crossing one.
+      const y = b.y + 46 + i * (TH + 8), x = b.x + 68;
+      const sel = n === table;
+      const node = el("g", { class: "hit", tabindex: "0", role: "button",
+        "aria-label": `Inspect ${n}` });
+      node.dataset.table = n;
+      node.append(el("rect", { class: "nd sub-nd" + (sel ? " sel" : ""), x, y,
+          width: TW, height: TH, rx: 3 }),
+        el("text", { class: "txt", x: x + 10, y: y + 17 }, n.replace("otel_", "")),
+        el("text", { class: "val", x: x + TW - 10, y: y + 17 },
+          fmt(row ? row[KEY[n]] : (r.bronze || {})[n])),
+        el("text", { class: "sub", x: x + 10, y: y + 32 },
+          row ? `${service.slice(0, 22)} only` : `${tables[n].section} · +${fmt((r.bronze_rate || {})[n])}/s`));
+      g.append(node);
+      // One lane in, fanning to each table — and each strand carries the colour of what
+      // actually lands there. Routing is by data-point TYPE, so a log only ever reaches
+      // otel_logs; painting every strand the same colour said the opposite.
+      const id = `be${i}`;
+      pipe(edges, id, fan(b.x, b.y + b.h / 2, x, y + TH / 2));
+      mouth(x, y + TH / 2);
+      const cls = { otel_logs: "p1", otel_traces: "p2",
+                    otel_metrics_gauge: "p3", otel_metrics_sum: "p3" }[n] || "p1";
+      // Departures are keyed to the batch ARRIVALS, so a strand leaves at the instant the
+      // ball opens. That is the unpacking, not a loop that happens to look like one.
+      const { dur, n: inFlight } = pools.__batch || { dur: 3.2, n: 3 };
+      const pool = [];
+      for (let k = 0; k < inFlight; k++) {
+        const c = el("circle", { class: cls, r: 3.2, opacity: 0 });
+        const a = el("animateMotion", { dur: `${dur}s`, repeatCount: "indefinite",
+          begin: `${(k * dur / inFlight + dur).toFixed(2)}s` });
+        a.append(el("mpath", { href: `#${id}` }));
+        c.append(a); fx.append(c); pool.push(c);
+      }
+      pools[id] = pool;
+    });
+  }
+
+  /* ── the datasheet, only when bronze is open ───────────────── */
+  function datasheet(parent, b) {
+    const d = (graph?.tables || {})[table];
+    if (!d) return;
+    const x = b.x + b.w + 40, y = b.y, w = 320, h = b.h;
+    parent.append(el("rect", { class: "nd sheet", x, y, width: w, height: h, rx: 4 }),
+      el("text", { class: "lbl", x: x + 16, y: y + 24, style: "fill:var(--sec)" },
+        table.toUpperCase()));
+    (d.summary.match(/.{1,48}(\s|$)/g) || []).slice(0, 2).forEach((line, i) =>
+      parent.append(el("text", { class: "sub", x: x + 16, y: y + 42 + i * 13 }, line.trim())));
+    d.columns.slice(0, 8).forEach(([name, type], i) => {
+      const cy = y + 84 + i * 17;
+      parent.append(el("text", { class: "txt", x: x + 16, y: cy }, name),
+        el("text", { class: "sub", x: x + w - 16, y: cy, style: "text-anchor:end" }, type));
+    });
+    parent.append(el("text", { class: "sub", x: x + 16, y: y + h - 12 },
+      `TTL ${d.ttl} · ${d.section}`));
+  }
+
+  /* ── render ────────────────────────────────────────────────── */
+  const TITLE = { origin: "ORIGIN", collector: "COLLECTOR-RUST", bronze: "BRONZE" };
+
+  function render() {
+    const stage = $("stage");
+    pools = {};
+    const L = layout(), B = L.boxes;
+    const svg = el("svg", { viewBox: `0 0 ${VW} ${VH}`, preserveAspectRatio: "xMidYMid meet" });
+    const defs = el("defs");
+    const f = el("filter", { id: "bloom", x: "-70%", y: "-70%", width: "240%", height: "240%" });
+    f.append(el("feGaussianBlur", { stdDeviation: "2.6", result: "b" }));
+    const m = el("feMerge");
+    m.append(el("feMergeNode", { in: "b" }), el("feMergeNode", { in: "SourceGraphic" }));
+    f.append(m); defs.append(f);
+    // Arrowheads. A dependency without a head is a line, and a line does not say which
+    // way the data goes.
+    for (const [id, colour] of [["arrow", "var(--rule-arrow)"], ["arrow-sec", "var(--sec)"],
+                                ["arrow-tap", "var(--rule-arrow)"]]) {
+      const mk = el("marker", { id, viewBox: "0 0 8 8", refX: "7", refY: "4",
+        markerWidth: "5", markerHeight: "5", orient: "auto-start-reverse" });
+      mk.append(el("path", { d: "M0 1 L7 4 L0 7 z", fill: colour }));
+      defs.append(mk);
+    }
+    svg.append(defs);
+
+    root = el("g", { id: "vp" });
+    const edges = el("g", { class: "ed-layer" });
+    vias = el("g", { class: "via" });
+    const fx = el("g", { filter: "url(#bloom)" });
+    const nodes = el("g");
+    root.append(edges, vias, fx, nodes);
+    svg.append(root);
+
+    // Between-container edges. These exist whatever is expanded — the flow is continuous.
+    const lanes = [["logs", "p1"], ["trace", "p2"], ["metrics", "p3"]];
+    lanes.forEach(([name, cls], i) => {
+      pipe(edges, `L${i}`,
+        route(B.origin.out[i][0], B.origin.out[i][1], B.collector.in[i][0], B.collector.in[i][1]));
+      flow(fx, `L${i}`, name, cls);
+      mouth(B.origin.out[i][0], B.origin.out[i][1]);
+      mouth(B.collector.in[i][0], B.collector.in[i][1]);
+    });
+    pipe(edges, "B0",
+      route(B.collector.out[0], B.collector.out[1], B.bronze.in[0], B.bronze.in[1]), "trunk");
+    mouth(B.collector.out[0], B.collector.out[1], 24);
+    mouth(B.bronze.in[0], B.bronze.in[1], 24);
+    // Three batches in flight, evenly spaced. Each one's ARRIVAL time is what the burst
+    // and the per-table fan below are keyed to, so the unpacking is not decorative timing
+    // — it happens when the batch actually gets there.
+    const BATCH_DUR = 3.2, IN_FLIGHT = 3;
+    const blk = [];
+    for (let k = 0; k < IN_FLIGHT; k++) {
+      const ball = batchBall();
+      ball.setAttribute("opacity", 0);
+      const a = el("animateMotion", { dur: `${BATCH_DUR}s`, repeatCount: "indefinite",
+        begin: `${(k * BATCH_DUR / IN_FLIGHT).toFixed(2)}s` });
+      a.append(el("mpath", { href: "#B0" }));
+      ball.append(a); fx.append(ball); blk.push(ball);
+    }
+    pools.blk = blk;
+    // The moment of arrival: a ring that opens at the entry point, on the same period.
+    for (let k = 0; k < IN_FLIGHT; k++) {
+      const at = (k * BATCH_DUR / IN_FLIGHT + BATCH_DUR).toFixed(2);
+      const ring = el("circle", { class: "burst", cx: B.bronze.in[0], cy: B.bronze.in[1],
+        r: 3, fill: "none", stroke: "var(--sec)", "stroke-width": 1.6, opacity: 0 });
+      ring.append(
+        el("animate", { attributeName: "r", values: "3;20;20", keyTimes: "0;0.18;1",
+          dur: `${BATCH_DUR}s`, begin: `${at}s`, repeatCount: "indefinite" }),
+        el("animate", { attributeName: "opacity", values: ".9;0;0", keyTimes: "0;0.18;1",
+          dur: `${BATCH_DUR}s`, begin: `${at}s`, repeatCount: "indefinite" }));
+      fx.append(ring);
+      (pools.burst ||= []).push(ring);
+    }
+    pools.__batch = { dur: BATCH_DUR, n: IN_FLIGHT };
+
+    for (const id of ["origin", "collector", "bronze"]) {
+      const b = B[id];
+      const g = el("g", { class: "hit node", tabindex: "0", role: "button",
+        "aria-expanded": String(open[id]),
+        "aria-label": `${open[id] ? "Collapse" : "Expand"} ${TITLE[id]}` });
+      g.dataset.node = id;
+      g.append(el("rect", { class: "nd" + (open[id] ? " open" : ""), x: b.x, y: b.y,
+          width: b.w, height: b.h, rx: 5 }),
+        el("text", { class: "lbl", x: b.x + 18, y: b.y + 26 }, TITLE[id]),
+        el("text", { class: "cue", x: b.x + b.w - 18, y: b.y + 26,
+          style: "text-anchor:end" }, open[id] ? "CLOSE ▾" : "OPEN ▸"));
+      nodes.append(g);
+      ({ origin: originBody, collector: collectorBody, bronze: bronzeBody }[id])(g, b, edges, fx);
+    }
+    if (open.bronze) datasheet(nodes, B.bronze);
+    // The burst only means something when a batch is actually arriving.
+    show("burst", 0);
+
+    stage.replaceChildren(svg);
+    stage.querySelectorAll("[data-node]").forEach((n) => {
+      n.addEventListener("click", () => { open[n.dataset.node] = !open[n.dataset.node]; repaint(); });
+      n.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); n.click(); }
+      });
+    });
+    stage.querySelectorAll("[data-table]").forEach((n) => {
+      n.addEventListener("click", (e) => { e.stopPropagation(); table = n.dataset.table; repaint(); });
+    });
+    stage.querySelectorAll("[data-service]").forEach((n) => {
+      const pick = (e) => {
+        e.stopPropagation();
+        service = service === n.dataset.service ? null : n.dataset.service;
+        repaint();
+      };
+      n.addEventListener("click", pick);
+      n.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); pick(e); }
+      });
+    });
+    L.content = { w: L.width, h: L.height };
+    lastLayout = L;
+    applyView();
+    $("legend").innerHTML = legend();
+    if (snap) density(snap);
+  }
+  let lastLayout = null;
+
+  function legend() {
+    if (service) {
+      // The rates on screen are the whole pipeline's. Saying so is not a caveat — it is
+      // the difference between a filtered view and a lie.
+      return `<span class="on">tracing <b>${service}</b></span>
+        <span>bronze figures are <b>this service only</b></span>
+        <span>rates stay <b>pipeline-wide</b> — the collector does not label by service</span>
+        <span class="sp">click it again, or ⌂, to clear</span>`;
+    }
+    // Every hop carries all three signal types, inside a container as well as between
+    // them, so there is one rule and it holds everywhere. An earlier legend claimed a dot
+    // meant a trace inside a box; once internal edges started carrying all three, that
+    // stopped being true.
+    const base = `<span><span class="gl" style="background:var(--pri)"></span>logs</span>
+      <span><span class="gl" style="background:var(--ter)"></span>traces</span>
+      <span><span class="gl" style="background:var(--sec)"></span>metrics</span>
+      <span class="sp">one dot = <b>${QUANTUM} signals</b> of that type</span>
+      <span><span class="tri"></span>= <b>one batch</b>, all three mixed</span>`;
+    // With the collector open the same three colours take on a second job — they name
+    // which type FAILED — so that rule is spelled out only where falling dots exist.
+    return open.collector ? base
+      + `<span>leaving the chain = <b>what failed</b></span>
+         <span><span class="tri ring"></span>= a <b>lost batch</b>, type unknowable</span>`
+      : base;
+  }
+
+  /* ── viewport: transform only, never a re-render ───────────── */
+  function applyView() {
+    if (root) root.setAttribute("transform",
+      `translate(${view.x.toFixed(2)} ${view.y.toFixed(2)}) scale(${view.k.toFixed(3)})`);
+  }
+  function fit() {
+    if (!lastLayout) return;
+    const { w, h } = lastLayout.content;
+    view.k = Math.min(1, Math.min((VW - 20) / w, (VH - 20) / h));
+    view.x = (VW - w * view.k) / 2;
+    view.y = (VH - h * view.k) / 2;
+    applyView();
+  }
+  const clampK = (k) => Math.max(0.3, Math.min(3, k));
+  /** Zoom about a point in viewBox space, so the thing under the cursor stays put. */
+  function zoomAt(px, py, factor) {
+    const k = clampK(view.k * factor);
+    if (k === view.k) return;
+    view.x = px - (px - view.x) * (k / view.k);
+    view.y = py - (py - view.y) * (k / view.k);
+    view.k = k;
+    applyView();
+  }
+  const toViewBox = (evt, svg) => {
+    const r = svg.getBoundingClientRect();
+    return [(evt.clientX - r.left) / r.width * VW, (evt.clientY - r.top) / r.height * VH];
+  };
+
+  function wireViewport() {
+    const stage = $("stage");
+    stage.addEventListener("wheel", (e) => {
+      const svg = stage.querySelector("svg"); if (!svg) return;
+      e.preventDefault();
+      const [px, py] = toViewBox(e, svg);
+      zoomAt(px, py, e.deltaY < 0 ? 1.12 : 1 / 1.12);
+    }, { passive: false });
+
+    // Right-drag pans, the way a canvas tool does. The context menu is suppressed only
+    // while dragging on the stage, so a right-click elsewhere still behaves normally.
+    let drag = null;
+    stage.addEventListener("contextmenu", (e) => e.preventDefault());
+    stage.addEventListener("pointerdown", (e) => {
+      if (e.button !== 2 && !(e.button === 0 && e.target.closest("[data-node],[data-table]") === null))
+        return;
+      const svg = stage.querySelector("svg"); if (!svg) return;
+      const [px, py] = toViewBox(e, svg);
+      drag = { px, py, x: view.x, y: view.y };
+      stage.setPointerCapture(e.pointerId);
+      stage.classList.add("grabbing");
+    });
+    stage.addEventListener("pointermove", (e) => {
+      if (!drag) return;
+      const svg = stage.querySelector("svg"); if (!svg) return;
+      const [px, py] = toViewBox(e, svg);
+      view.x = drag.x + (px - drag.px);
+      view.y = drag.y + (py - drag.py);
+      applyView();
+    });
+    const end = (e) => {
+      if (!drag) return;
+      drag = null;
+      stage.classList.remove("grabbing");
+      if (e.pointerId != null && stage.hasPointerCapture?.(e.pointerId))
+        stage.releasePointerCapture(e.pointerId);
+    };
+    stage.addEventListener("pointerup", end);
+    stage.addEventListener("pointercancel", end);
+
+    $("z-in").addEventListener("click", () => zoomAt(VW / 2, VH / 2, 1.25));
+    $("z-out").addEventListener("click", () => zoomAt(VW / 2, VH / 2, 1 / 1.25));
+    $("z-home").addEventListener("click", () => {
+      open.origin = open.collector = open.bronze = false;
+      table = "otel_logs";
+      service = null;
+      repaint();
+      fit();
+    });
+  }
+
+  /* ── health board ──────────────────────────────────────────
+   *
+   * Not a second flow diagram. Health answers three questions the pipeline view cannot:
+   * what state is it in and why, what has it been doing for the last few minutes, and how
+   * far is the tail from the mean. Everything here is either a window or a distribution —
+   * an instantaneous 0/s says nothing, because it looks the same whether the number has
+   * been zero all day or dropped from a spike one second ago.
+   */
+  let hist = [];
+  const HIST_MAX = 300;
+  let ceiling = 80;
+
+  /** A sparkline over the window, with the current value emphasised at the endpoint. */
+  function spark(parent, x, y, w, h, key, colour) {
+    const pts = hist.slice(-120);
+    if (pts.length < 2) {
+      parent.append(el("text", { class: "sub", x, y: y + h / 2 }, "collecting…"));
+      return 0;
+    }
+    const vals = pts.map((p) => p[key] || 0);
+    const max = Math.max(...vals, 1e-9);
+    const step = w / (pts.length - 1);
+    const yy = (v) => y + h - (v / max) * h;
+    const d = vals.map((v, i) => `${i ? "L" : "M"}${(x + i * step).toFixed(1)} ${yy(v).toFixed(1)}`).join(" ");
+    parent.append(el("path", { d: `${d} L${x + w} ${y + h} L${x} ${y + h} Z`,
+      fill: colour, opacity: .13, stroke: "none" }));
+    parent.append(el("path", { d, fill: "none", stroke: colour, "stroke-width": 1.4,
+      "stroke-linejoin": "round" }));
+    parent.append(el("circle", { cx: x + w, cy: yy(vals[vals.length - 1]), r: 2.6, fill: colour }));
+    return max;
+  }
+
+  /** Mode over time as coloured regions. Length of a region is time spent in that state —
+   *  the one panel that says WHEN something changed and for how long. */
+  function timeline(parent, x, y, w, h) {
+    const pts = hist.slice(-120);
+    if (pts.length < 2) return;
+    const step = w / pts.length;
+    const paint = { stream: "var(--pri)", batch: "var(--sec)", idle: "var(--rule)" };
+    let i = 0;
+    while (i < pts.length) {
+      let j = i;
+      while (j + 1 < pts.length && pts[j + 1].m === pts[i].m) j++;
+      parent.append(el("rect", { x: x + i * step, y, width: Math.max(1, (j - i + 1) * step),
+        height: h, fill: paint[pts[i].m] || "var(--rule)", opacity: pts[i].m === "idle" ? .5 : .8 }));
+      i = j + 1;
+    }
+  }
+
+  function renderHealth() {
+    const r = snap || {};
+    const svg = el("svg", { viewBox: `0 0 ${VW} ${VH}`, preserveAspectRatio: "xMidYMid meet" });
+    const state = r.health || "idle";
+    const tone = { ok: "var(--pri)", warn: "var(--sec)", fail: "var(--alarm)", idle: "var(--dim2)" }[state];
+
+    // ── verdict: the state, and the sentence behind it ──
+    svg.append(el("rect", { class: "nd", x: 30, y: 26, width: 940, height: 58, rx: 5,
+        style: `stroke:${tone}` }),
+      el("circle", { cx: 56, cy: 55, r: 7, fill: tone }),
+      el("text", { class: "vtitle", x: 76, y: 50, style: `fill:${tone}` }, state.toUpperCase()),
+      el("text", { class: "sub", x: 76, y: 68 }, r.health_note || ""),
+      el("text", { class: "sub", x: 950, y: 50, style: "text-anchor:end" },
+        `window ${Math.min(hist.length, 120)}s`),
+      el("text", { class: "sub", x: 950, y: 68, style: "text-anchor:end" },
+        `policy · ${graph?.contract?.validation || ""}`));
+
+    // ── four rolling series: current, mean over the window, peak ──
+    const sum = (o) => Object.values(o || {}).reduce((a, b) => a + b, 0);
+    const rows = [
+      ["INGEST",   "in", "var(--pri)",   sum(r.ingest_rate)],
+      ["STORED",   "st", "var(--ter)",   r.persist_rate || 0],
+      ["FLUSHES",  "fl", "var(--sec)",   r.flush_rate || 0],
+      ["REJECTED", "rj", "var(--alarm)", sum(r.reject_rate)],
+    ];
+    rows.forEach(([label, key, colour, now], i) => {
+      const y = 104 + i * 62;
+      const vals = hist.slice(-120).map((h) => h[key] || 0);
+      const avg = vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : 0;
+      const peak = vals.length ? Math.max(...vals) : 0;
+      svg.append(el("text", { class: "lbl", x: 30, y: y + 14 }, label),
+        el("text", { class: "big", x: 30, y: y + 40, style: `fill:${colour}` }, fmt(now) + "/s"),
+        el("text", { class: "sub", x: 152, y: y + 26 }, `avg ${fmt(avg)}`),
+        el("text", { class: "sub", x: 152, y: y + 40 }, `peak ${fmt(peak)}`));
+      spark(svg, 236, y + 2, 430, 44, key, colour);
+    });
+
+    // ── the tail the mean hides ──
+    const lat = [["p50", r.export_latency_p50], ["p90", r.export_latency_p90],
+                 ["p99", r.export_latency_p99]];
+    const over = (r.export_latency_p99 || 0) > ceiling;
+    svg.append(el("rect", { class: "nd", x: 706, y: 104, width: 264, height: 152, rx: 5,
+        style: over ? "stroke:var(--sec)" : null }),
+      el("text", { class: "lbl", x: 726, y: 128 }, "EXPORT LATENCY"),
+      el("text", { class: "sub", x: 950, y: 128, style: "text-anchor:end" },
+        `mean ${fmt(r.export_latency_ms)} ms`));
+    const lmax = Math.max(ceiling, r.export_latency_p99 || 0, 1);
+    lat.forEach(([name, v], i) => {
+      const y = 152 + i * 32;
+      svg.append(el("text", { class: "sub", x: 726, y: y + 9 }, name),
+        el("rect", { x: 762, y, width: 168, height: 10, rx: 5, fill: "var(--rule)" }),
+        el("rect", { x: 762, y, width: Math.max(3, ((v || 0) / lmax) * 168), height: 10, rx: 5,
+          fill: i === 2 && over ? "var(--sec)" : "var(--pri)" }),
+        el("text", { class: "sub", x: 950, y: y + 9, style: "text-anchor:end" },
+          fmt(v) + " ms"));
+    });
+    svg.append(el("line", { x1: 762 + (ceiling / lmax) * 168, y1: 146,
+      x2: 762 + (ceiling / lmax) * 168, y2: 250, stroke: "var(--sec)",
+      "stroke-width": 1, "stroke-dasharray": "3 3", opacity: .8 }),
+      el("text", { class: "sub", x: 726, y: 248 }, `ceiling ${ceiling} ms`));
+
+    // ── mode over time ──
+    svg.append(el("text", { class: "lbl", x: 706, y: 292 }, "MODE OVER TIME"));
+    timeline(svg, 706, 300, 264, 16);
+    svg.append(el("text", { class: "sub", x: 706, y: 330 },
+      hist.length ? `${hist[0]?.m || ""} → ${r.mode || ""}` : "collecting…"));
+
+    // ── rejections split by reason, because they are different problems ──
+    const reasons = [
+      ["contract", "bad payload · still exported under warn", "var(--sec)"],
+      ["backpressure", "batch refused · producer retries", "var(--sec)"],
+    ];
+    svg.append(el("text", { class: "lbl", x: 30, y: 366 }, "WHY SIGNALS ARE REFUSED"));
+    reasons.forEach(([key, what, colour], i) => {
+      const y = 380 + i * 30, v = (r.reject_by_reason || {})[key] || 0;
+      svg.append(el("text", { class: "sub", x: 30, y: y + 9 }, key),
+        el("rect", { x: 128, y, width: 180, height: 9, rx: 4, fill: "var(--rule)" }),
+        el("rect", { x: 128, y, width: v > 0 ? 180 : 2, height: 9, rx: 4,
+          fill: v > 0 ? colour : "var(--rule)" }),
+        el("text", { class: "sub", x: 322, y: y + 9 }, `${fmt(v)}/s · ${what}`));
+    });
+
+    // ── cumulative, for scale ──
+    svg.append(el("text", { class: "lbl", x: 706, y: 366 }, "SINCE START"),
+      el("text", { class: "sub", x: 706, y: 386 },
+        `${fmt((r.totals || {}).persisted)} stored`),
+      el("text", { class: "sub", x: 706, y: 402 },
+        `${fmt(r.export_errors)} batches lost · no dead-letter queue`));
+
+    $("stage-h").replaceChildren(svg);
+    $("legend-h").innerHTML = `<span class="on" style="color:${tone}">● ${state}</span>
+      <span>${r.health_note || ""}</span>
+      <span class="sp">series are a <b>${Math.min(hist.length, 120)}s window</b></span>
+      <span>counts are <b>aggregate</b>, never per trace</span>`;
+  }
+
+  /* ── per-tick visibility ───────────────────────────────────── */
+  function density(s) {
+    const ing = s.ingest_rate || {};
+    show("logs", dots(ing.logs || 0));
+    show("trace", dots(ing.trace || 0));
+    show("metrics", dots(ing.metrics || 0));
+    const inFlight = Math.min(3, Math.round((s.flush_rate || 0) * 3.2 / 2));
+    show("blk", inFlight);
+    show("burst", inFlight);
+    const total = Object.values(ing).reduce((a, z) => a + z, 0);
+    const rej = Object.values(s.reject_rate || {}).reduce((a, z) => a + z, 0);
+    const live = total > 0 ? 1 : 0;
+    // Inside a container every hop carries all three types, so each is shown or hidden
+    // on its own rather than as a single lane.
+    for (let i = 0; i < 12; i++)
+      LANES.forEach(([n]) => show(`oe${i}-${n}`, live * ((ing[n] || 0) > 0 ? 2 : 0)));
+    for (let i = 0; i < 2; i++)
+      LANES.forEach(([n]) => show(`ce${i}-${n}`, live * ((ing[n] || 0) > 0 ? 2 : 0)));
+    // Each strand runs on THAT table's growth. `bronze_rate` is per table, so gating all
+    // four on one estate-wide figure had the logs strand moving through a metrics-only
+    // scenario — the same defect as a hard-coded colour, moved into the gate.
+    const tnames = Object.keys(graph?.tables || {});
+    for (let i = 0; i < 6; i++)
+      show(`be${i}`, ((s.bronze_rate || {})[tnames[i]] || 0) > 0 ? 3 : 0);
+    // Each tap runs only while its own outcome is happening. A pipeline losing nothing
+    // should have three still lines, not three animations implying otherwise.
+    //
+    // And per SIGNAL TYPE, not per tap: `reject_matrix` is the `signal` × `reason`
+    // cross-product, so if only metrics fail the contract, exactly one amber dot falls.
+    // The previous version ran a single hard-coded pool per tap, which meant every
+    // rejection of any type fell amber — right by accident for metrics, wrong for the
+    // other two.
+    const byReason = s.reject_by_reason || {};
+    const mx = s.reject_matrix || {};
+    ["contract", "backpressure"].forEach((reason, i) => {
+      const per = mx[reason] || {};
+      LANES.forEach(([n]) => {
+        const on = (per[n] || 0) > 0 ? 2 : 0;
+        show(`tap${i}-${n}`, on);
+        show(`ret${i}-${n}`, on);   // absent unless this outcome carries data back
+      });
+    });
+    // The drop is the one payload whose type is not measured — one mixed sphere, ringed.
+    show("tap2", (s.drop_rate || 0) > 0 ? 2 : 0);
+    // The lines themselves brighten here rather than at render: whether an outcome is
+    // live is throughput, not structure, and gating it on a repaint left a tap dim while
+    // dots were visibly falling down it.
+    [(byReason.contract || 0) > 0, (byReason.backpressure || 0) > 0, (s.drop_rate || 0) > 0]
+      .forEach((on, i) => ["tap", "tapv", "ret"].forEach((pre) =>
+        $(`${pre}${i}`)?.classList.toggle("live", on)));
+    show("h-ok", (s.persist_rate || 0) > 0 ? 4 : 0);
+    show("h-rej", rej > 0 ? 2 : 0);
+    show("h-drop", (s.drop_rate || 0) > 0 ? 2 : 0);
+  }
+
+  /* ── structural repaint ────────────────────────────────────── */
+  function repaint() {
+    const key = [snap?.mode || "", graph ? 1 : 0, open.origin, open.collector, open.bronze,
+                 table, service].join("|");
+    if (key === painted) return false;
+    const first = painted === "";
+    painted = key;
+    render();
+    renderHealth();
+    if (first) fit();
+    return true;
+  }
+
+  const set = (id, v) => { const n = $(id); if (n) n.textContent = v; };
+  function apply(s) {
+    snap = s;
+    const ing = Object.values(s.ingest_rate || {}).reduce((a, z) => a + z, 0);
+    const rej = Object.values(s.reject_rate || {}).reduce((a, z) => a + z, 0);
+    set("t-in", fmt(ing)); set("t-fl", fmt(s.flush_rate)); set("t-bt", fmt(s.records_per_flush));
+    set("t-lt", fmt(s.export_latency_ms)); set("t-ps", fmt(s.persist_rate)); set("t-rj", fmt(rej));
+    $("tile-rj")?.classList.toggle("bad", rej > 0);
+    $("m-col")?.setAttribute("data-up", s.collector_up ? "y" : "n");
+    $("m-ch")?.setAttribute("data-up", s.clickhouse_up ? "y" : "n");
+    hist.push({ t: s.ts, in: sum2(s.ingest_rate), fl: s.flush_rate, lat: s.export_latency_ms,
+      st: s.persist_rate, rj: sum2(s.reject_rate), dr: s.drop_rate, m: s.mode });
+    if (hist.length > HIST_MAX) hist.shift();
+    // Health only draws when it is on screen. It has no animation to preserve, but
+    // rebuilding a chart nobody is looking at, once a second, is work for nothing.
+    if (!$("v-health").hidden) renderHealth();
+    if (repaint()) return;          // structural only; throughput never rebuilds
+    density(s);
+  }
+  const sum2 = (o) => Object.values(o || {}).reduce((a, b) => a + b, 0);
+
+  /* ── palette · dashboards · stream ─────────────────────────── */
+  const setWorld = (w) => {
+    document.documentElement.dataset.world = w;
+    $("pal").setAttribute("aria-pressed", String(w === "substrate"));
+    try { localStorage.setItem("sentinel.world", w); } catch (_) { /* private mode */ }
+  };
+  let saved = "command";
+  try { saved = localStorage.getItem("sentinel.world") || "command"; } catch (_) { /* ignore */ }
+  setWorld(saved);
+  $("pal").addEventListener("click", () =>
+    setWorld(document.documentElement.dataset.world === "command" ? "substrate" : "command"));
+
+  const dtabs = [...document.querySelectorAll('[role="tab"]')];
+  dtabs.forEach((t, i) => t.addEventListener("click", () => {
+    dtabs.forEach((x, k) => {
+      const on = k === i;
+      x.setAttribute("aria-selected", String(on));
+      x.tabIndex = on ? 0 : -1;
+      $(x.getAttribute("aria-controls")).hidden = !on;
+    });
+    if (!$("v-health").hidden) renderHealth();
+  }));
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") $("z-home").click();
+  });
+
+  wireViewport();
+  render(); fit();
+  // Seed from the server's window so a page opened now shows the last few minutes rather
+  // than an empty chart, and two viewers see the same history.
+  fetch("/api/history").then((r) => r.json()).then((h) => {
+    hist = h.points || [];
+    ceiling = h.ceiling_ms || ceiling;
+    if (!$("v-health").hidden) renderHealth();
+  }).catch(() => {});
+  fetch("/api/graph").then((r) => r.json()).then((g) => { graph = g; painted = ""; repaint(); fit(); })
+    .catch(() => {});
+  const es = new EventSource("/stream");
+  es.onmessage = (e) => { try { apply(JSON.parse(e.data)); } catch (_) { /* bad frame */ } };
+})();

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -163,6 +163,11 @@
     // three types are a property of every service, not of any one of them.
     const o = boxes.origin, c = boxes.collector, b = boxes.bronze;
     o.out = [0.28, 0.5, 0.72].map((f) => [o.x + o.w, o.y + o.h * f]);
+    // The node grid is laid out in the height the box has WITHOUT the signal panel. Selecting
+    // a service grows the container by 138px to make room for that panel, and spreading the
+    // nodes across the taller box pushed the lower rows straight underneath it — the panel
+    // covered the very nodes it describes. The extra height belongs to the panel alone.
+    o.gridH = SIZE.origin.open[1];
 
     // Stage geometry lives in the layout, not in the body renderer, so the lanes coming
     // from ORIGIN can land on `receive` and the lane leaving for BRONZE can start at
@@ -320,7 +325,7 @@
     t.nodes.forEach((n) => (cols[depth[n.id] ?? 0] ||= []).push(n));
     const NW = 196, NH = 42, pos = {};
     Object.entries(cols).forEach(([d, list]) => list.forEach((n, i) => {
-      const step = (b.h - 56) / list.length;
+      const step = ((b.gridH || b.h) - 56) / list.length;
       pos[n.id] = { x: b.x + 20 + (+d) * (NW + 52), y: b.y + 44 + step * i + (step - NH) / 2 };
     }));
     // Internal edges first, so nodes paint over them.
@@ -397,7 +402,7 @@
 
   function collectorBody(g, b, edges, fx) {
     const r = snap || {};
-    const policy = graph?.contract?.validation || "warn";
+    const policy = policyOf();
     const byReason = r.reject_by_reason || {};
     if (!open.collector) {
       g.append(
@@ -685,7 +690,13 @@
         "aria-label": `${open[id] ? "Collapse" : "Expand"} ${TITLE[id]}` });
       g.dataset.node = id;
       g.append(el("rect", { class: "nd" + (open[id] ? " open" : ""), x: b.x, y: b.y,
-          width: b.w, height: b.h, rx: 5 }),
+          width: b.w, height: b.h, rx: 5 }));
+      // Open, only the header carries the click. The full-size rect covers everything drawn
+      // inside the container, so leaving it hit-testable meant the pointer was always over
+      // the container even while aiming at a table inside it.
+      if (open[id]) g.append(el("rect", { class: "chrome", x: b.x, y: b.y,
+        width: b.w, height: 38, rx: 5 }));
+      g.append(
         el("text", { class: "lbl", x: b.x + 18, y: b.y + 26 }, TITLE[id]),
         el("text", { class: "cue", x: b.x + b.w - 18, y: b.y + 26,
           style: "text-anchor:end" }, open[id] ? "CLOSE ▾" : "OPEN ▸"));
@@ -849,7 +860,9 @@
       parent.append(el("text", { class: "sub", x, y: y + h / 2 }, "collecting…"));
       return 0;
     }
-    const vals = pts.map((p) => p[key] || 0);
+    // `key` may be a field name or a reader, because the contract board charts one slot
+    // of an array (`rc`/`rb` carry the per-signal split) and a field name cannot say that.
+    const vals = pts.map(typeof key === "function" ? key : (p) => p[key] || 0);
     const max = Math.max(...vals, 1e-9);
     const step = w / (pts.length - 1);
     const yy = (v) => y + h - (v / max) * h;
@@ -975,6 +988,285 @@
       <span>counts are <b>aggregate</b>, never per trace</span>`;
   }
 
+  /** The receive-boundary policy, or `unknown` — never a guess. `warn` is the collector's
+   *  own default, which makes it precisely the wrong fallback: a board showing `warn`
+   *  because it has not loaded `/api/graph` yet is indistinguishable from one reading a
+   *  real `warn`, and knowing which is the entire point of the panel. */
+  const policyOf = () => graph?.contract?.validation || "unknown";
+
+  /** Whichever board is visible, redrawn. Adding a third panel to three separate
+   *  `hidden` tests is how one of them gets forgotten. */
+  const drawBoards = () => {
+    if (!$("v-health").hidden) renderHealth();
+    if (!$("v-contract").hidden) renderContract();
+    if (!$("v-watch").hidden) renderWatch();
+  };
+
+  /* ── contract board ────────────────────────────────────────
+   *
+   * V2.1. The receive boundary is the one place in this pipeline where a contract is
+   * actually enforced, and until now nothing rendered it. Two sources, and the split
+   * between them is the whole design:
+   *
+   *   the collector  knows HOW MANY violated and HOW (`signals_rejected_total{signal,
+   *                  reason}`) but not WHO — its counters carry no service label.
+   *   bronze         knows WHO, because under the default `warn` policy a violating
+   *                  signal is exported anyway and the evidence lands in the table.
+   *
+   * One thing V2.1 asked for is NOT here and cannot be: contract-version adoption per
+   * producer. `collector-rust/src/otlp.rs` injects `CONTRACT_VERSION` into every signal it
+   * builds — "OTLP carries no contract_version field" — so every producer reads back the
+   * collector's own constant. The panel would show 1.0.0 for everyone and mean nothing.
+   */
+  function renderContract() {
+    const r = snap || {};
+    const policy = policyOf();
+    const svg = el("svg", { viewBox: `0 0 ${VW} ${VH}`, preserveAspectRatio: "xMidYMid meet" });
+    const byReason = r.reject_by_reason || {};
+    const contract = byReason.contract || 0;
+    const ingest = Object.values(r.ingest_rate || {}).reduce((a, z) => a + z, 0);
+
+    // ── the counterfactual, as the headline ──
+    //
+    // Under `warn` the collector counts what it would have dropped and exports it anyway,
+    // so this number IS the answer to "what happens if we promote to strict" — measured,
+    // not modelled. Under `off` the same counter reads zero for a completely different
+    // reason, and saying so is the difference between evidence and a false all-clear.
+    const off = policy === "off", strict = policy === "strict";
+    const unknown = policy === "unknown";
+    // Three different reasons this number can be zero, and only one of them is good news.
+    // `off` means nothing is checked; `idle` means nothing arrived to check; clean means
+    // traffic came through and passed. Collapsing them into one green headline is the
+    // false all-clear this board exists to prevent.
+    const idle = ingest <= 0;
+    const clean = !off && !unknown && !idle && contract <= 0;
+    const tone = off || unknown || idle ? "var(--dim2)" : contract > 0 ? "var(--sec)" : "var(--pri)";
+    const head = unknown ? "POLICY UNREADABLE"
+      : off ? "NOT MEASURED"
+      : idle ? "NO TRAFFIC"
+      : strict ? `${fmt(contract)}/s discarded at the boundary`
+      : `${fmt(contract)}/s would be dropped under strict`;
+    const note = unknown
+      ? "the collector config is not mounted — the counters below are real, the policy is not known"
+      : off
+        ? "validation is off — this zero means nothing is checked, not that nothing is wrong"
+      : idle
+        ? "nothing is arriving, so nothing is being validated — the series below still hold the window"
+      : strict ? "already dropping. flip to warn to keep the data while you fix producers"
+      : clean
+        ? "traffic is flowing and passing · this is the only zero that is good news"
+        : `flagged and exported anyway · ${(contract / ingest * 100).toFixed(2)}% of throughput`;
+    svg.append(el("rect", { class: "nd", x: 30, y: 26, width: 940, height: 62, rx: 5,
+        style: `stroke:${tone}` }),
+      el("text", { class: "lbl", x: 52, y: 46 }, "GRPC_VALIDATION"),
+      el("text", { class: "vtitle", x: 52, y: 70, style: `fill:${tone}` }, policy.toUpperCase()),
+      el("text", { class: "big", x: 950, y: 56, style: `text-anchor:end;fill:${tone}` }, head),
+      el("text", { class: "sub", x: 950, y: 74, style: "text-anchor:end" }, note));
+
+    // ── violation rate over the window, per signal ──
+    //
+    // Split by type rather than totalled: `signals_rejected_total` is labelled by both
+    // `signal` and `reason`, so "which type is failing" is measured. A single line would
+    // throw away the only thing that tells a metrics problem from a logs problem.
+    const cols = [
+      ["FAILING THE CONTRACT", "rc", "contract", 30,
+       "at validate · under warn these still reach bronze"],
+      ["REFUSED BY THE BUFFER", "rb", "backpressure", 520,
+       "backpressure · the producer was told to retry"],
+    ];
+    cols.forEach(([title, key, reason, x, sub]) => {
+      svg.append(el("text", { class: "lbl", x, y: 116 }, title),
+        el("text", { class: "sub", x, y: 130 }, sub));
+      LANES.forEach(([name, cls], i) => {
+        const colour = { p1: "var(--pri)", p2: "var(--ter)", p3: "var(--sec)" }[cls];
+        const y = 146 + i * 34;
+        const now = ((r.reject_matrix || {})[reason] || {})[name] || 0;
+        svg.append(el("text", { class: "sub", x, y: y + 20 }, name));
+        // `spark` returns the peak it scaled to. Without it the shape has no units: a hump
+        // reads the same at 4/s and 4000/s, and the figure beside it is the tick, not the
+        // window. Two numbers, and the labels say which is which.
+        const peak = spark(svg, x + 66, y, 250, 26, (p) => (p[key] || [])[i] || 0, colour);
+        svg.append(el("text", { class: "val", x: x + 372, y: y + 20,
+            style: `fill:${colour}` }, fmt(now) + "/s"),
+          el("text", { class: "sub", x: x + 380, y: y + 20 },
+            peak > 1e-6 ? `peak ${fmt(peak)}` : ""));
+      });
+    });
+
+    // ── who, from bronze ──
+    svg.append(el("text", { class: "lbl", x: 30, y: 272 }, "WHO IS VIOLATING"),
+      el("text", { class: "sub", x: 168, y: 272 },
+        "from bronze — the rows that landed anyway, so the evidence outlives the tick"));
+    const rows = r.contract_violations || [];
+    if (!rows.length) {
+      svg.append(el("text", { class: "sub", x: 30, y: 300 },
+        graph ? "no producer is missing a required key" : "collecting…"));
+    }
+    rows.slice(0, 4).forEach((v, i) => {
+      const y = 286 + i * 38;
+      // Share of that producer's ROWS, not of its key slots. The sum of per-key counts
+      // over-counts a row missing four keys as four, which read as "80%" for a producer
+      // whose every row is bad.
+      const share = v.rows > 0 ? (v.violating / v.rows) * 100 : 0;
+      const keys = Object.keys(v.missing);
+      svg.append(el("rect", { class: "nd sub-nd", x: 30, y, width: 940, height: 32, rx: 3,
+          style: "stroke:var(--sec)" }),
+        el("text", { class: "txt", x: 44, y: y + 20 }, clip(v.service, 26)),
+        el("text", { class: "sub", x: 260, y: y + 20 },
+          `${fmt(v.violating)} of ${fmt(v.rows)} rows`),
+        el("text", { class: "sub", x: 396, y: y + 20, style: "fill:var(--sec)" },
+          `${keys.length} of 5 keys missing · ` + keys.join(" · ")),
+        el("text", { class: "val", x: 956, y: y + 20, style: "fill:var(--sec)" },
+          share.toFixed(0) + "%"));
+    });
+
+    $("stage-c").replaceChildren(svg);
+    // The mode has no timeline because it has no history: `grpc_validation` is read from
+    // the collector's config at startup and is not exposed as a metric, so it cannot
+    // change without a restart. Drawing a state strip over a constant would invent one.
+    $("legend-c").innerHTML = `<span class="on" style="color:${tone}">● policy <b>${policy}</b></span>
+      <span>set at collector startup · not a metric, so it cannot change mid-window</span>
+      <span class="sp">series are a <b>${Math.min(hist.length, 120)}s window</b></span>
+      <span>producer rows refresh every <b>30s</b></span>`;
+  }
+
+  /* ── watchers board ────────────────────────────────────────
+   *
+   * V2.2, volume. Every competitor surveyed keeps its estimator private; the one credible
+   * wedge available to an open project is to publish the algorithm, the window and the
+   * meaning of the threshold — so the header states all three rather than saying
+   * "ML-powered".
+   *
+   * The band drawn here IS the alerting rule: both come from `volume_state`, one place, one
+   * set of numbers. Metaplane shipped a version where they were computed separately and
+   * publicly called reconciling them a simplification.
+   */
+  //: Rank, tone, label. The two alerting severities used to differ ONLY by colour — both
+  //: read "alerting" — which this repo's own rule forbids: colour is never the sole carrier.
+  //: The label now names the threshold that was crossed, which doubles as publishing the
+  //: rule on every row.
+  const WSTATE = {
+    fail:        [0, "var(--alarm)", "alerting ≥5σ"],
+    warn:        [1, "var(--sec)",   "alerting ≥3σ"],
+    unmonitored: [2, "var(--dim2)",  "not monitored"],
+    passing:     [3, "var(--pri)",   "passing"],
+  };
+
+  /** One producer's series with its band behind it. The band is a filled region, not a pair
+   *  of lines, because it is a region: "inside" is the whole claim. */
+  function bandSpark(parent, x, y, w, h, v) {
+    const pts = v.series || [];
+    const vals = pts.map((p) => p[1]);
+    const lo = Math.min(v.lo, ...vals, v.median), hi = Math.max(v.hi, ...vals, v.median);
+    const span = Math.max(hi - lo, 1e-9);
+    const yy = (n) => y + h - ((n - lo) / span) * h;
+    const mon = v.state !== "unmonitored";
+    if (mon) {
+      parent.append(el("rect", { x, y: yy(v.hi), width: w, height: Math.max(1, yy(v.lo) - yy(v.hi)),
+        fill: "var(--pri)", opacity: .10 }));
+      parent.append(el("line", { x1: x, y1: yy(v.median), x2: x + w, y2: yy(v.median),
+        stroke: "var(--dim2)", "stroke-width": 1, "stroke-dasharray": "3 4", opacity: .7 }));
+    }
+    if (pts.length < 2) return;
+    // Buckets are plotted on their own timestamps, so a gap in the series is a gap on the
+    // chart — a producer that went quiet leaves a hole rather than a straight line across
+    // the absence, which is exactly the thing being measured.
+    const t0 = pts[0][0], t1 = pts[pts.length - 1][0], dt = Math.max(t1 - t0, 1);
+    const px = (t) => x + ((t - t0) / dt) * w;
+    parent.append(el("path", { fill: "none", stroke: mon ? "var(--txt)" : "var(--dim2)",
+      "stroke-width": 1.3, "stroke-linejoin": "round",
+      d: pts.map((p, i) => `${i ? "L" : "M"}${px(p[0]).toFixed(1)} ${yy(p[1]).toFixed(1)}`).join(" ") }));
+    // Only the points the rule would actually alert on are marked, so the dots and the
+    // band can never disagree about what counts as an exception.
+    if (mon) pts.filter((p) => p[1] < v.lo || p[1] > v.hi).forEach((p) =>
+      parent.append(el("circle", { cx: px(p[0]), cy: yy(p[1]), r: 2.4, fill: "var(--alarm)" })));
+  }
+
+  function renderWatch() {
+    const r = snap || {};
+    const rows = r.volume || [];
+    const svg = el("svg", { viewBox: `0 0 ${VW} ${VH}`, preserveAspectRatio: "xMidYMid meet" });
+
+    // ── the method, published ──
+    svg.append(el("rect", { class: "nd", x: 30, y: 18, width: 940, height: 58, rx: 5 }),
+      el("text", { class: "lbl", x: 48, y: 36 }, "VOLUME · ROWS PER MINUTE, PER PRODUCER"),
+      el("text", { class: "sub", x: 48, y: 52 },
+        "median ± 3σ, σ from MAD × 1.4826 · stddev only where MAD collapses · "
+        + "60-minute sliding window · 1-minute buckets, current one excluded (partial) · "
+        + "warn 3σ · fail 5σ"),
+      // Two different time scopes on one row, and a row marked PASSING with red points on
+      // its series is unreadable until you are told which is which.
+      el("text", { class: "sub", x: 48, y: 66 },
+        "the verdict is the LATEST complete bucket · marked points are every bucket in the "
+        + "window the same rule would have alerted on"));
+
+    if (!rows.length) {
+      svg.append(el("text", { class: "sub", x: 30, y: 140 },
+        graph ? "no producer has enough buckets yet" : "collecting…"));
+    }
+    // Severity first, then a producer that went silent, then size. A watcher board sorted by
+    // volume buries its one interesting row among seven identical ones; median stays as the
+    // tiebreak so the order is otherwise stable tick to tick.
+    const ranked = [...rows].sort((a, z) =>
+      (WSTATE[a.state] || WSTATE.unmonitored)[0] - (WSTATE[z.state] || WSTATE.unmonitored)[0]
+      || (z.absent > 0) - (a.absent > 0) || z.median - a.median);
+    // What the eight rows add up to, so the answer does not require counting them.
+    const tally = (f) => ranked.filter(f).length;
+    const alerting = tally((v) => v.state === "warn" || v.state === "fail");
+    const grey = tally((v) => v.state === "unmonitored");
+    const silent = tally((v) => v.absent > 0);
+    const fallback = tally((v) => v.estimator === "stddev");
+    svg.append(el("text", { class: "sub", x: 30, y: 92 },
+      `${ranked.length} producers · ${alerting} alerting · ${grey} not monitored · `
+      + `${silent} silent in some bucket · ${fallback} on the stddev fallback`));
+    // Seven bare figures per row and nothing saying which is which. Every column is named,
+    // and the names carry their units, so a row can be read without the legend.
+    [["PRODUCER", 30, ""], ["LAST 60 MIN · SHADED BAND = THE RULE", 210, ""],
+     ["LATEST", 604, "text-anchor:end"], ["DISTANCE FROM MEDIAN", 616, ""],
+     // "VERDICT · COVERAGE" grew right from 800 into "ESTIMATOR · FIT" growing left from
+     // 956 and the two interleaved. The coverage line under each verdict already carries
+     // its own unit ("34/34 buckets"), so the header does not need to repeat it.
+     ["VERDICT", 800, ""], ["ESTIMATOR · FIT", 956, "text-anchor:end"],
+    ].forEach(([t, x, style]) =>
+      svg.append(el("text", { class: "lbl", x, y: 110, style: style || null }, t)));
+    svg.append(el("line", { x1: 30, y1: 116, x2: 970, y2: 116,
+      stroke: "var(--rule)", "stroke-width": 1 }));
+    ranked.slice(0, 8).forEach((v, i) => {
+      const y = 124 + i * 39, [, tone, label] = WSTATE[v.state] || WSTATE.unmonitored;
+      svg.append(el("text", { class: "txt", x: 30, y: y + 22 }, clip(v.service, 24)));
+      bandSpark(svg, 210, y + 4, 330, 30, v);
+      svg.append(
+        el("text", { class: "val", x: 604, y: y + 22, style: `fill:${tone}` }, fmt(v.latest)),
+        el("text", { class: "sub", x: 616, y: y + 22 },
+          v.state === "unmonitored" ? v.why : `${v.z}σ · median ${fmt(v.median)}`),
+        el("text", { class: "lbl", x: 800, y: y + 18, style: `fill:${tone}` },
+          label.toUpperCase()),
+        // A separate axis from the band: the estate received something in these buckets and
+        // this producer did not. Absence, as a signal — the one a table at rest cannot give.
+        el("text", { class: "sub", x: 800, y: y + 30,
+            style: v.absent > 0 ? "fill:var(--alarm)" : "fill:var(--dim)" },
+          v.absent > 0 ? `silent in ${v.absent} of ${v.estate} buckets`
+                       : `${v.seen}/${v.estate} buckets`),
+        // Which estimator won, and how well its band actually fits the window it was built
+        // from. `oob` is the number that decided: a band rejecting its own training data is
+        // describing one mode of it, not the series.
+        // One line, not two: end-anchored at 956 it ran left into the bucket count growing
+        // right from 800, and they collided into "31/31 bucket5% of window out of band".
+        el("text", { class: "sub", x: 956, y: y + 22, style: "text-anchor:end" },
+          (v.estimator === "none" ? "—" : v.estimator)
+          + (v.oob == null ? "" : ` · ${(v.oob * 100).toFixed(0)}% oob`)));
+    });
+
+    $("stage-w").replaceChildren(svg);
+    $("legend-w").innerHTML =
+      `<span><span class="gl" style="background:var(--pri)"></span>passing</span>
+       <span><span class="gl" style="background:var(--sec)"></span>alerting ≥3σ</span>
+       <span><span class="gl" style="background:var(--alarm)"></span>alerting ≥5σ</span>
+       <span><span class="gl" style="background:var(--dim2)"></span>not monitored — grey is <b>not observed</b>, never fine</span>
+       <span class="sp">the shaded band <b>is</b> the alerting rule</span>
+       <span>bronze event time · <b>not</b> arrival</span>`;
+  }
+
   /* ── per-tick visibility ───────────────────────────────────── */
   function density(s) {
     const ing = s.ingest_rate || {};
@@ -1056,9 +1348,9 @@
     hist.push({ t: s.ts, in: sum2(s.ingest_rate), fl: s.flush_rate, lat: s.export_latency_ms,
       st: s.persist_rate, rj: sum2(s.reject_rate), dr: s.drop_rate, m: s.mode });
     if (hist.length > HIST_MAX) hist.shift();
-    // Health only draws when it is on screen. It has no animation to preserve, but
+    // A board only draws when it is on screen. Neither has animation to preserve, but
     // rebuilding a chart nobody is looking at, once a second, is work for nothing.
-    if (!$("v-health").hidden) renderHealth();
+    drawBoards();
     if (repaint()) return;          // structural only; throughput never rebuilds
     density(s);
   }
@@ -1084,7 +1376,7 @@
       x.tabIndex = on ? 0 : -1;
       $(x.getAttribute("aria-controls")).hidden = !on;
     });
-    if (!$("v-health").hidden) renderHealth();
+    drawBoards();
   }));
   document.addEventListener("keydown", (e) => {
     if (e.key === "Escape") $("z-home").click();
@@ -1097,7 +1389,7 @@
   fetch("/api/history").then((r) => r.json()).then((h) => {
     hist = h.points || [];
     ceiling = h.ceiling_ms || ceiling;
-    if (!$("v-health").hidden) renderHealth();
+    drawBoards();
   }).catch(() => {});
   fetch("/api/graph").then((r) => r.json()).then((g) => { graph = g; painted = ""; repaint(); fit(); })
     .catch(() => {});

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -111,9 +111,18 @@
    *  BORE carries the id, so `animateMotion` puts the dots on its centreline and they read
    *  as travelling through the channel rather than along a wire. `extra` selects the gauge
    *  ("trunk") and any marker the run needs. */
-  const pipe = (parent, id, d, gauge = "", attrs = {}) => {
-    parent.append(el("path", { class: "pw " + gauge, d }),
-                  el("path", { class: "pb " + gauge, id, d, ...attrs }));
+  const pipe = (parent, id, d, gauge = "", attrs = {}, w = null, tone = null) => {
+    // `w` overrides the CSS gauge in user units, so an edge can be as thick as it carries.
+    // The bore keeps a 1.5px wall on each side at every width, which is what makes a thin
+    // pipe read as a thin pipe rather than as a line.
+    //
+    // As `style`, not as an attribute: `.pw{stroke-width:13}` is a stylesheet rule and a
+    // presentation attribute loses to it, so the widths were computed correctly and every
+    // pipe still rendered at its CSS gauge.
+    const pw = w ? { style: `stroke-width:${w.toFixed(1)}` + (tone ? `;stroke:${tone}` : "") } : {};
+    const pb = w ? { style: `stroke-width:${Math.max(4, w - 3).toFixed(1)}` } : {};
+    parent.append(el("path", { class: "pw " + gauge, d, ...pw }),
+                  el("path", { class: "pb " + gauge, id, d, ...attrs, ...pb }));
   };
   /** A pipe mouth: a short lip ACROSS the run, wider than the casing it caps. Every mouth
    *  on this board sits where a horizontal run meets a box, so the lip is a tall, narrow
@@ -400,16 +409,35 @@
     // a 45° elbow, and every edge that changes row would overshoot. The stub is staggered
     // per source, because edges leaving one node share a PORT and would otherwise share a
     // vertical column too — three 13px casings on one x is a blob, not a fan.
+    // Declared edges, drawn at what they were actually measured carrying.
+    //
+    // `topology.yaml` says which component depends on which; the traced call graph says
+    // how much went and how much failed. They are different claims and the picture shows
+    // both: a declared edge nothing was ever traced on is drawn as declared-only, which is
+    // the finding — here `spark_streaming -> processed_bucket` and
+    // `spark_streaming -> k8s-api-gateway` never carry a span, because the generator's
+    // engine parents every child to `depends_on[0]` and never to the second dependency.
+    const svc = Object.fromEntries((t.nodes || []).map((n) => [n.id, n.service]));
+    const measured = {};
+    (snap?.call_edges || []).forEach((e) => (measured[`${e.src}\u0000${e.dst}`] = e));
+    const peak = Math.max(1, ...(snap?.call_edges || []).map((e) => e.spans));
     const legs = {};
     t.edges.forEach((e, i) => {
       const a = pos[e.from], z = pos[e.to];
       if (!a || !z) return;
+      const m = measured[`${svc[e.from]}\u0000${svc[e.to]}`];
+      // Width from the share of the busiest edge, on a root so a 100x range stays legible;
+      // colour from the error rate on that edge, at the thresholds printed in the legend.
+      const w = m ? 8 + Math.sqrt(m.spans / peak) * 12 : 5;
+      const err = m && m.spans ? m.errors / m.spans : 0;
+      const tone = !m ? "var(--dim)"
+        : err >= 0.05 ? "var(--alarm)" : err >= 0.01 ? "var(--sec)" : null;
       // One casing apart, so three legs from one node stay three legs. Clamped to leave
       // the last chamfer room to land, which is what caps the fan at ~3 legs per node.
       const k = (legs[e.from] = (legs[e.from] ?? -1) + 1);
       const gap = z.x - (a.x + NW);
       pipe(edges, `oe${i}`, fan(a.x + NW, a.y + NH / 2, z.x, z.y + NH / 2,
-        Math.min(gap - 12, 14 + k * 14)));
+        Math.min(gap - 12, 14 + k * 14)), m ? "" : "declared", {}, w, tone);
       mouth(a.x + NW, a.y + NH / 2);
       mouth(z.x, z.y + NH / 2);
       flow3(fx, `oe${i}`, `oe${i}`, 2.6 + (i % 3) * .4, 3.2, 2);
@@ -841,7 +869,10 @@
     // With the collector open the same three colours take on a second job — they name
     // which type FAILED — so that rule is spelled out only where falling dots exist.
     if (open.origin) return base
-      + `<span>every producer carries its <b>fused state</b> — volume band, silence, contract keys</span>`;
+      + `<span>producers carry their <b>fused state</b> — volume band, silence, contract keys</span>`
+      + `<span>pipe width = <b>traced spans</b> · <span style="color:var(--sec)">≥1%</span>`
+      + ` / <span style="color:var(--alarm)">≥5%</span> of them failed</span>`
+      + `<span>dashed = <b>declared, never traced</b></span>`;
     return open.collector ? base
       + `<span>leaving the chain = <b>what failed</b></span>
          <span><span class="tri ring"></span>= a <b>lost batch</b>, type unknowable</span>`

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -342,6 +342,13 @@
     return [...seen].filter((n) => n && !declared.has(n)).sort();
   };
 
+  //: Silence has to be MATERIAL before it counts. `absent > 0` fired on every producer:
+  //: a run's first and last minute are partial, so everyone misses a bucket at the edges,
+  //: and seven of seven nodes went amber over 1 of 14. A share with a floor of two buckets
+  //: keeps the edges quiet and still catches a producer that stopped — measured here,
+  //: `third-party-agent` at 13 of 14.
+  const ABSENT_SHARE = 0.1, ABSENT_MIN = 2;
+
   const HRANK = { fail: 0, warn: 1, unmonitored: 2, unknown: 3, passing: 4 };
   const HTONE = { fail: "var(--alarm)", warn: "var(--sec)", unmonitored: "var(--dim2)",
                   unknown: "var(--dim)", passing: "var(--pri)" };
@@ -355,7 +362,8 @@
     if (v && (v.state === "warn" || v.state === "fail")) why.push(`volume ${v.z}σ off median`);
     // Silence is not a band violation — a producer sitting at its median while writing
     // nothing at all would read as passing — so it raises the state on its own axis.
-    if (v && v.absent > 0) { worse("warn"); why.push(`silent in ${v.absent} of ${v.estate} buckets`); }
+    const silent = v && v.absent >= ABSENT_MIN && v.absent >= v.estate * ABSENT_SHARE;
+    if (silent) { worse("warn"); why.push(`silent in ${v.absent} of ${v.estate} buckets`); }
     if (c && c.violating > 0) {
       worse("warn");
       why.push(`${fmt(c.violating)} rows missing ${Object.keys(c.missing).length} of 5 contract keys`);
@@ -426,9 +434,14 @@
       const a = pos[e.from], z = pos[e.to];
       if (!a || !z) return;
       const m = measured[`${svc[e.from]}\u0000${svc[e.to]}`];
-      // Width from the share of the busiest edge, on a root so a 100x range stays legible;
-      // colour from the error rate on that edge, at the thresholds printed in the legend.
-      const w = m ? 8 + Math.sqrt(m.spans / peak) * 12 : 5;
+      // Width from the share of the busiest edge, on a root so a 100x range stays legible.
+      // The range tops out AT the standard 13px gauge and never above it: what these edges
+      // carry is relative — which one moves more than which — and letting the busiest reach
+      // 20 made ORIGIN's internal dependencies fatter than the feeders and the bronze fan,
+      // so the board read as though a service call outweighed the pipeline it feeds. Only
+      // the trunk is allowed to be the widest thing on the canvas, because only it carries
+      // whole batches.
+      const w = m ? 6 + Math.sqrt(m.spans / peak) * 7 : 4;
       const err = m && m.spans ? m.errors / m.spans : 0;
       const tone = !m ? "var(--dim)"
         : err >= 0.05 ? "var(--alarm)" : err >= 0.01 ? "var(--sec)" : null;
@@ -454,12 +467,12 @@
       // Name on its own line, figure on the next: at 196px a 24-character service name
       // and a right-aligned count were landing on the same pixels.
       node.append(
+        // The border belongs to INTERACTION — hover and selection — and nothing else.
+        // Health took it too, in the same `--sec` the hover uses, so a warning node and a
+        // pointed-at node were indistinguishable and the pointer stopped meaning anything.
+        // State lives in the mark below; one channel each.
         el("rect", { class: "nd sub-nd" + (sel ? " sel" : ""), x: p.x, y: p.y,
-          width: NW, height: NH, rx: 3,
-          // Selection wins the border — it is a thing the reader just did. Health takes the
-          // border only when it has something to say and the node is not selected.
-          style: !sel && h.state !== "passing" && h.state !== "unknown"
-            ? `stroke:${h.tone}` : null }),
+          width: NW, height: NH, rx: 3 }),
         // A status mark on every node, including the healthy ones: a dot that appears only
         // when something is wrong cannot be told from a node nobody is watching.
         el("circle", { class: "hmark", cx: p.x + 6, cy: p.y + NH / 2, r: 3, fill: h.tone }),

--- a/services/flow-ui/src/flow_ui/templates/index.html
+++ b/services/flow-ui/src/flow_ui/templates/index.html
@@ -55,7 +55,7 @@
 </main>
 
 <main id="v-health" role="tabpanel" aria-labelledby="d-health" hidden>
-  <div class="crumb"><span class="now" id="h-pol">validation · {{ s.mode }}</span>
+  <div class="crumb"><span class="now" id="h-pol">validation · {{ contract.validation }}</span>
     <span class="esc">outcome per signal</span></div>
   <div class="stage" id="stage-h"></div>
   <div class="legend" id="legend-h"></div>

--- a/services/flow-ui/src/flow_ui/templates/index.html
+++ b/services/flow-ui/src/flow_ui/templates/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en" data-world="command">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sentinel</title>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap">
+<link rel="stylesheet" href="/static/app.css?v={{ asset_v() }}">
+</head>
+<body data-poll="{{ poll_ms }}">
+
+<header class="top">
+  <span class="brand"><span class="led" aria-hidden="true"></span>Sentinel</span>
+  <nav class="dash" role="tablist" aria-label="Dashboards">
+    <button role="tab" id="d-flow" aria-controls="v-flow" aria-selected="true">Flow</button>
+    <button role="tab" id="d-health" aria-controls="v-health" aria-selected="false" tabindex="-1">Health</button>
+  </nav>
+  <div class="meta">
+    <span class="st hide" id="m-col" data-up="{{ 'y' if s.collector_up else 'n' }}">collector</span>
+    <span class="st hide" id="m-ch" data-up="{{ 'y' if s.clickhouse_up else 'n' }}">clickhouse</span>
+    <button class="pal" id="pal" aria-label="Switch palette" aria-pressed="false"></button>
+  </div>
+</header>
+
+<!-- Server-rendered figures. The graph below illustrates these; if no script runs, the
+     numbers are still here and still true. -->
+<section class="tiles" aria-label="Throughput">
+  <div class="tile"><b id="t-in">{{ ingest_total|fmt }}</b><i>signals/s</i></div>
+  <div class="tile"><b id="t-fl">{{ s.flush_rate|fmt }}</b><i>flushes/s</i></div>
+  <div class="tile"><b id="t-bt">{{ s.records_per_flush|fmt }}</b><i>per batch</i></div>
+  <div class="tile"><b id="t-lt">{{ s.export_latency_ms|fmt }}<u>ms</u></b><i>export</i></div>
+  <div class="tile"><b id="t-ps">{{ s.persist_rate|fmt }}</b><i>stored/s</i></div>
+  <div class="tile {{ 'bad' if reject_total else '' }}" id="tile-rj"><b id="t-rj">{{ reject_total|fmt }}</b><i>rejected/s</i></div>
+</section>
+
+<main id="v-flow" role="tabpanel" aria-labelledby="d-flow">
+  <div class="crumb">
+    <button id="c-root">Pipeline</button>
+    <span class="sep" id="c-sep" hidden>›</span>
+    <span class="now" id="c-now" hidden></span>
+    <span class="esc" id="c-esc" hidden>esc</span>
+  </div>
+  <div class="canvas">
+    <div class="stage" id="stage"></div>
+    <div class="zoom" role="group" aria-label="Canvas controls">
+      <button id="z-home" title="Reset view (Esc)" aria-label="Reset view">⌂</button>
+      <button id="z-in" title="Zoom in" aria-label="Zoom in">+</button>
+      <button id="z-out" title="Zoom out" aria-label="Zoom out">−</button>
+    </div>
+  </div>
+  <div class="legend" id="legend"></div>
+</main>
+
+<main id="v-health" role="tabpanel" aria-labelledby="d-health" hidden>
+  <div class="crumb"><span class="now" id="h-pol">validation · {{ s.mode }}</span>
+    <span class="esc">outcome per signal</span></div>
+  <div class="stage" id="stage-h"></div>
+  <div class="legend" id="legend-h"></div>
+</main>
+
+<script src="/static/app.js?v={{ asset_v() }}" defer></script>
+</body>
+</html>

--- a/services/flow-ui/src/flow_ui/templates/index.html
+++ b/services/flow-ui/src/flow_ui/templates/index.html
@@ -15,6 +15,8 @@
   <nav class="dash" role="tablist" aria-label="Dashboards">
     <button role="tab" id="d-flow" aria-controls="v-flow" aria-selected="true">Flow</button>
     <button role="tab" id="d-health" aria-controls="v-health" aria-selected="false" tabindex="-1">Health</button>
+    <button role="tab" id="d-contract" aria-controls="v-contract" aria-selected="false" tabindex="-1">Contract</button>
+    <button role="tab" id="d-watch" aria-controls="v-watch" aria-selected="false" tabindex="-1">Watchers</button>
   </nav>
   <div class="meta">
     <span class="st hide" id="m-col" data-up="{{ 'y' if s.collector_up else 'n' }}">collector</span>
@@ -57,6 +59,20 @@
     <span class="esc">outcome per signal</span></div>
   <div class="stage" id="stage-h"></div>
   <div class="legend" id="legend-h"></div>
+</main>
+
+<main id="v-contract" role="tabpanel" aria-labelledby="d-contract" hidden>
+  <div class="crumb"><span class="now">contract health</span>
+    <span class="esc">the receive boundary, made visible</span></div>
+  <div class="stage" id="stage-c"></div>
+  <div class="legend" id="legend-c"></div>
+</main>
+
+<main id="v-watch" role="tabpanel" aria-labelledby="d-watch" hidden>
+  <div class="crumb"><span class="now">volume watcher</span>
+    <span class="esc">the band you see is the threshold</span></div>
+  <div class="stage" id="stage-w"></div>
+  <div class="legend" id="legend-w"></div>
 </main>
 
 <script src="/static/app.js?v={{ asset_v() }}" defer></script>

--- a/services/flow-ui/src/flow_ui/topology.py
+++ b/services/flow-ui/src/flow_ui/topology.py
@@ -32,6 +32,39 @@ _CANDIDATES = (
 )
 
 
+#: The collector's own config, mounted read-only. Same argument as the topology above:
+#: read the policy from the file that sets it, so the board cannot drift from the collector.
+_COLLECTOR_CFG = (
+    Path(os.getenv("COLLECTOR_CONFIG", "/app/collector-config.yaml")),
+    Path(__file__).resolve().parents[3] / "collector-rust" / "config.docker.yaml",
+)
+
+
+def grpc_validation() -> str:
+    """The receive-boundary policy actually in force: `off` / `warn` / `strict`.
+
+    Read from the collector's config because there is nowhere else to read it: the policy
+    is not exposed as a metric, so no amount of scraping recovers it. Returns `"unknown"`
+    rather than a plausible default when the file is absent — a board whose headline is the
+    policy must not invent one, and this field was previously hard-coded to the literal
+    string `"grpc_validation"`, i.e. the config KEY, which rendered as the mode everywhere.
+    """
+    for path in _COLLECTOR_CFG:
+        if not path.is_file():
+            continue
+        try:
+            raw = yaml.safe_load(path.read_text()) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            log.warning("collector config unreadable (%s): %s", path, exc)
+            continue
+        mode = str((raw.get("contract") or {}).get("grpc_validation", "")).strip().lower()
+        if mode in ("off", "warn", "strict"):
+            return mode
+        log.warning("collector config has no usable contract.grpc_validation: %r", mode)
+    log.warning("collector config not found; validation policy unknown")
+    return "unknown"
+
+
 def _config_dir() -> Path | None:
     for p in _CANDIDATES:
         if (p / "topology" / "default.yaml").is_file():
@@ -178,5 +211,7 @@ CONTRACT = {
     "producer_version": "1.0.0",
     "consumer": "collector/v1",
     "consumer_version": "1.0.0.1",
-    "validation": "grpc_validation",
+    # Filled at import from the collector's own config — never hard-coded. It used to be
+    # the literal string "grpc_validation", the config key rather than its value.
+    "validation": grpc_validation(),
 }

--- a/services/flow-ui/src/flow_ui/topology.py
+++ b/services/flow-ui/src/flow_ui/topology.py
@@ -1,0 +1,182 @@
+"""The producer's declared topology, and what each bronze table holds.
+
+Two static sources feed the detail levels of the graph. Neither is invented here.
+
+**The service graph** is Pod 1's own `config/topology/default.yaml` — the seven synthetic
+services and the `depends_on` edges between them. Reading the producer's config rather than
+redrawing it means the picture cannot drift from what actually emits the telemetry.
+
+*A note on where this goes next:* this is the **declared** topology. The **observed** one is
+recoverable from `bronze.otel_traces` by following `ParentSpanId` across services, and the
+two disagreeing would itself be a finding worth surfacing. That comparison is out of scope
+for v1 but is the reason this module keeps the two ideas namable.
+
+**The table documentation** is the Pod 2 → Pod 3 read contract v1.0.0.1, transcribed. It is
+the semantic layer the DDL cannot express: which columns Pod 2 populates, what it guarantees,
+and which tables stay empty by design.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import yaml
+
+log = logging.getLogger("flow_ui.topology")
+
+#: Mounted read-only by compose; falls back to the source checkout for local runs.
+_CANDIDATES = (
+    Path(os.getenv("GENERATOR_CONFIG_DIR", "/app/generator-config")),
+    Path(__file__).resolve().parents[3] / "generator-python" / "config",
+)
+
+
+def _config_dir() -> Path | None:
+    for p in _CANDIDATES:
+        if (p / "topology" / "default.yaml").is_file():
+            return p
+    return None
+
+
+def service_graph() -> dict:
+    """The declared service topology as `{nodes, edges, source}`.
+
+    Edges point the way data *flows*: `depends_on: [a]` on component `b` means a produces
+    what b consumes, so the edge is `a → b`. Reading it the other way would draw every
+    arrow backwards, which is the kind of mistake a diagram never announces.
+    """
+    cfg = _config_dir()
+    if cfg is None:
+        log.warning("generator topology not found; detail level will be empty")
+        return {"nodes": [], "edges": [], "source": None}
+
+    path = cfg / "topology" / "default.yaml"
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except (OSError, yaml.YAMLError) as exc:
+        log.warning("topology unreadable (%s): %s", path, exc)
+        return {"nodes": [], "edges": [], "source": None}
+
+    by_component = {c["name"]: c for c in raw.get("components", [])}
+    nodes, edges = [], []
+    for comp in raw.get("components", []):
+        nodes.append({
+            "id": comp["name"],
+            "service": comp["service_name"],
+            "kind": comp.get("type", "unknown"),
+            "rate": comp.get("base_rate"),
+            "latency_ms": comp.get("base_latency_ms"),
+            "error_ratio": comp.get("error_ratio"),
+            "roots": not comp.get("depends_on"),
+        })
+        for upstream in comp.get("depends_on") or []:
+            if upstream in by_component:
+                edges.append({"from": upstream, "to": comp["name"]})
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "source": str(path),
+        "version": raw.get("version"),
+    }
+
+
+#: Per-table semantics from the read contract. `columns` lists only what Pod 2 actually
+#: writes — every other bronze column sits at its ClickHouse default by design (§2), which
+#: is why showing the full DDL here would misrepresent what a consumer can rely on.
+TABLE_DOCS: dict[str, dict] = {
+    "otel_logs": {
+        "section": "§2.1",
+        "summary": "OTLP log records. The six sentinel.* keys travel inside "
+                   "ResourceAttributes, not as columns.",
+        "order_by": "(ServiceName, TimestampDate, TimestampTime)",
+        "partition": "toYYYYMM(TimestampDate)",
+        "ttl": "30d",
+        "columns": [
+            ("Timestamp", "DateTime64(9)", "event time, UTC, ns"),
+            ("ServiceName", "LowCardinality(String)", "always present · indexed"),
+            ("SeverityText", "LowCardinality(String)", "INFO, ERROR, …"),
+            ("SeverityNumber", "UInt8", "0–24"),
+            ("Body", "String", "log message"),
+            ("TraceId", "String", "'' when absent, never NULL"),
+            ("SpanId", "String", "'' when absent, never NULL"),
+            ("LogAttributes", "Map", "record-level attributes"),
+            ("ResourceAttributes", "Map", "includes the sentinel.* keys"),
+        ],
+    },
+    "otel_traces": {
+        "section": "§2.2",
+        "summary": "Spans. Duration is nanoseconds, precomputed; end time is not a column "
+                   "— it is Timestamp + Duration.",
+        "order_by": "(ServiceName, SpanName, toUnixTimestamp(Timestamp), TraceId)",
+        "partition": "toDate(Timestamp)",
+        "ttl": "30d",
+        "columns": [
+            ("Timestamp", "DateTime64(9)", "span start"),
+            ("TraceId", "String", "32 hex, always present"),
+            ("SpanId", "String", "16 hex, always present"),
+            ("ParentSpanId", "String", "'' for root spans"),
+            ("SpanName", "LowCardinality(String)", "span name"),
+            ("ServiceName", "LowCardinality(String)", "always present · indexed"),
+            ("Duration", "Int64", "nanoseconds"),
+            ("StatusCode", "LowCardinality(String)", "Ok or Error"),
+            ("SpanAttributes", "Map", "span-level attributes"),
+            ("ResourceAttributes", "Map", "includes the sentinel.* keys"),
+        ],
+    },
+    "otel_metrics_gauge": {
+        "section": "§2.3",
+        "summary": "Gauge data points. The data-point type selects the table — there is no "
+                   "MetricType column.",
+        "order_by": "(ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))",
+        "partition": "toDate(TimeUnix)",
+        "ttl": "30d",
+        "columns": [
+            ("ServiceName", "LowCardinality(String)", "always present · indexed"),
+            ("MetricName", "LowCardinality(String)", "metric name"),
+            ("TimeUnix", "DateTime64(9)", "event time"),
+            ("Value", "Float64", "sample value"),
+            ("Attributes", "Map", "data-point attributes"),
+            ("ResourceAttributes", "Map", "includes the sentinel.* keys"),
+        ],
+    },
+    "otel_metrics_sum": {
+        "section": "§2.3",
+        "summary": "Sum data points. Same shape as gauge; AggregationTemporality and "
+                   "IsMonotonic are left at their defaults.",
+        "order_by": "(ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))",
+        "partition": "toDate(TimeUnix)",
+        "ttl": "30d",
+        "columns": [
+            ("ServiceName", "LowCardinality(String)", "always present · indexed"),
+            ("MetricName", "LowCardinality(String)", "metric name"),
+            ("TimeUnix", "DateTime64(9)", "event time"),
+            ("Value", "Float64", "sample value"),
+            ("Attributes", "Map", "data-point attributes"),
+            ("ResourceAttributes", "Map", "includes the sentinel.* keys"),
+        ],
+    },
+}
+
+#: Present in the DDL, empty in this contract version — Pod 1 v1.0.0 emits gauge and sum
+#: only (§2.3, §5.5). Named on screen so three permanently-zero tables read as a decision
+#: rather than as a failure.
+EMPTY_BY_CONTRACT = {
+    "otel_metrics_histogram": "no histogram data points in contract v1.0.0",
+    "otel_metrics_exponential_histogram": "no exponential histogram data points in v1.0.0",
+    "otel_metrics_summary": "no summary data points in v1.0.0",
+}
+
+#: Bronze also carries the contrib trace-id index and the view that fills it. It is not a
+#: table Pod 2 writes — the MV does — so it is listed apart from both groups above.
+DERIVED = {
+    "otel_traces_trace_id_ts": "trace-id index, filled by otel_traces_trace_id_ts_mv",
+}
+
+CONTRACT = {
+    "producer": "generator/v1",
+    "producer_version": "1.0.0",
+    "consumer": "collector/v1",
+    "consumer_version": "1.0.0.1",
+    "validation": "grpc_validation",
+}

--- a/services/flow-ui/tests/test_app.py
+++ b/services/flow-ui/tests/test_app.py
@@ -1,0 +1,159 @@
+"""The page, asserted by the markup it actually served.
+
+`TestClient` is used without its context manager on purpose: entering it would run the
+lifespan and start the real poller, which would try to reach a collector and a ClickHouse.
+These tests render against an injected snapshot instead.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from flow_ui import main
+from flow_ui.pipeline import Snapshot
+
+client = TestClient(main.app)
+
+
+def _snapshot() -> Snapshot:
+    return Snapshot(
+        mode="batch", collector_up=True, clickhouse_up=True,
+        ingest_rate={"logs": 3100.0, "trace": 3100.0, "metrics": 12154.0},
+        reject_rate={"logs": 0.4},
+        reject_by_reason={"contract": 0.4},
+        reject_matrix={"contract": {"logs": 0.4}},
+        flush_rate=5.9, records_per_flush=2500.0, export_latency_ms=45.3,
+        persist_rate=14750.0, drop_rate=0.0,
+        totals={"ingested": 233100.0, "persisted": 233100.0},
+        bronze={"otel_logs": 40200, "otel_traces": 40200,
+                "otel_metrics_gauge": 83400, "otel_metrics_sum": 69300},
+        bronze_rate={"otel_logs": 2723.0},
+        lineage=[{"service": "pubsub-ingestion-topic", "total": 98700,
+                  "logs": 16450, "traces": 16450, "gauge": 32900, "sum": 32900}],
+        metrics_by_service={"pubsub-ingestion-topic": {
+            "gauge": ["operation.latency_ms"],
+            "sum": ["operation.request_count", "operation.error_count"]}},
+        scenario="baseline",
+    )
+
+
+def test_the_figures_are_printed_before_any_script_runs(monkeypatch):
+    """The load-bearing property: with JavaScript disabled the page still answers what the
+    pipeline is doing. The graph only illustrates these numbers."""
+    monkeypatch.setattr(main.poller, "latest", _snapshot())
+    body = client.get("/").text
+    assert "18.4k" in body          # 3100 + 3100 + 12154 signals/s
+    assert "2.5k" in body           # records per batch
+    assert ">45<" in body           # export latency, ms, rounded for the tile
+    assert "14.8k" in body          # stored/s
+
+
+def test_the_detected_mode_is_no_longer_in_the_header(monkeypatch):
+    """The header used to print `baseline stream` — two bare words with no label, which
+    read as noise. They were removed deliberately. The mode is still detected and still
+    reaches the client; it is drawn on the Health timeline, where a coloured region and a
+    duration say what a bare word could not."""
+    monkeypatch.setattr(main.poller, "latest", _snapshot())
+    body = client.get("/").text
+    assert "baseline" not in body
+    assert client.get("/api/snapshot").json()["mode"] == "batch"
+
+
+def test_a_nonzero_rejection_rate_marks_its_tile(monkeypatch):
+    """Rejections must be legible as a state, not only as a number — the tile takes a
+    class so it reads at a glance, and colour is never the only carrier."""
+    monkeypatch.setattr(main.poller, "latest", _snapshot())
+    body = client.get("/").text
+    assert 'class="tile bad"' in body and "rejected/s" in body
+
+
+def test_an_empty_snapshot_renders_a_real_state_not_a_crash(monkeypatch):
+    """Cold start: no scrape yet, every labelled counter family absent from /metrics.
+    The tiles must still render — as zeros, which is the truth — rather than blank."""
+    monkeypatch.setattr(main.poller, "latest", Snapshot())
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert 'id="t-in"' in resp.text and 'id="t-fl"' in resp.text
+    assert "signals/s" in resp.text
+
+
+def test_the_page_defaults_to_the_command_palette(monkeypatch):
+    """Both palettes are complete, but the page must paint one before any script runs —
+    a document with no world attribute would render on the host's ground."""
+    monkeypatch.setattr(main.poller, "latest", _snapshot())
+    assert 'data-world="command"' in client.get("/").text
+
+
+def test_the_page_never_points_the_browser_at_the_collector_or_clickhouse(monkeypatch):
+    """CORS: the collector's /metrics server sets only Content-Type and ClickHouse has no
+    CORS header configured, so a fetch from the page would be blocked with no visible
+    error. If an edit ever puts those origins in the markup, this fails."""
+    monkeypatch.setattr(main.poller, "latest", _snapshot())
+    body = client.get("/").text
+    assert ":9090" not in body
+    assert ":8123" not in body
+
+
+def test_graph_endpoint_carries_the_declared_topology_and_table_docs():
+    data = client.get("/api/graph").json()
+    assert len(data["topology"]["nodes"]) == 7
+    assert len(data["topology"]["edges"]) == 8
+    assert set(data["tables"]) == {
+        "otel_logs", "otel_traces", "otel_metrics_gauge", "otel_metrics_sum"}
+    # The three permanently-empty tables are named, so zero rows reads as a decision.
+    assert "otel_metrics_histogram" in data["empty_by_contract"]
+    assert data["contract"]["consumer_version"] == "1.0.0.1"
+
+
+def test_snapshot_endpoint_returns_the_current_tick(monkeypatch):
+    monkeypatch.setattr(main.poller, "latest", _snapshot())
+    data = client.get("/api/snapshot").json()
+    assert data["mode"] == "batch"
+    assert data["bronze"]["otel_logs"] == 40200
+
+
+def test_healthz_reports_both_sources(monkeypatch):
+    monkeypatch.setattr(main.poller, "latest", _snapshot())
+    assert client.get("/healthz").json() == {
+        "ok": True, "collector": True, "clickhouse": True, "subscribers": 0}
+
+
+def test_fmt_keeps_a_rate_readable_in_a_tile():
+    assert main.fmt(18354) == "18.4k"
+    assert main.fmt(5.9) == "5.9"
+    assert main.fmt(0) == "0"
+    assert main.fmt(1_200_000) == "1.2M"
+
+
+def test_the_snapshot_carries_what_each_zoom_level_needs(monkeypatch):
+    """The page fetches /api/graph once for the static half and reads the SSE snapshot for
+    everything that moves. These are the fields the detail levels read; dropping one would
+    blank a view with no error."""
+    monkeypatch.setattr(main.poller, "latest", _snapshot())
+    d = client.get("/api/snapshot").json()
+    # overview
+    assert set(d["ingest_rate"]) >= {"logs", "trace", "metrics"}
+    assert "flush_rate" in d and "records_per_flush" in d
+    # origin — observed row counts drawn beside the declared topology
+    assert d["lineage"] and "service" in d["lineage"][0]
+    # split per destination table — every service reaches all four, so the SPLIT is the
+    # only per-service information there is downstream
+    assert set(d["lineage"][0]) >= {"logs", "traces", "gauge", "sum"}
+    # the metric mix is what makes one service's split differ from another's
+    assert d["metrics_by_service"]["pubsub-ingestion-topic"]["gauge"]
+    # collector / health — the three outcomes
+    assert "persist_rate" in d and "drop_rate" in d and "reject_rate" in d
+    # …and which signal type each rejection was, which is what colours the falling dot.
+    # Losing this field would silently repaint every rejection as one arbitrary type.
+    assert d["reject_matrix"]["contract"]["logs"] == 0.4
+    # health — batches lost, which is a different granularity from signals dropped
+    assert "export_errors" in d
+    assert "persisted" in d["totals"]
+
+
+def test_bronze_growth_is_reported_per_table(monkeypatch):
+    """Deltas of count(), not a time-window query — bronze stores event time and the
+    backfill writes history, so 'rows that arrived' cannot come from a WHERE on Timestamp."""
+    monkeypatch.setattr(main.poller, "latest", _snapshot())
+    d = client.get("/api/snapshot").json()
+    assert set(d["bronze"]) == {
+        "otel_logs", "otel_traces", "otel_metrics_gauge", "otel_metrics_sum"}

--- a/services/flow-ui/tests/test_app.py
+++ b/services/flow-ui/tests/test_app.py
@@ -21,6 +21,10 @@ def _snapshot() -> Snapshot:
         reject_rate={"logs": 0.4},
         reject_by_reason={"contract": 0.4},
         reject_matrix={"contract": {"logs": 0.4}},
+        contract_violations=[{"service": "third-party-agent", "rows": 2760,
+                              "violating": 2760,
+                              "missing": {"sentinel.run_id": 2760},
+                              "total_missing": 2760}],
         flush_rate=5.9, records_per_flush=2500.0, export_latency_ms=45.3,
         persist_rate=14750.0, drop_rate=0.0,
         totals={"ingested": 233100.0, "persisted": 233100.0},
@@ -145,6 +149,11 @@ def test_the_snapshot_carries_what_each_zoom_level_needs(monkeypatch):
     # …and which signal type each rejection was, which is what colours the falling dot.
     # Losing this field would silently repaint every rejection as one arbitrary type.
     assert d["reject_matrix"]["contract"]["logs"] == 0.4
+    # contract board — who violated, which the collector's counters cannot say (no service
+    # label). `violating` is rows, not the sum of per-key counts, so it can be a share.
+    v = d["contract_violations"][0]
+    assert v["service"] == "third-party-agent" and v["violating"] <= v["rows"]
+    assert "sentinel.run_id" in v["missing"]
     # health — batches lost, which is a different granularity from signals dropped
     assert "export_errors" in d
     assert "persisted" in d["totals"]

--- a/services/flow-ui/tests/test_pipeline.py
+++ b/services/flow-ui/tests/test_pipeline.py
@@ -10,7 +10,14 @@ so the two distributions do not overlap on either axis.
 from __future__ import annotations
 
 from flow_ui.config import Settings
-from flow_ui.pipeline import MODE_BATCH, MODE_IDLE, MODE_STREAM, Poller, Snapshot, Broadcaster
+from flow_ui.pipeline import (
+    MODE_BATCH,
+    MODE_IDLE,
+    MODE_STREAM,
+    Broadcaster,
+    Poller,
+    Snapshot,
+)
 
 
 def poller() -> Poller:

--- a/services/flow-ui/tests/test_pipeline.py
+++ b/services/flow-ui/tests/test_pipeline.py
@@ -1,0 +1,137 @@
+"""Mode detection — the inference the whole animation hangs off.
+
+The thresholds come from measuring this pipeline, not from taste:
+
+    --mode stream    1.03 flushes/s, 500–1000 records per flush
+    --mode backfill  6.6  flushes/s (min 4, max 8), ~2534 records per flush
+
+so the two distributions do not overlap on either axis.
+"""
+from __future__ import annotations
+
+from flow_ui.config import Settings
+from flow_ui.pipeline import MODE_BATCH, MODE_IDLE, MODE_STREAM, Poller, Snapshot, Broadcaster
+
+
+def poller() -> Poller:
+    return Poller(Settings())
+
+
+def test_stream_cadence_is_read_as_stream():
+    p = poller()
+    for _ in range(3):
+        p._flush_rates.append(1.0)
+    assert p._detect_mode(0.99, 1000.0, 988.0) == MODE_STREAM
+
+
+def test_backfill_cadence_is_read_as_batch():
+    p = poller()
+    for r in (5.9, 5.9, 6.6):
+        p._flush_rates.append(r)
+    assert p._detect_mode(5.9, 2500.0, 16297.0) == MODE_BATCH
+
+
+def test_a_fat_batch_is_batch_even_if_the_flush_rate_sample_dips():
+    """A poll can land between bursts and see a low rate; batch size is the second tell."""
+    p = poller()
+    p._flush_rates.append(1.0)
+    assert p._detect_mode(1.0, 2500.0, 16000.0) == MODE_BATCH
+
+
+def test_no_traffic_is_idle():
+    assert poller()._detect_mode(0.0, 0.0, 0.0) == MODE_IDLE
+
+
+def test_stream_is_not_promoted_to_batch_by_its_own_1000_record_flush():
+    """Stream's largest observed flush (1000) must stay below the batch threshold."""
+    p = poller()
+    p._flush_rates.append(0.99)
+    assert p._detect_mode(0.99, 1000.0, 988.0) == MODE_STREAM
+
+
+def test_snapshot_serializes_to_json_safe_primitives():
+    import json
+    json.dumps(Snapshot().as_dict())
+
+
+def test_snapshot_names_the_tables_that_are_empty_by_contract():
+    """Contract §2.3/§5: histogram, exponential-histogram and summary stay empty in
+    v1.0.0. The page says so rather than drawing three dead tables unexplained."""
+    assert "otel_metrics_histogram" in Snapshot().bronze_empty
+    assert "otel_metrics_summary" in Snapshot().bronze_empty
+
+
+def test_a_full_subscriber_queue_drops_its_own_frames_not_the_publisher():
+    b = Broadcaster()
+    q = b.subscribe()
+    for _ in range(6):
+        b.publish(Snapshot())        # must never raise, whatever the queue depth
+    assert q.qsize() <= 2
+    b.unsubscribe(q)
+    assert b.subscribers == 0
+
+
+def test_the_verdict_names_a_state_and_the_reason_for_it():
+    """Colour is never the only carrier: every state ships the sentence a reader acts on."""
+    p = poller()
+    healthy = Snapshot(collector_up=True, clickhouse_up=True,
+                       ingest_rate={"logs": 500.0}, export_latency_p99=30.0)
+    assert p._verdict(healthy) == ("ok", "flowing, nothing rejected or lost")
+
+
+def test_an_unreachable_source_outranks_everything_else():
+    p = poller()
+    assert p._verdict(Snapshot(collector_up=False, clickhouse_up=True))[0] == "fail"
+    assert p._verdict(Snapshot(collector_up=True, clickhouse_up=False))[0] == "fail"
+
+
+def test_loss_is_a_failure_and_rejection_is_a_warning():
+    """A contract violation under the `warn` policy is recorded and let through — the data
+    still arrives. A dropped batch is data that no longer exists anywhere."""
+    p = poller()
+    assert p._verdict(Snapshot(collector_up=True, clickhouse_up=True,
+                               ingest_rate={"logs": 1.0}, drop_rate=0.5))[0] == "fail"
+    p2 = poller()
+    assert p2._verdict(Snapshot(collector_up=True, clickhouse_up=True,
+                                ingest_rate={"logs": 1.0},
+                                reject_by_reason={"contract": 0.2}))[0] == "warn"
+
+
+def test_a_tail_over_the_measured_ceiling_warns_even_when_nothing_is_lost():
+    p = poller()
+    state, note = p._verdict(Snapshot(collector_up=True, clickhouse_up=True,
+                                      ingest_rate={"logs": 900.0}, export_latency_p99=120.0))
+    assert state == "warn" and "p99" in note
+
+
+def test_no_traffic_is_idle_not_a_failure():
+    p = poller()
+    assert p._verdict(Snapshot(collector_up=True, clickhouse_up=True))[0] == "idle"
+
+
+def test_the_two_rejection_reasons_are_not_the_same_problem():
+    """`contract` is a bad payload — under the `warn` policy it is counted and exported
+    anyway, so the data still lands. `backpressure` is the collector refusing a batch it
+    has no room for, which the producer is told about and can retry. Reporting them as one
+    number hides which of the two is happening."""
+    p = poller()
+    _, contract = p._verdict(Snapshot(collector_up=True, clickhouse_up=True,
+                                      ingest_rate={"logs": 1.0},
+                                      reject_by_reason={"contract": 3.0}))
+    p2 = poller()
+    _, back = p2._verdict(Snapshot(collector_up=True, clickhouse_up=True,
+                                   ingest_rate={"logs": 1.0},
+                                   reject_by_reason={"backpressure": 3.0}))
+    assert "contract" in contract and "exported anyway" in contract
+    assert "saturated" in back and "retry" in back
+    assert contract != back
+
+
+def test_saturation_outranks_a_bad_payload():
+    """If both are happening, the one that means the collector cannot keep up is the one
+    worth naming first."""
+    p = poller()
+    _, note = p._verdict(Snapshot(collector_up=True, clickhouse_up=True,
+                                  ingest_rate={"logs": 1.0},
+                                  reject_by_reason={"contract": 9.0, "backpressure": 1.0}))
+    assert "saturated" in note

--- a/services/flow-ui/tests/test_pipeline.py
+++ b/services/flow-ui/tests/test_pipeline.py
@@ -135,3 +135,91 @@ def test_saturation_outranks_a_bad_payload():
                                   ingest_rate={"logs": 1.0},
                                   reject_by_reason={"contract": 9.0, "backpressure": 1.0}))
     assert "saturated" in note
+
+
+def _band(**kw):
+    base = {"service": "s", "median": 100.0, "mad": 0.0, "sd": 0.0,
+            "seen": 30, "estate": 30, "latest": 100, "latest_t": 0, "series": []}
+    return {**base, **kw}
+
+
+def test_the_band_returned_is_the_band_that_decided():
+    """Metaplane shipped a version where the drawn area and the alerting rule were computed
+    separately, then called reconciling them a simplification. One function returns both."""
+    from flow_ui.pipeline import MAD_TO_SIGMA, Z_WARN, volume_state
+
+    v = volume_state(_band(mad=10.0, latest=100))
+    scale = 10.0 * MAD_TO_SIGMA
+    assert v["lo"] == round(100 - Z_WARN * scale, 1)
+    assert v["hi"] == round(100 + Z_WARN * scale, 1)
+    # a value placed just outside the drawn band must be the one that alerts
+    assert volume_state(_band(mad=10.0, latest=int(v["hi"]) + 2))["state"] != "passing"
+    assert volume_state(_band(mad=10.0, latest=int(v["hi"]) - 2))["state"] == "passing"
+
+
+def test_a_perfectly_regular_producer_is_unmonitored_not_healthy():
+    """The degenerate case that makes robust statistics bite: MAD = 0 gives a zero-width
+    band in which every value is infinitely anomalous. Falls back to stddev; if that is flat
+    too the series is declared unmodellable. Grey means *not observed*, never *fine*."""
+    from flow_ui.pipeline import volume_state
+
+    flat = volume_state(_band(mad=0.0, sd=0.0, latest=1_000_000))
+    assert flat["state"] == "unmonitored" and flat["estimator"] == "none"
+    assert flat["why"] == "no dispersion to model"
+
+    fallback = volume_state(_band(mad=0.0, sd=20.0, latest=100))
+    assert fallback["estimator"] == "stddev" and fallback["state"] == "passing"
+
+    assert volume_state(_band(mad=5.0, sd=99.0))["estimator"] == "mad"
+
+
+def test_too_short_a_window_is_unmonitored_rather_than_a_band_drawn_from_three_points():
+    from flow_ui.pipeline import MIN_BUCKETS, volume_state
+
+    v = volume_state(_band(mad=10.0, seen=3, estate=3, latest=99999))
+    assert v["state"] == "unmonitored" and str(MIN_BUCKETS) not in v["service"]
+    assert "buckets in the window" in v["why"]
+
+
+def test_absence_is_its_own_axis_not_a_band_violation():
+    """A producer silent while the estate kept receiving is the write that never happened —
+    a signal a tool reading tables at rest cannot produce. It must not be folded into the
+    band verdict, or a silent producer sitting at its median would read as passing."""
+    from flow_ui.pipeline import volume_state
+
+    v = volume_state(_band(mad=10.0, seen=18, estate=30, latest=100))
+    assert v["state"] == "passing"      # the buckets it DID write were normal
+    assert v["absent"] == 12            # and it missed twelve the estate received
+
+
+def test_the_estimator_is_chosen_by_whether_its_band_fits_not_by_mad_being_nonzero():
+    """The regression: `mad * 1.4826 or sd` was a cliff, not a fallback. On a series that
+    alternates full minutes with partial ones the median sits on the dominant mode, MAD
+    measures that mode's spread against itself (50 against a true 699), and the instant MAD
+    crossed zero σ moved 74 → 699 between two ticks — flipping every producer from passing
+    to alerting on one new bucket. Observed live, not hypothesised."""
+    from flow_ui.pipeline import volume_state
+
+    # 20 full minutes at 2850, 11 partial ones: bimodal, exactly the measured shape
+    series = [[i, 2850] for i in range(20)] + [[20 + i, v] for i, v in
+              enumerate([600, 750, 1000, 1250, 1300, 1600, 1900, 2000, 2200, 2400, 2600])]
+    row = _band(median=2800.0, mad=50.0, sd=699.0, seen=31, estate=31,
+                latest=1600, series=series)
+    v = volume_state(row)
+    # the MAD band would reject nearly half its own window, so it is not the one used
+    assert v["estimator"] == "stddev"
+    assert v["oob"] <= 0.15
+    assert v["state"] == "passing"
+
+
+def test_a_series_no_band_fits_is_unmonitored_rather_than_eight_alerts():
+    """When both estimators produce a band that rejects its own training window, the series
+    is multi-modal and no single band describes it. Grey, with the reason."""
+    from flow_ui.pipeline import volume_state
+
+    # two tight modes far apart: every band either misses one mode or spans nothing
+    series = [[i, 100] for i in range(15)] + [[15 + i, 10_000] for i in range(15)]
+    v = volume_state(_band(median=100.0, mad=0.5, sd=1.0, seen=30, estate=30,
+                           latest=10_000, series=series))
+    assert v["state"] == "unmonitored"
+    assert "not single-mode" in v["why"]

--- a/services/flow-ui/tests/test_prom.py
+++ b/services/flow-ui/tests/test_prom.py
@@ -1,0 +1,146 @@
+"""The parser's contract — above all, that an absent metric family is a normal state."""
+from __future__ import annotations
+
+from flow_ui import prom
+
+# A freshly started collector serves exactly this: the three unlabelled/histogram families.
+# The five `IntCounterVec` families are absent because no label combination exists yet.
+COLD = """\
+# HELP sentinel_batch_flush_size Number of records per batch flush.
+# TYPE sentinel_batch_flush_size histogram
+sentinel_batch_flush_size_bucket{le="1"} 0
+sentinel_batch_flush_size_bucket{le="+Inf"} 0
+sentinel_batch_flush_size_sum 0
+sentinel_batch_flush_size_count 0
+# HELP sentinel_export_errors_total Total ClickHouse insert errors after all retry attempts.
+# TYPE sentinel_export_errors_total counter
+sentinel_export_errors_total 0
+"""
+
+WARM = """\
+sentinel_signals_ingested_total{signal="logs"} 40200
+sentinel_signals_ingested_total{signal="metrics"} 152700
+sentinel_signals_ingested_total{signal="trace"} 40200
+sentinel_batch_flush_total{signal="all",status="success"} 92
+sentinel_batch_flush_size_count 92
+sentinel_batch_flush_size_sum 233100
+sentinel_storage_signals_total{outcome="persisted",signal="all"} 233100
+sentinel_signals_rejected_total{reason="contract",signal="metrics"} 900
+sentinel_signals_rejected_total{reason="contract",signal="logs"} 40
+sentinel_signals_rejected_total{reason="backpressure",signal="trace"} 12
+sentinel_export_errors_total 0
+"""
+
+
+def test_absent_family_reads_as_zero_not_an_error():
+    """The cold-start case that would otherwise take the whole page down."""
+    s = prom.parse(COLD)
+    assert s.value("sentinel_signals_ingested_total", signal="logs") == 0.0
+    assert s.sum_over("sentinel_signals_ingested_total", "signal") == {}
+    assert not s.has("sentinel_signals_ingested_total")
+    assert s.has("sentinel_export_errors_total")
+
+
+def test_labelled_series_are_addressable_and_label_order_does_not_matter():
+    s = prom.parse(WARM)
+    assert s.value("sentinel_batch_flush_total", signal="all", status="success") == 92
+    # The scrape writes signal first; asking status first must find the same series.
+    assert s.value("sentinel_batch_flush_total", status="success", signal="all") == 92
+
+
+def test_sum_over_groups_by_one_label():
+    s = prom.parse(WARM)
+    assert s.sum_over("sentinel_signals_ingested_total", "signal") == {
+        "logs": 40200.0, "metrics": 152700.0, "trace": 40200.0,
+    }
+    assert s.sum_over("sentinel_storage_signals_total", "outcome") == {"persisted": 233100.0}
+
+
+def test_sum_over_pair_recovers_the_cross_product_one_label_at_a_time_destroys():
+    """The reason this method exists. Grouping by `signal` says 900 metrics were rejected;
+    grouping by `reason` says 940 rejections were contract failures. Neither answers "which
+    type failed the contract" — and the page paints the falling dot from that answer."""
+    s = prom.parse(WARM)
+    assert s.sum_over_pair("sentinel_signals_rejected_total", "reason", "signal") == {
+        "contract": {"metrics": 900.0, "logs": 40.0},
+        "backpressure": {"trace": 12.0},
+    }
+    # Both single-label views remain correct — and both remain insufficient on their own.
+    assert s.sum_over("sentinel_signals_rejected_total", "reason") == {
+        "contract": 940.0, "backpressure": 12.0,
+    }
+
+
+def test_sum_over_pair_on_an_absent_or_half_labelled_family_is_empty():
+    """Cold start, and the buffer-side families that only carry one of the two labels."""
+    assert prom.parse(COLD).sum_over_pair(
+        "sentinel_signals_rejected_total", "reason", "signal") == {}
+    # `export_errors_total` has no labels at all; asking for two of them yields nothing
+    # rather than inventing a bucket.
+    assert prom.parse(WARM).sum_over_pair(
+        "sentinel_export_errors_total", "reason", "signal") == {}
+
+
+def test_value_without_labels_sums_the_family():
+    s = prom.parse(WARM)
+    assert s.value("sentinel_signals_ingested_total") == 233100.0
+
+
+def test_histogram_buckets_with_inf_do_not_break_parsing():
+    s = prom.parse(COLD)
+    assert s.value("sentinel_batch_flush_size_bucket", le="+Inf") == 0.0
+
+
+def test_comments_and_blank_lines_are_ignored():
+    assert prom.parse("# HELP x y\n\n# TYPE x counter\n").series == {}
+
+
+def test_rate_is_per_second():
+    assert prom.rate(100.0, 40.0, 2.0) == 30.0
+
+
+def test_counter_reset_reports_the_new_value_not_a_negative_rate():
+    """The collector builds a fresh Registry per process, so a restart resets every
+    counter to zero. A naive delta would report a large negative rate."""
+    assert prom.rate(5.0, 233100.0, 1.0) == 5.0
+
+
+def test_zero_elapsed_time_does_not_divide_by_zero():
+    assert prom.rate(10.0, 0.0, 0.0) == 0.0
+
+
+HIST = """\
+sentinel_export_latency_seconds_bucket{le="0.005"} 0
+sentinel_export_latency_seconds_bucket{le="0.01"} 10
+sentinel_export_latency_seconds_bucket{le="0.02"} 50
+sentinel_export_latency_seconds_bucket{le="0.04"} 80
+sentinel_export_latency_seconds_bucket{le="0.08"} 99
+sentinel_export_latency_seconds_bucket{le="+Inf"} 100
+sentinel_export_latency_seconds_sum 2.45
+sentinel_export_latency_seconds_count 100
+"""
+
+
+def test_quantiles_recover_the_tail_the_mean_hides():
+    """The reason this exists: on the live pipeline the mean was 24.5 ms and the p99 was
+    79 ms. One number cannot say whether export is healthy."""
+    s = prom.parse(HIST)
+    p50 = prom.quantile(s, "sentinel_export_latency_seconds", 0.5)
+    p99 = prom.quantile(s, "sentinel_export_latency_seconds", 0.99)
+    assert 0.01 < p50 <= 0.02      # the 50th observation sits on the bucket edge
+    assert p99 > p50 * 2
+
+
+def test_a_quantile_over_an_absent_histogram_is_zero_not_a_crash():
+    assert prom.quantile(prom.parse(""), "sentinel_export_latency_seconds", 0.99) == 0.0
+
+
+def test_a_value_in_the_inf_bucket_reports_the_last_finite_edge():
+    """`+Inf` has no upper bound to interpolate toward, so the honest answer is the last
+    edge we can actually name."""
+    s = prom.parse("""\
+sentinel_x_bucket{le="0.01"} 1
+sentinel_x_bucket{le="+Inf"} 100
+sentinel_x_count 100
+""")
+    assert prom.quantile(s, "sentinel_x", 0.99) == 0.01

--- a/services/flow-ui/tests/test_topology.py
+++ b/services/flow-ui/tests/test_topology.py
@@ -54,3 +54,24 @@ def test_the_empty_tables_carry_a_reason_not_just_a_name():
     for name, why in topology.EMPTY_BY_CONTRACT.items():
         assert name.startswith("otel_metrics_")
         assert "v1.0.0" in why
+
+
+def test_the_validation_policy_is_the_MODE_not_the_config_key():
+    """The regression this exists for: `CONTRACT["validation"]` was hard-coded to the
+    literal string `"grpc_validation"` — the config KEY — and every board rendered it where
+    it meant the mode. A policy board whose headline is the policy cannot guess it."""
+    from flow_ui import topology
+
+    assert topology.grpc_validation() in ("off", "warn", "strict", "unknown")
+    assert topology.CONTRACT["validation"] == topology.grpc_validation()
+    assert topology.CONTRACT["validation"] != "grpc_validation"
+
+
+def test_an_unreadable_collector_config_reports_unknown_not_a_default(monkeypatch, tmp_path):
+    """`warn` is the collector's default, which makes it exactly the wrong thing to assume:
+    a board that shows `warn` when it cannot read the policy is indistinguishable from one
+    reading a real `warn`, and the whole point of the panel is knowing which."""
+    from flow_ui import topology
+
+    monkeypatch.setattr(topology, "_COLLECTOR_CFG", (tmp_path / "nope.yaml",))
+    assert topology.grpc_validation() == "unknown"

--- a/services/flow-ui/tests/test_topology.py
+++ b/services/flow-ui/tests/test_topology.py
@@ -1,0 +1,56 @@
+"""The declared topology, read from the producer's own config rather than redrawn."""
+from __future__ import annotations
+
+from flow_ui import topology
+
+
+def test_the_graph_comes_from_the_generators_own_config():
+    g = topology.service_graph()
+    assert g["source"] and g["source"].endswith("topology/default.yaml")
+    assert g["version"] == "1.0.0"
+
+
+def test_every_component_becomes_a_node():
+    assert len(topology.service_graph()["nodes"]) == 7
+
+
+def test_edges_point_the_way_data_flows_not_the_way_the_yaml_reads():
+    """`depends_on: [a]` on b means a produces what b consumes, so the edge is a → b.
+    Reading it the other way would draw every arrow backwards — the kind of mistake a
+    diagram never announces."""
+    g = topology.service_graph()
+    edges = {(e["from"], e["to"]) for e in g["edges"]}
+    assert ("messaging.ingestion_topic", "compute.spark_batch") in edges
+    assert ("compute.spark_batch", "messaging.ingestion_topic") not in edges
+    assert len(edges) == 8
+
+
+def test_roots_are_the_components_that_depend_on_nothing():
+    roots = {n["service"] for n in topology.service_graph()["nodes"] if n["roots"]}
+    assert roots == {"pubsub-ingestion-topic", "cloud-composer-etl"}
+
+
+def test_a_missing_config_degrades_to_an_empty_graph(monkeypatch):
+    """The page must still render where the generator config is not mounted."""
+    monkeypatch.setattr(topology, "_CANDIDATES", ())
+    g = topology.service_graph()
+    assert g == {"nodes": [], "edges": [], "source": None}
+
+
+def test_table_docs_only_list_columns_pod_2_actually_writes():
+    """Contract §2: every other bronze column stays at its ClickHouse default by design.
+    Listing the full DDL would misrepresent what a consumer may rely on."""
+    cols = {c[0] for c in topology.TABLE_DOCS["otel_logs"]["columns"]}
+    assert "Body" in cols and "ServiceName" in cols
+    assert "TraceFlags" not in cols and "ScopeName" not in cols
+
+
+def test_optional_ids_are_documented_as_empty_string_never_null():
+    doc = dict((c[0], c[2]) for c in topology.TABLE_DOCS["otel_logs"]["columns"])
+    assert "never NULL" in doc["TraceId"]
+
+
+def test_the_empty_tables_carry_a_reason_not_just_a_name():
+    for name, why in topology.EMPTY_BY_CONTRACT.items():
+        assert name.startswith("otel_metrics_")
+        assert "v1.0.0" in why

--- a/services/flow-ui/tests/test_topology.py
+++ b/services/flow-ui/tests/test_topology.py
@@ -46,7 +46,7 @@ def test_table_docs_only_list_columns_pod_2_actually_writes():
 
 
 def test_optional_ids_are_documented_as_empty_string_never_null():
-    doc = dict((c[0], c[2]) for c in topology.TABLE_DOCS["otel_logs"]["columns"])
+    doc = {c[0]: c[2] for c in topology.TABLE_DOCS["otel_logs"]["columns"]}
     assert "never NULL" in doc["TraceId"]
 
 

--- a/services/generator-python/src/otelgen/exporters/otlp.py
+++ b/services/generator-python/src/otelgen/exporters/otlp.py
@@ -114,6 +114,26 @@ class OTLPExporter(Exporter):
             trace_flags=TraceFlags(TraceFlags.SAMPLED),
         )
 
+        # The parent link. `ScenarioEngine` already assembles correlated traces by walking
+        # `depends_on`, and every other path carries the result: the model has the field, the
+        # ClickHouse exporter writes it, `otlp_output.schema.json` declares it as 16 hex
+        # characters, and the Pod 2 -> Pod 3 read contract documents `ParentSpanId` as `''`
+        # *for root spans* — which only means anything if non-root spans have one.
+        #
+        # This path dropped it. `ReadableSpan` was built with a context and no `parent`, so
+        # `trace_id` survived onto the wire and the parent did not: measured over a live run,
+        # traces were correlated (8.5 spans each, 30k of them spanning more than one service)
+        # while 1,491,881 of 1,491,881 spans arrived in bronze as roots. A call graph that
+        # exists in the generator and nowhere downstream.
+        parent_ctx = None
+        if signal.parent_span_id:
+            parent_ctx = SpanContext(
+                trace_id=trace_id_int,
+                span_id=int(signal.parent_span_id, 16),
+                is_remote=False,
+                trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            )
+
         status = Status(
             StatusCode.ERROR if signal.status_code == "ERROR" else StatusCode.OK
         )
@@ -124,6 +144,7 @@ class OTLPExporter(Exporter):
         return ReadableSpan(
             name=signal.name,
             context=ctx,
+            parent=parent_ctx,
             resource=resource,
             instrumentation_scope=scope,
             attributes=signal.attributes,

--- a/services/generator-python/tests/unit/test_otlp_exporter.py
+++ b/services/generator-python/tests/unit/test_otlp_exporter.py
@@ -268,3 +268,38 @@ class TestOTLPExporterExport:
         )
         exporter.export([error_span])
         mock_span_exp.export.assert_called_once()
+
+
+def test_a_child_span_carries_its_parent_onto_the_wire():
+    """The regression this exists for.
+
+    `ScenarioEngine` assembles correlated traces by walking `depends_on`, the model carries
+    the result, the ClickHouse exporter writes it, `otlp_output.schema.json` declares
+    `parent_span_id` as 16 hex characters, and the Pod 2 -> Pod 3 read contract documents
+    `ParentSpanId` as `''` *for root spans* — which only means something if non-root spans
+    have one. This path built `ReadableSpan` with a context and no `parent`, so `trace_id`
+    reached the wire and the parent did not: measured on a live run, traces arrived
+    correlated (8.5 spans each, 30k spanning more than one service) and 1,491,881 of
+    1,491,881 spans landed in bronze as roots. The call graph existed in the generator and
+    nowhere downstream.
+    """
+    from otelgen.exporters.otlp import OTLPExporter
+
+    from dataclasses import replace
+
+    child = replace(_make_span(), parent_span_id="c" * 16)
+
+    span = OTLPExporter._build_readable_span(OTLPExporter.__new__(OTLPExporter), child)
+
+    assert span.parent is not None, "a child span must reach the wire with its parent"
+    assert span.parent.span_id == int("c" * 16, 16)
+    # Same trace on both ends, or the two spans are not in one trace at all.
+    assert span.parent.trace_id == span.context.trace_id
+
+
+def test_a_root_span_has_no_parent_and_is_not_given_a_fake_one():
+    from otelgen.exporters.otlp import OTLPExporter
+
+    root = _make_span()          # parent_span_id is None
+    span = OTLPExporter._build_readable_span(OTLPExporter.__new__(OTLPExporter), root)
+    assert span.parent is None


### PR DESCRIPTION
A pipeline that watches itself: four boards over the collector's `/metrics` and `bronze.*`,
read-only. Nothing in the pipeline depends on it being up.

```bash
make up && make ui                     # → http://localhost:8080
make generate-stream DURATION=10m
```

Full walkthrough, and how to make each failure path move, in
[`services/flow-ui/README.md`](services/flow-ui/README.md).

---

## ⚠️ One file belongs to Pod 1 and needs their review

**`services/generator-python/src/otelgen/exporters/otlp.py`** (commit `00013d1`, ~20 lines
plus two tests).

`ReadableSpan` was built with a context and no `parent`, so `trace_id` reached the wire and
the parent did not. Everything around it was already right: `ScenarioEngine` assembles
correlated traces by walking `depends_on`, the model carries `parent_span_id`, the ClickHouse
exporter writes it, `otlp_output.schema.json` declares it as 16 hex characters, and the Pod 2
→ Pod 3 read contract documents `ParentSpanId` as `''` **for root spans** — which only means
something if non-root spans have one.

Measured on a live run before the fix: traces arrived correlated (8.5 spans each, 30k of them
spanning more than one service) while **1,491,881 of 1,491,881 spans landed in bronze as
roots**. A call graph that existed in the generator and nowhere downstream. After: 310 of 518
in a fresh window carry a parent.

**This changes what lands in bronze for every consumer** — non-root spans now carry
`ParentSpanId`. It is what the contract already promised, but it is an observable behaviour
change and anyone who assumed "all roots" should know.

---

## What the boards do

| Board | |
|---|---|
| **Flow** | one pan/zoom canvas, boxes expand in place. The flow runs through pipes; whatever falls **out** of a pipe is a thin line, so an outcome is a different object from the flow rather than the same object at another weight |
| **Health** | the verdict and the sentence behind it, 120s series, latency quantiles from the Prometheus histogram |
| **Contract** (V2.1) | the receive boundary: **what would be dropped under `strict`**, violations per signal over the window, and which producers wrote rows missing a required key |
| **Watchers** (V2.2) | rows per minute per producer against a band — and **the band drawn is the alerting rule** |

**V2.3** fuses per-producer state onto the DAG and draws edges at what they were measured
carrying, with colour from that edge's error rate.

## Three things it refuses to draw

Each was asked for by the V2 shortlist and is not measurable. None was faked; each is
recorded in `STATUS.md` with the evidence.

- **Contract-version adoption per producer.** `otlp.rs` injects `CONTRACT_VERSION` into every
  signal it builds, so every producer reads back the collector's own constant.
- **The Arrival watcher and V2.4 freshness.** Bronze carries `Timestamp` (event time) and two
  columns derived from it, and nothing else — there is nowhere to read when a row arrived.
  Adding one is a collector change against a contract Authoritative at `1.0.0.1`: an ADR, not
  UI work.
- **A per-node state timeline.** Needs per-service history, which nothing retains.

## Findings the work surfaced

- **Two producers write into bronze that are in no declared topology** — `legacy-billing-api`
  and `third-party-agent`, and they are the only two with contract violations. Nothing
  declared them, so nothing told them the contract. Reported apart from the graph, because
  they have no position in it.
- **The measured call graph is a subgraph of the declared one.** `spark_streaming →
  processed_bucket` and `→ k8s-api-gateway` are declared and carry no span, because the engine
  parents every child to `depends_on[0]`. Drawn dashed — *declared, never traced*.
- **`topology.CONTRACT["validation"]` was hard-coded to the string `"grpc_validation"`** — the
  config *key*, not its value — and every board rendered it where it meant the mode. Now read
  from the collector's own config, reporting `unknown` rather than guessing `warn`.

## Before merging

- **`make test` and `make lint` now cover flow-ui.** They did not, while CLAUDE.md called
  `make test` "all unit suites". Adding the targets meant clearing seven pre-existing lint
  findings; both aggregates are green across all three services.
- **The commits are unsigned.** No GPG key on the machine they were made on, so they used
  `--no-gpg-sign`. They need re-signing before this reaches `main`.
- A `/code-review` pass over the branch before opening this found eight defects, all real, all
  fixed in `11c1aba` — including a self-join that inflated every measured edge 27.6x.

## Not covered by tests

SVG geometry. Where things land on the canvas is checked by looking, and that gap has cost
real defects: a detail panel drawn over the nodes it describes, two header collisions, and a
pipe routed out from under the box it was meant to reach.


<img width="1694" height="1309" alt="image" src="https://github.com/user-attachments/assets/da74b791-9c9f-4a9e-823e-f5a344c39cbe" />

<img width="1714" height="380" alt="image" src="https://github.com/user-attachments/assets/aaecf65e-11be-4ab3-94e2-e9a727375c19" />

<img width="1694" height="1122" alt="image" src="https://github.com/user-attachments/assets/98c24bf4-973a-4845-a059-7e3fd42cd8b2" />

<img width="1706" height="999" alt="image" src="https://github.com/user-attachments/assets/e7307946-3091-4c28-9b72-fba8a3cb4f99" />

<img width="1689" height="1023" alt="image" src="https://github.com/user-attachments/assets/9f345809-1ded-4140-a7e7-a89df40ba247" />

<img width="1700" height="860" alt="image" src="https://github.com/user-attachments/assets/80a3b812-8a84-4390-ba00-f0e52c44cb5d" />
