### PR TITLE
feat(process): pull request template, issue anatomy, roadmap pointers

### DIFF
--- a/.claude/docs/ROADMAP.md
+++ b/.claude/docs/ROADMAP.md
@@ -1,5 +1,10 @@
 # `.claude/` Roadmap
 
+> **Looking for the product roadmap?** It is
+> [`docs/research/data-observability-competitive-landscape.md`](../../docs/research/data-observability-competitive-landscape.md)
+> §6 — the ranked V2 shortlist for `services/flow-ui`, with what has shipped tracked in
+> [`services/flow-ui/STATUS.md`](../../services/flow-ui/STATUS.md). **This file is not that.**
+>
 > Evolution plan for Sentinel's Claude Code knowledge system.
 > Last updated: 2026-08-18
 

--- a/.claude/kb/process/crew-b-wow/index.md
+++ b/.claude/kb/process/crew-b-wow/index.md
@@ -219,6 +219,43 @@ Every work item — feature, bug, spike, or research task — lives as a GitHub 
 - Issues are closed by a merged PR, not by hand.
 - `good-first-issue` is the sacred tag. Captain pre-tags 5-10 per sprint before the Tuesday sync. These are the entry points for Astronautas picking up new work.
 
+### Anatomy
+
+Derived from the Commander's own issues (#4–#23, 2026-05-26), which are the only worked
+examples the repo has. Recorded here because it was practice and nowhere written, so anyone
+opening the twentieth issue had to reverse-engineer it from the first nineteen.
+
+**Title** — `[TYPE] Short imperative description`, where TYPE is `EPIC`, `FEATURE`,
+`COMPONENT`, `ADR-NNN`, `CA` (Commander Attention) or `BLOCKER`.
+
+**Labels — four axes, always all four:**
+
+| Axis | Values |
+|---|---|
+| crew | `crew-a` … `crew-d` |
+| type | `type:epic` · `type:feature` · `type:component` · `type:task` · `type:adr` · `type:blocker` · `type:commander-attention` |
+| priority | `priority:p0` · `priority:p1` · `priority:p2` |
+| phase | `phase:backlog` · `phase:spec` · `phase:design` · `phase:build` · `phase:review` · `phase:ship` |
+
+Plus `blocked` when something external is holding it.
+
+**Body** — two header lines, then prose:
+
+```markdown
+**Feature:** <the feature or area this belongs to>
+**Parent Epic:** https://github.com/luanmorenommaciel/sentinel/issues/4
+
+<What and why, in a few sentences. Evidence or a quote where it decides something.>
+```
+
+**Bodies are short.** #19 is three sentences; #21 is a quoted example plus one line. An issue
+states *what* and *why*; *how* belongs in the PR that closes it. Decision issues (`ADR-NNN`,
+`CA`) add a `## Decision` or `## Decision Required` heading and nothing else.
+
+**Issues are closed by a merged PR, not by hand** — restated here because it is the rule most
+often broken when an issue has drifted rather than been delivered. An issue that no longer
+makes sense is closed with the reason, not silently.
+
 ---
 
 ## Lego Principle

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,17 @@ Closes #
 
      For anything visual, a screenshot. For a fix, the numbers before and after. -->
 
+## What could this break, and how did you check?
+
+<!-- A different question from "does it work", and the one a green suite does not answer.
+
+     Name what you touched that something else depends on — a contract, a shared query, a
+     schema, a column something reads, a public path — and say how you checked it still
+     holds. "Nothing depends on this" is a good answer when it is true.
+
+     Until CI runs every suite (#34), this section is the only thing standing between a
+     regression and `main`. -->
+
 ---
 
 <!-- Before requesting review:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## What
+
+<!-- One or two sentences: what changes. Not how. -->
+
+## Why
+
+Closes #
+
+<!-- The issue carries the why. No issue? Say why here and add the `no-issue` label. -->
+
+## Tests / evidence
+
+<!-- What you ran and what it showed.
+
+     "make test passes" is a claim. The output is the evidence:
+
+         make test      → 178 + 57 pytest, 92 cargo, 60 silver asserts, all green
+         make lint      → exit 0
+
+     For anything visual, a screenshot. For a fix, the numbers before and after. -->
+
+---
+
+<!-- Before requesting review:
+     - [ ] commits are signed (`git commit -S`) — `main` requires it
+     - [ ] commit messages follow Conventional Commits
+     - [ ] `Co-Authored-By:` trailers for every human and LLM that contributed  -->

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -1,0 +1,44 @@
+name: PR links an issue
+
+# `edited` and `labeled` matter as much as `opened`: without them a PR that fails, then gets
+# its `Closes #` added or the escape-hatch label applied, never re-runs and stays red.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  linked-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a closing issue reference
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          if printf '%s' "$LABELS" | grep -q '"no-issue"'; then
+            echo "::notice::'no-issue' label present — not every change needs an issue."
+            exit 0
+          fi
+
+          # `closingIssuesReferences` is what a `Closes #n` keyword produces, and what the
+          # Development sidebar produces. A bare `#n` mention produces a cross-reference and
+          # nothing here, which is the trap this check exists to catch.
+          linked=$(gh pr view "$PR" --repo "$REPO" \
+                     --json closingIssuesReferences --jq '.closingIssuesReferences | length')
+
+          if [ "$linked" -eq 0 ]; then
+            echo "::error::This PR closes no issue. Put 'Closes #<n>' in the description, or apply the 'no-issue' label if it genuinely needs none."
+            exit 1
+          fi
+
+          gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[] | "closes #\(.number) — \(.title)"'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ services/
   flow-ui/                 # the pipeline watching itself — four boards over /metrics + bronze
 infra/                     # ClickHouse bootstrap (users/db init + users.d network override + bronze DDL in init.d/)
 docs/                      # shared docs (ADRs, research, proposals)
+                           #   research/ holds the V2 product roadmap for flow-ui:
+                           #   data-observability-competitive-landscape.md §6
 docker-compose.yml         # root orchestrator
 Makefile                   # one-command UX
 ```

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -194,6 +194,17 @@ uv venv && uv pip install -e . && uv pip install pytest pytest-asyncio
 .venv/bin/uvicorn flow_ui.main:app --reload --port 8080
 ```
 
+## Roadmap
+
+Shipped and next, in order: [`STATUS.md`](STATUS.md).
+
+The ranked shortlist it draws from is
+[`docs/research/data-observability-competitive-landscape.md`](../../docs/research/data-observability-competitive-landscape.md)
+**§6**, ordered by *(differentiation × evidence) ÷ effort*. The filename says what the
+document *is* — a survey of what the category ships — and §6 is what it is *for*. Note that
+`.claude/docs/ROADMAP.md` is a different thing entirely: the plan for the knowledge system,
+not for this service.
+
 ## Contracts this reads
 
 - **`contracts/collector/v1/pod2-pod3-read-contract.md` v1.0.0.1** — the bronze semantics. Only


### PR DESCRIPTION
## What

A `.github/PULL_REQUEST_TEMPLATE.md`, plus the two documentation gaps found while writing it:
the issue anatomy the Commander has been using, and a set of pointers to the product roadmap.

## Why

Closes #33.

The other two are the same problem one step earlier — process that exists only as a pattern
in past artifacts, which every newcomer has to reverse-engineer:

- **The issue anatomy** lived only across #4–#23. Title format, four label axes, two header
  lines, and the part easiest to get wrong: bodies are short. #19 is three sentences. There is
  no `.github/ISSUE_TEMPLATE/` either. Written into the WoW KB, which already had rules for
  issues and nothing about their shape.
- **The product roadmap** (`docs/research/data-observability-competitive-landscape.md` §6) was
  referenced by exactly one file. Its filename says what the document *is*, not what it is
  *for*, and `.claude/docs/ROADMAP.md` — a different thing, the knowledge system's plan — is
  what a search for "roadmap" finds first. That has already cost one fruitless hunt. Three
  pointers added, nothing renamed or moved.

## Tests / evidence

Documentation only; no code paths touched.

- Every relative link and the `§6` anchor checked against the tree — 4 links, all resolve.
- `CLAUDE.md` conflicted against `f064f51` (docs refresh after the Rust selection) during the
  rebase onto current `main`; kept upstream's wording, which was correct — the stashed version
  still said `docker-compose.yml # root orchestrator (rust|go profiles)`, obsolete since
  `collector-go` was deleted.
- Confirmed no duplicate roadmap pointers already existed on `main`.

## Note for review

The template's `Closes #` prompt is only the cheap half of "every PR links an issue". The
enforcing half is a CI check on `closingIssuesReferences` with a `no-issue` escape hatch, and
it is not in this PR — it belongs with #34 (CI) and #36 (how process gets enforced).
