### PR TITLE
docs: correct the live documents that describe a repo two merges out of date

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -134,10 +134,11 @@ Each agent has its own `.md` under `.claude/agents/<category>/<name>.md`. All ag
 
 Skill frontmatter follows [`.claude/skills/_template.md.example`](skills/_template.md.example).
 
-## Rules (1 path-scoped file)
+## Rules (2 path-scoped files)
 
 | Rule | Scope | Purpose |
 |---|---|---|
+| [`pre-pr-discipline.md`](rules/pre-pr-discipline.md) | all | Two checks before a PR: does an issue cover this (propose, never create unprompted), and which documents describe what changed. Both detect-and-propose. Written after #40 found a merged service with zero mentions in the README. |
 | [`kb-enrichment.md`](rules/kb-enrichment.md) | all | Policy: knowledge discovered during sessions must flow back into `.claude/kb/` via `/enrich-kb` or `/create-kb`. Defines the decision tree for KB vs. CLAUDE.md placement and the dating + confidence convention. |
 
 ## Knowledge Base (11 seed KBs)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Sentinel — Claude Code Project Context
 
-> Last updated: 2026-08-18
+> Last updated: 2026-09-02
 
 ## Mission
 
@@ -27,6 +27,29 @@ otel_core → rolling_stats → tiered_engine → cross_watcher → policy_engin
 
 **6 Watcher Crews:** Arrival · Parse · Volume · Schema · Latency · Storage.
 **3-tier detection cascade:** Statistical (z-scores) → Pattern (signature) → LLM (Haiku→Sonnet→Opus). *Cheapest tier wins. Opus only when Sonnet confidence is low AND blast radius is high.*
+
+## What exists today
+
+Three services and two data layers, all verified running:
+
+| | | |
+|---|---|---|
+| `services/generator-python` | Pod 1 — OTLP generator | 178 pytest |
+| `services/collector-rust` | Pod 2 — OTLP → `bronze.*` | 92 inline + 4 integration |
+| `services/flow-ui` | the pipeline watching itself · `:8080` · read-only | 57 pytest |
+| `bronze.*` | ADR-0007 · 4 live tables + 3 empty by contract | applied on ClickHouse boot |
+| `silver.*` | ADR-0010 · 3 typed models + 6 read views | 60 SQL asserts |
+
+**flow-ui** (merged in PR #31) has four boards over the collector's `/metrics` and a read-only
+view of bronze: *Flow* (the path, expandable in place), *Health*, *Contract* (what would be
+dropped under `strict`, and which producers violate), *Watchers* (rows/min per producer against
+a band, where the band drawn **is** the alerting rule). Nothing in the pipeline depends on it.
+It re-derives from Bronze several things Silver was built to serve —
+[#37](https://github.com/luanmorenommaciel/sentinel/issues/37).
+
+**Silver is defined but not necessarily deployed**: the DDL runs on ClickHouse boot, so a
+volume older than the merge will not have it, and the MVs do not `POPULATE` — they see new
+inserts only.
 
 ## Current state (Pod 2 — `collector-rust`)
 
@@ -130,7 +153,7 @@ Skill frontmatter follows [`.claude/skills/_template.md.example`](skills/_templa
 | Languages | `kb/languages/go/` | Concurrency, channels, OTel Collector internals *(retained as reference; the Go collector was removed in PR #28)* |
 | Contracts | `kb/contracts/` | Pydantic (Python), Protobuf (Go/Rust), versioning, boundary validation |
 | Detection | `kb/detection/anomaly-detection/` | Statistical baselines, z-scores, rolling windows |
-| Process | `kb/process/crew-b-wow/` | Sentinel WoW: syncs, ADRs, PR flow, attribution, 7 CI gates |
+| Process | `kb/process/crew-b-wow/` | Sentinel WoW: syncs, ADRs, PR flow, attribution, CI gates |
 | Patterns | `kb/patterns/agentic-architecture/` | Packt *Agentic Architectural Patterns* book index — when to consult |
 
 Browse `.claude/kb/README.md` for the full index with decision frameworks.
@@ -169,7 +192,7 @@ Per Sync 01 + `bem-vindos.md`:
 - **Conventional Commits.** `<type>(<scope>): <description>`
 - **Signed commits.** `git commit -S`.
 - **Mandatory attribution trailer** on every commit: `Co-Authored-By: <human>`, `Co-Authored-By: <LLM model>`, optional `Reviewed-by: <bot>`.
-- **7 CI gates** (all must pass before human review): ruff · mypy --strict · pytest >80% · bandit + safety · markdownlint · CodeRabbit · Docker build. ⚠️ This is the *agreement* from Sync 01, not the current state: only [`rust-ci.yml`](../.github/workflows/rust-ci.yml) is implemented today.
+- **CI gates.** ⚠️ Two workflows exist — `rust-ci.yml` and `pr-linked-issue.yml`. The seven the WoW names (ruff · mypy --strict · pytest >80% · bandit + safety · markdownlint · CodeRabbit · Docker build) are a **target, not a description**: none runs, and the four Python/Silver suites gate nothing ([#34](https://github.com/luanmorenommaciel/sentinel/issues/34)). ⚠️ This is the *agreement* from Sync 01, not the current state: only [`rust-ci.yml`](../.github/workflows/rust-ci.yml) is implemented today.
 - **2 approvals** required: first peer, second Captain. Squash-merge to main *(ADR-0009 proposes a merge commit for swimlane→main — pending ratification)*.
 - **Weekly sync** Tuesday Zoom ~60min.
 - **Tool freedom on input, rigor on output.** Pick any LLM coding tool (Claude Code, Cursor, Codex CLI, Aider, etc.); the contract is honest attribution + 7-gate CI.

--- a/.claude/agents/code-quality/test-generator.md
+++ b/.claude/agents/code-quality/test-generator.md
@@ -32,7 +32,7 @@ Read these before writing tests. They encode Sentinel's conventions; deviating w
 | Source | Use for |
 |---|---|
 | [`.claude/kb/languages/rust/index.md`](../../kb/languages/rust/index.md) | Tokio async test patterns, `Result<T, E>` exhaustive matching, anyhow vs thiserror in test assertions |
-| [`.claude/kb/process/crew-b-wow/`](../../kb/process/crew-b-wow/) | 7 CI gates, signed commits, Conventional Commits for `test:` scope |
+| [`.claude/kb/process/crew-b-wow/`](../../kb/process/crew-b-wow/) | CI gates, signed commits, Conventional Commits for `test:` scope |
 | [`.claude/kb/contracts/`](../../kb/contracts/) | Pydantic + Protobuf contract conventions; every field gets a positive + negative test |
 | [`.claude/kb/telemetry/`](../../kb/telemetry/) | OTLP gRPC fixture shape — what a `signal_type=log` vs `=span` vs `=metric` looks like on the wire |
 | [`.claude/kb/patterns/agentic-architecture/`](../../kb/patterns/agentic-architecture/) | Tiered-detection test seams (mock LLM tier 3 in unit tests; only hit live LLMs in nightly e2e) |
@@ -177,7 +177,7 @@ This test fails on `main` and passes after the fix — anchoring the regression 
 
 ## See also
 
-- [`.claude/CLAUDE.md`](../../CLAUDE.md) — project context, 7 CI gates, 80% coverage rule, agent inventory.
+- [`.claude/CLAUDE.md`](../../CLAUDE.md) — project context, CI gates, 80% coverage rule, agent inventory.
 - [`.claude/agents/code-quality/code-reviewer.md`](./code-reviewer.md) — sibling agent; reviews the tests this agent writes.
 - [`.claude/agents/languages/rust-specialist.md`](../languages/rust-specialist.md) — defers to this agent for Rust idioms beyond test scaffolding.
 - [`.claude/agents/data/otel-collector-specialist.md`](../data/otel-collector-specialist.md) — owns OTLP correctness; consulted on wire-format test assertions.

--- a/.claude/docs/CREW_B_GLOSSARY.md
+++ b/.claude/docs/CREW_B_GLOSSARY.md
@@ -1,6 +1,6 @@
 # Crew B Glossary
 
-> Last updated: 2026-06-01
+> Last reviewed: 2026-09-02 — corrected the CI-gate entry, which described gates that do not exist
 
 Sentinel uses program-specific terminology that doesn't always map cleanly to industry conventions. This glossary keeps everyone (and every agent) on the same page.
 
@@ -36,7 +36,7 @@ Sentinel uses program-specific terminology that doesn't always map cleanly to in
 | **Sprint 1 ADRs** | The three foundational ADRs assigned in `bem-vindos.md`: ADR-001 (blast radius), ADR-002 (baseline), ADR-003 (primary user). All owed by end of Sprint 1. |
 | **good-first-issue** | The sacred tag for backlog items suitable as an Astronaut's first PR of the sprint. Captain pre-tags 5–10 per sprint. Closed by PR, not by hand. |
 | **Weekly Sync** | Tuesday, Zoom, ~60 minutes. Pod assignments confirmed, first PRs reviewed live, ADRs progressed. |
-| **The 7 CI gates** | Required green-light checks before human review: ruff · mypy --strict · pytest >80% · bandit + safety · markdownlint · CodeRabbit · Docker build. CI fail = no human review. |
+| **The 7 CI gates** | The *target* set of checks — ruff · mypy --strict · pytest >80% · bandit + safety · markdownlint · CodeRabbit · Docker build. ⚠️ **None of them runs today.** What runs is `rust-ci.yml` and `pr-linked-issue.yml`; the four Python and Silver suites are green locally and gate nothing ([#34](https://github.com/luanmorenommaciel/sentinel/issues/34)). |
 | **The Contract** (capital C) | Every commit on `sentinel` declares its contributors via mandatory `Co-Authored-By:` trailers — human, LLM model, and bot (CodeRabbit `Reviewed-By:`). Visible in `git log --author` forever. |
 | **Tool freedom** | The Astronaut picks any agentic coding tool (Claude Code, Cursor, Codex CLI, Aider, Zed AI, Kimi K2, Cline, Windsurf, or propose another). The non-negotiable is *attribution*. |
 | **Lego principle** | Every component declares input/output contracts (Pydantic in Python, Protobuf in Go/Rust). Components are swappable — change what's inside the boundary; the contract holds. |

--- a/.claude/docs/INGESTION_WORKFLOW.md
+++ b/.claude/docs/INGESTION_WORKFLOW.md
@@ -1,6 +1,6 @@
 # Document Ingestion Workflow
 
-> Last updated: 2026-06-01
+> Last reviewed: 2026-09-02 · unchanged since 2026-06-01 — describes a process, not repo state
 
 ## Why this exists
 

--- a/.claude/docs/OCR_STRATEGY.md
+++ b/.claude/docs/OCR_STRATEGY.md
@@ -1,6 +1,6 @@
 # OCR & Document-Extraction Strategy
 
-> Last updated: 2026-06-01
+> Last reviewed: 2026-09-02 · unchanged since 2026-06-01 — describes a process, not repo state
 
 ## Why this doc exists
 

--- a/.claude/docs/RUST_PROJECT_STANDARDS.md
+++ b/.claude/docs/RUST_PROJECT_STANDARDS.md
@@ -420,7 +420,7 @@ A Sentinel contributor types `just setup` at the root after cloning (which deleg
 
 ## CI mapping to the Crew B 7-gate spec
 
-The Crew B WoW defines 7 CI gates. Per-language profiles map them:
+The Crew B WoW names seven CI gates as a target — **none of them runs today**; see the WoW's Step 4 for what actually does. The per-language profile below is what Rust maps onto once they exist, and `rust-ci.yml` already implements most of it:
 
 | Crew B gate | Python (via UV) | Rust |
 |---|---|---|
@@ -571,5 +571,5 @@ Three minutes from clone to running the Collector. Same vibe as `uv sync && uv r
 - `services/collector-rust/README.md` — the canonical example service README
 - `docs/adr/0004-collector-implementation-language.md` — why we're doing Rust at all
 - `kb/languages/rust/` — deeper Rust technique KB (idioms, tokio patterns, error handling, async lifetimes)
-- `kb/process/crew-b-wow/` — the 7 CI gates this maps to
+- `kb/process/crew-b-wow/` — the CI gates this maps to
 - Python equivalent in our other projects: `briefing-hub/pyproject.toml`, `duck-quant/pyproject.toml`

--- a/.claude/kb/README.md
+++ b/.claude/kb/README.md
@@ -39,7 +39,7 @@
 ### Process
 | KB | What it covers |
 |---|---|
-| [`process/crew-b-wow/`](process/crew-b-wow/index.md) | Crew B Way of Working — roles, sprints, ADRs, 8-step PR flow, 7 CI gates, attribution contract |
+| [`process/crew-b-wow/`](process/crew-b-wow/index.md) | Crew B Way of Working — roles, sprints, ADRs, 8-step PR flow, CI gates, attribution contract |
 
 ### Communication
 | KB | What it covers |

--- a/.claude/kb/languages/go/index.md
+++ b/.claude/kb/languages/go/index.md
@@ -337,7 +337,7 @@ close(done) // broadcast to all receivers
 - `../rust/index.md` — Rust KB sibling (Tokio, tonic, the bake-off counterpart)
 - `../../telemetry/otel-collector/index.md` — receiver/processor/exporter pipeline concepts
 - `../../storage/clickhouse/index.md` — ClickHouse schema, OTel table layout, connection tuning
-- `../../process/crew-b-wow/index.md` — 7 CI gates, PR flow, ADR process
+- `../../process/crew-b-wow/index.md` — CI gates, PR flow, ADR process
 - `../../../CLAUDE.md` — KB routing table, terminology guardrails
 - `../../../docs/RUST_PROJECT_STANDARDS.md` — Rust standards (parallel to these Go conventions)
 - `docs/adr/0004-collector-implementation-language.md` — Go vs Rust bake-off decision record

--- a/.claude/kb/process/crew-b-wow/index.md
+++ b/.claude/kb/process/crew-b-wow/index.md
@@ -133,7 +133,7 @@ For agent-authored changes, the eight steps run inside the isolation and governa
 flowchart TD
     A[Branch off main\nfeat/area-short] --> B[Conventional Commits\n+ attribution trailers]
     B --> C[Push signed commits]
-    C --> D{7 CI gates pass?}
+    C --> D{CI gates pass?}
     D -- No --> E[Fix locally. CI fail = no human review.]
     D -- Yes --> F[CODEOWNERS auto-routes\nto reviewer]
     F --> G[Optional: /claude review]
@@ -152,6 +152,12 @@ docs/<area>-<short-description>
 ```
 
 Examples: `feat/collector-otlp-receiver`, `docs/adr-0004-go-rust-bakeoff`, `fix/b2-grpc-shutdown`.
+
+⚠️ [ADR-0009](../../../../docs/adr/0009-agentic-gitflow.md) introduces a second, finer level —
+`leg/<area>/<task>-v<n>` for a parallelizable chunk worked in its own worktree — and lists only
+`feat/` and `leg/` as prefixes. Whether `fix/`, `chore/` and `docs/` survive is open, and so is
+how any of it gets enforced:
+[#36](https://github.com/luanmorenommaciel/sentinel/issues/36).
 
 ### Step 2 — Conventional Commits + attribution
 
@@ -173,30 +179,54 @@ The `Co-Authored-By` trailers for human and LLM are **mandatory**. `Reviewed-by`
 
 ### Step 3 — Signed commits
 
-All commits must be GPG-signed (`git commit -S`). `main` enforces this at the branch protection level.
+All commits must be GPG-signed (`git commit -S`).
 
-### Step 4 — 7 CI gates
+⚠️ **`main` does not currently enforce this, or anything else** — the branch has no protection
+rules at all, so unsigned commits and unreviewed pushes both go through. Signing remains the
+rule; it is presently honour-based. Tracked in
+[#35](https://github.com/luanmorenommaciel/sentinel/issues/35), which needs an admin.
 
-CI runs on every push. All gates must be green before human review is requested:
+### Step 3b — Open the PR against the template
 
-| Gate | What it checks | Language |
-|------|---------------|----------|
-| `ruff` | Lint + format | Python |
-| `mypy --strict` | Type safety | Python |
-| `pytest >80%` | Unit + integration coverage | Python |
-| `bandit + safety` | Security scan (SAST + dep vulns) | Python |
-| `markdownlint` | Docs format consistency | All |
-| `CodeRabbit` | AI code review (automated first pass) | All |
-| `Docker build` | Container builds clean | All |
+`.github/PULL_REQUEST_TEMPLATE.md` pre-fills three sections and one question:
 
-For Rust services (Pod B2), the per-language profile extends the above:
+- **What** changes — not how.
+- **Why**, which is `Closes #<n>`. **A PR that closes no issue fails `pr-linked-issue.yml`.**
+  Forgot? Edit the description and the check re-runs itself; the issue does not have to exist
+  before the PR. A change that genuinely needs none takes the `no-issue` label, which leaves a
+  record of who decided that.
+- **Tests / evidence** — `make test passes` is a claim, the output is the evidence.
+- **What could this break, and how did you check?** A different question from "does it work",
+  and the one a green suite does not answer.
 
-| Additional gate | What it checks |
-|----------------|----------------|
-| `cargo fmt --check` | Format (rustfmt.toml) |
-| `cargo clippy -- -D warnings` | Lint (strict) |
-| `cargo nextest run` | Test runner (replaces `cargo test`) |
-| `cargo audit` | Dependency security audit |
+A bare `#33` does **not** link. It needs the keyword — `Closes`, `Fixes` or `Resolves` —
+otherwise it is a cross-reference and the check will (correctly) fail.
+
+### Step 4 — CI gates
+
+**What actually runs today** — `.github/workflows/`, verified against the repository:
+
+| Workflow | Covers |
+|---|---|
+| `rust-ci.yml` | `cargo fmt --check` · `cargo clippy -D warnings` · `cargo test` · a round-trip against a live ClickHouse · `cargo-deny` · Docker build |
+| `pr-linked-issue.yml` | fails a PR that closes no issue, unless labelled `no-issue` |
+
+**What does not run, and should.** These four suites are green locally and gate nothing —
+a PR can break any of them and merge clean. Tracked in
+[#34](https://github.com/luanmorenommaciel/sentinel/issues/34):
+
+| Suite | Command | Size |
+|---|---|---|
+| generator-python | `make test-generator` | 178 pytest |
+| flow-ui | `make test-flow-ui` | 57 pytest |
+| Silver read models | `make test-silver` | 60 SQL asserts |
+| Python lint | `make lint` | ruff over both services |
+
+**The seven-gate target.** This section previously listed `ruff`, `mypy --strict`,
+`pytest >80%`, `bandit + safety`, `markdownlint`, `CodeRabbit` and `Docker build` as if they
+existed. None of them did. They remain the goal; they are written here as a backlog, not as a
+description of the present, because a process document that overstates its own enforcement
+teaches people to distrust it.
 
 Full Rust setup: `.claude/docs/RUST_PROJECT_STANDARDS.md`.
 

--- a/.claude/rules/kb-enrichment.md
+++ b/.claude/rules/kb-enrichment.md
@@ -1,7 +1,7 @@
 # KB Enrichment Rule
 
 > Knowledge discovered during development must flow back into the KB system.
-> *Last updated: 2026-06-01*
+> *Last reviewed: 2026-09-02 · unchanged since 2026-06-01 — describes a policy, not repo state*
 
 ## When to enrich
 

--- a/.claude/rules/pre-pr-discipline.md
+++ b/.claude/rules/pre-pr-discipline.md
@@ -1,0 +1,57 @@
+# Pre-PR Discipline Rule
+
+> Two checks before a pull request. Both are **detect and propose** — never act alone.
+> *Last reviewed: 2026-09-02*
+
+## 1. Does an issue cover this?
+
+**Before starting.** Search open issues for the work about to be done.
+
+- **Found one** → note the number. It goes in the PR as `Closes #<n>`.
+- **None** → say so, propose one (title, four labels, two-line body), and **wait for
+  confirmation**. Do not create it unprompted: the tracker is shared, and an issue nobody asked
+  for is noise with the Commander's name on it.
+- **Genuinely needs none** — a typo, a revert, a hotfix — say that instead of inventing one.
+  The PR takes the `no-issue` label, which records who decided.
+
+`pr-linked-issue.yml` fails a PR that closes no issue, so this is not optional; the only
+question is whether the issue is written before the work or after it. Either is fine — the
+check reads the end state, not the order.
+
+## 2. Which documents describe what I changed?
+
+**Before opening the PR.** A document that describes something which no longer exists is
+broken by the change that made it wrong, the same as a caller of a deleted function.
+
+```sh
+# What mentions the thing you touched?
+git ls-files '*.md' | xargs grep -ln "<service, target, table, flag>"
+
+# Does any live doc still claim something you just changed?
+git ls-files '*.md' | xargs grep -ln "<the old fact>"
+```
+
+For each hit: name it, say whether it still holds, and fix the ones that do not **in the same
+PR**. "Nothing describes this" is a good answer when it is true.
+
+**Do not update records to match the present.** `docs/adr/0*`, `.claude/sdd/**` and
+`docs/proposals/` are history. An ADR that weighs Go against Rust is correct even though
+`collector-go` is gone; rewriting it destroys what makes the decision readable. Only documents
+that assert the **present** are in scope.
+
+**Do not blanket-edit to look thorough.** A diff touching twenty markdown files to change a
+date is noise that hides the one file that mattered.
+
+## Why this exists
+
+Issue [#40](https://github.com/luanmorenommaciel/sentinel/issues/40) swept 88 markdown files
+and found `flow-ui` — a service with four boards and ~4k lines, merged in #31 — with **zero
+mentions in the root README**, and nine documents asserting seven CI gates that have never
+existed. Both drifted the same way: nobody was asked at the moment the change landed.
+
+## See also
+
+- [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) — the same two
+  questions, aimed at humans
+- [`kb-enrichment.md`](kb-enrichment.md) — the sibling rule, for knowledge that should reach the KB
+- [`.claude/kb/process/crew-b-wow/index.md`](../kb/process/crew-b-wow/index.md) — PR flow, step 3b

--- a/.claude/skills/adr/SKILL.md
+++ b/.claude/skills/adr/SKILL.md
@@ -5,7 +5,7 @@ description: Open a new Architecture Decision Record using the Sentinel template
 
 # /adr
 
-Scaffolds `docs/adr/NNNN-<kebab-title>.md` with the standard Sentinel ADR template, in `Proposed` status. The ADR is committed on its own feature branch and reviewed via the standard 8-step PR flow (signed commits, 2 approvals, 7 CI gates).
+Scaffolds `docs/adr/NNNN-<kebab-title>.md` with the standard Sentinel ADR template, in `Proposed` status. The ADR is committed on its own feature branch and reviewed via the standard 8-step PR flow (signed commits, 2 approvals, CI gates).
 
 ## Usage
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,15 @@ Closes #
      schema, a column something reads, a public path — and say how you checked it still
      holds. "Nothing depends on this" is a good answer when it is true.
 
+     Include the docs. A file that describes something which no longer exists is broken by
+     the change that made it wrong:
+
+         git ls-files '*.md' | xargs grep -ln "<what you touched>"
+
+     Fix the ones that no longer hold, here. Leave `docs/adr/`, `.claude/sdd/` and
+     `docs/proposals/` alone — those are records, and rewriting history to match the present
+     is what makes an ADR unreadable.
+
      Until CI runs every suite (#34), this section is the only thing standing between a
      regression and `main`. -->
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sentinel is an open-source observability + remediation system for data pipelines
 
 ## 1. System architecture
 
-Telemetry flows top-to-bottom through the Pods. **Phase 1 builds the data path:** Pod 1 *generates* telemetry and defines the OTLP contract, Pod 2 *ingests, validates, transforms, and exports* it, and Pod 3 *consumes* Pod 2's output contract for data modelling (bronze → silver → read models). **Watchers, detection, CrewAI-driven reasoning, and remediation are a future phase** layered on top. Each **gold gate** is a **contract boundary** — a versioned interface owned by the upstream Pod and consumed by the downstream one.
+Telemetry flows top-to-bottom through the Pods. **Phase 1 builds the data path:** Pod 1 *generates* telemetry and defines the OTLP contract, Pod 2 *ingests, validates, transforms, and exports* it, and Pod 3 *consumes* Pod 2's output contract for data modelling (bronze → silver → read models). **Watchers, detection, CrewAI-driven reasoning, and remediation are a future phase** layered on top. Alongside the path — not in it — **`flow-ui` observes the pipeline** from the collector's `/metrics` and a read-only view of bronze; nothing in the path depends on it being up. Each **gold gate** is a **contract boundary** — a versioned interface owned by the upstream Pod and consumed by the downstream one.
 
 ```mermaid
 flowchart TB
@@ -55,6 +55,12 @@ flowchart TB
     end
 
     POD3 -.->|"feeds future detection"| FUTURE
+
+    subgraph OBS["🔭 OBSERVABILITY · reads the path, is not in it"]
+        FLOW["flow-ui :8080<br/>four boards · read-only"]
+    end
+    POD2 -. "/metrics :9090" .-> FLOW
+    STORE -. "bronze.* read-only" .-> FLOW
 
     classDef contract fill:#fde68a,stroke:#b45309,stroke-width:4px,color:#3a2f00;
     classDef zone fill:#f1f5f9,stroke:#94a3b8,color:#0f172a;
@@ -144,7 +150,9 @@ sentinel/
 ├── infra/                         # 🔗 SHARED · ClickHouse bootstrap
 │   ├── clickhouse-init.sql                #   db/users init (dev-only auth)
 │   ├── clickhouse-users.d/                #   default-user network override (Rust HTTP path)
-│   └── clickhouse/init.d/01-bronze-otel.sql  #   the BRONZE schema (bronze.*, Pod-3-owned)
+│   └── clickhouse/init.d/            #   applied on ClickHouse boot, in order
+│       ├── 01-bronze-otel.sql         #     the BRONZE schema (bronze.*, Pod-3-owned)
+│       └── 02-silver-layer.sql        #     SILVER v1 · typed models + read views (ADR-0010)
 │
 ├── docs/                          # 🔗 SHARED · cross-cutting knowledge
 │   ├── adr/                       #   architecture decisions (numbered, Pod-spanning)
@@ -152,9 +160,12 @@ sentinel/
 │
 ├── services/                      # 🧩 PER-COMPONENT · self-contained implementations
 │   ├── collector-rust/            #   Pod 2 — selected Rust collector. Cargo/Docker/tests ✅
-│   └── generator-python/          #   Pod 1 — Python telemetry generator (otelgen)
+│   ├── generator-python/          #   Pod 1 — Python telemetry generator (otelgen)
+│   └── flow-ui/                   #   the pipeline watching itself — four boards, read-only
 │
-├── .github/workflows/             # per-component CI, path-filtered (rust-ci.yml, …)
+├── .github/
+│   ├── PULL_REQUEST_TEMPLATE.md   # what · why (the linked issue) · tests/evidence
+│   └── workflows/                 # rust-ci.yml · pr-linked-issue.yml
 └── .claude/                       # Crew B knowledge env (agents · KBs · skills · standards)
 ```
 
@@ -179,6 +190,13 @@ make logs                      # tail collector logs
 # inspect at http://localhost:8123/play  →  SELECT count() FROM bronze.otel_traces
 # scrape collector metrics at http://localhost:9090/metrics
 make reset                     # stop everything + drop the ClickHouse volume
+```
+
+Watch it happen instead of querying for it:
+
+```sh
+make ui                            # flow-ui → http://localhost:8080
+make generate-stream DURATION=10m  # real-time telemetry, paced by the wall clock
 ```
 
 Run `make help` for all targets and the active `SCENARIO / SEED / WINDOW`. Per-component dev still works standalone (`cd services/collector-rust && cargo test`).

--- a/docs/research/learning-roadmap-pod2-rust.md
+++ b/docs/research/learning-roadmap-pod2-rust.md
@@ -12,7 +12,7 @@
 
 ## Sprint deliverable
 
-A working Rust binary that consumes Pod 1's NDJSON output (per `contract/schema/otlp_output.schema.json` v1.0.0) and writes the parsed signals into ClickHouse. End-to-end, tested against the golden fixture (`contract/golden/baseline_seed42.jsonl`), packaged in Docker, passing all 7 CI gates.
+A working Rust binary that consumes Pod 1's NDJSON output (per `contract/schema/otlp_output.schema.json` v1.0.0) and writes the parsed signals into ClickHouse. End-to-end, tested against the golden fixture (`contract/golden/baseline_seed42.jsonl`), packaged in Docker, passing all CI gates.
 
 OTLP gRPC `:4317` transport is the architectural target but is **out of scope for the MVP**. Week 2 work, after the NDJSON path is solid.
 


### PR DESCRIPTION
## What

Corrects the live `.md` files that describe a repo two merges out of date. 13 files.

## Why

Closes #40.
Closes #42 — the pre-PR rule and its template counterpart, folded in here rather than opened
as a second PR, since they are the fix for what #40 found.

## Tests / evidence

Documentation only. Checked by re-running the sweep that found the problems:

- **`7 CI gates` asserted as fact in live docs: 0** — was 9 files. Two were real assertions
  (`.claude/CLAUDE.md`, `RUST_PROJECT_STANDARDS.md`) and were rewritten; seven were
  table-of-contents pointers and lost the number.
- **README mentions of `flow-ui`: 4** — was 0.
- **Mermaid diagram balanced:** 8 `subgraph` / 8 `end`.
- **New relative links resolve** against the tree.
- **No ADR, SDD report or proposal touched** — verified against the diff.

## What could this break, and how did you check?

Nothing executable: no code, no CI config, no schema. The risk here is the opposite one —
deleting history by "fixing" it — so the sweep deliberately excluded `docs/adr/0*`,
`.claude/sdd/**`, `.claude/kb/languages/go/` and `docs/proposals/`, where a mention of
`collector-go` or an open bake-off is correct. That exclusion is asserted in the evidence
above against the actual diff.

The one judgement call worth a reviewer's eye: the seven CI gates are now written as a
**target with a pointer to #34**, not deleted. If the crew considers that list dead rather
than pending, it should be removed instead — but that is a decision, not a doc fix.

## Left flagged, not resolved

`.claude/CLAUDE.md` carries an unresolved ⚠️ about the Pod↔layer mapping — it lists
B3 = Volume/Schema/Latency/Storage watchers while the README frames POD3 as the
storage/read layer. That is a ratification question for Captain/Commander, so it stays
flagged rather than silently decided.

