### PR TITLE
feat(flow-ui): Silver on the Flow board, drawn from the database

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,7 +36,7 @@ Three services and two data layers, all verified running:
 |---|---|---|
 | `services/generator-python` | Pod 1 — OTLP generator | 178 pytest |
 | `services/collector-rust` | Pod 2 — OTLP → `bronze.*` | 92 inline + 4 integration |
-| `services/flow-ui` | the pipeline watching itself · `:8080` · read-only | 57 pytest |
+| `services/flow-ui` | the pipeline watching itself · `:8080` · read-only | 63 pytest |
 | `bronze.*` | ADR-0007 · 4 live tables + 3 empty by contract | applied on ClickHouse boot |
 | `silver.*` | ADR-0010 · 3 typed models + 6 read views | 60 SQL asserts |
 
@@ -45,10 +45,14 @@ view of bronze: *Flow* (the path, expandable in place), *Health*, *Contract* (wh
 dropped under `strict`, and which producers violate), *Watchers* (rows/min per producer against
 a band, where the band drawn **is** the alerting rule). Nothing in the pipeline depends on it.
 It now reads `silver.service_health_1m` for per-producer latency and error rate — drawn on
-each ORIGIN node as **declared → measured**, beside the latency `topology.yaml` claims. It
-still derives contract violations, volume bands and call edges from Bronze: Silver's MVs do
-not `POPULATE`, so moving those across would drop the history they depend on
-([#37](https://github.com/luanmorenommaciel/sentinel/issues/37)).
+each ORIGIN node as **declared → measured**, beside the latency `topology.yaml` claims — and
+draws Silver itself as the fourth box on the Flow board, linked to Bronze by a **derivation,
+not a pipe**: ADR-0010's materialized views fire inside ClickHouse on the same insert, so
+there is no hop to draw. It still derives contract violations, volume bands and call edges
+from Bronze: those MVs do not `POPULATE`, so moving them across would drop the history they
+depend on ([#37](https://github.com/luanmorenommaciel/sentinel/issues/37)).
+How it is built — stack, cadences, module map, six Mermaid diagrams — is
+[`services/flow-ui/ARCHITECTURE.md`](../services/flow-ui/ARCHITECTURE.md).
 
 **Silver is defined but not necessarily deployed**: the DDL runs on ClickHouse boot, so a
 volume older than the merge will not have it, and the MVs do not `POPULATE` — they see new

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,8 +44,11 @@ Three services and two data layers, all verified running:
 view of bronze: *Flow* (the path, expandable in place), *Health*, *Contract* (what would be
 dropped under `strict`, and which producers violate), *Watchers* (rows/min per producer against
 a band, where the band drawn **is** the alerting rule). Nothing in the pipeline depends on it.
-It re-derives from Bronze several things Silver was built to serve —
-[#37](https://github.com/luanmorenommaciel/sentinel/issues/37).
+It now reads `silver.service_health_1m` for per-producer latency and error rate — drawn on
+each ORIGIN node as **declared → measured**, beside the latency `topology.yaml` claims. It
+still derives contract violations, volume bands and call edges from Bronze: Silver's MVs do
+not `POPULATE`, so moving those across would drop the history they depend on
+([#37](https://github.com/luanmorenommaciel/sentinel/issues/37)).
 
 **Silver is defined but not necessarily deployed**: the DDL runs on ClickHouse boot, so a
 volume older than the merge will not have it, and the MVs do not `POPULATE` — they see new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,8 @@ Variables: `SCENARIO` (default `baseline`), `SEED` (`42`), `WINDOW` (`5m`).
 - **The collector writes the bronze split schema directly into database `bronze`** (`otel_logs / otel_traces / otel_metrics_gauge / otel_metrics_sum`, otel-collector-contrib v0.105.0 style with metrics split by data-point type, Sentinel-enriched via `ResourceAttributes`). The old normalized `default.*` write path and the `otel_metrics_1m` rollup MV are retired; the rollup is now a Pod 3 silver artifact.
 - **The bronze DDL is Pod-3-owned** and auto-applies on ClickHouse boot from `infra/clickhouse/init.d/01-bronze-otel.sql`. The collector issues no DDL — it only `INSERT`s. (The repo calls this policy `create_schema:false`, borrowing the contrib exporter's flag name; it is not a literal key in our Rust config.) The former collector→bronze gap is now closed (historical rationale: [docs/research/pod3-bronze-gap.md](docs/research/pod3-bronze-gap.md)).
 - **flow-ui reads, never writes.** It polls the collector's `/metrics` and queries `bronze.*`
-  read-only, plus Pod 1's `topology/default.yaml` and the collector's `config.docker.yaml`,
-  both mounted read-only — the picture is drawn from the files that define the thing, so it
+  and `silver.*` read-only, plus Pod 1's `topology/default.yaml` and the collector's
+  `config.docker.yaml`, both mounted read-only — the picture is drawn from the files that define the thing, so it
   cannot drift from them. Nothing in the pipeline depends on it being up.
 - **Agent-assisted work follows [ADR-0009](docs/adr/0009-agentic-gitflow.md)** — *seam → swimlane → leg → task*. One `git worktree` per agent under `.worktrees/`, branches named `leg/<area>/<task>-v<n>`, and **every leg declares disjoint paths** before it opens. Commands and gotchas: [`.claude/docs/AGENTIC_GITFLOW.md`](.claude/docs/AGENTIC_GITFLOW.md). Export a shared `CARGO_TARGET_DIR` before running a fleet, or N worktrees means N cold Rust builds.
 - **No comments-as-noise**; match each service's existing style. Keep the repo clean for the agentic phase that follows this baseline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ contracts/                 # SSOT contract registry, namespaced by producing Pod
 services/
   generator-python/        # POD 1 — synthetic OTLP generator (otelgen CLI); config/ holds scenarios/topology/provider_profiles
   collector-rust/          # POD 2 — OTLP→ClickHouse collector (Rust), the selected implementation
-  flow-ui/                 # the pipeline watching itself — four boards over /metrics + bronze
+  flow-ui/                 # the pipeline watching itself — four boards over /metrics + bronze/silver
+                           #   ARCHITECTURE.md = stack + cadences + module map (Mermaid)
 infra/                     # ClickHouse bootstrap (users/db init + users.d network override + bronze DDL in init.d/)
 docs/                      # shared docs (ADRs, research, proposals)
                            #   research/ holds the V2 product roadmap for flow-ui:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ flowchart TB
         FLOW["flow-ui :8080<br/>four boards · read-only"]
     end
     POD2 -. "/metrics :9090" .-> FLOW
-    STORE -. "bronze.* read-only" .-> FLOW
+    STORE -. "bronze.* + silver.* read-only" .-> FLOW
 
     classDef contract fill:#fde68a,stroke:#b45309,stroke-width:4px,color:#3a2f00;
     classDef zone fill:#f1f5f9,stroke:#94a3b8,color:#0f172a;
@@ -162,6 +162,7 @@ sentinel/
 │   ├── collector-rust/            #   Pod 2 — selected Rust collector. Cargo/Docker/tests ✅
 │   ├── generator-python/          #   Pod 1 — Python telemetry generator (otelgen)
 │   └── flow-ui/                   #   the pipeline watching itself — four boards, read-only
+│       └── ARCHITECTURE.md      #     how it is built (FastAPI + SSE + no-framework SVG)
 │
 ├── .github/
 │   ├── PULL_REQUEST_TEMPLATE.md   # what · why (the linked issue) · tests/evidence

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sentinel is an open-source observability + remediation system for data pipelines
 
 ## 1. System architecture
 
-Telemetry flows top-to-bottom through the Pods. **Phase 1 builds the data path:** Pod 1 *generates* telemetry and defines the OTLP contract, Pod 2 *ingests, validates, transforms, and exports* it, and Pod 3 *consumes* Pod 2's output contract for data modelling (bronze → silver → read models). **Watchers, detection, CrewAI-driven reasoning, and remediation are a future phase** layered on top. Alongside the path — not in it — **`flow-ui` observes the pipeline** from the collector's `/metrics` and a read-only view of bronze; nothing in the path depends on it being up. Each **gold gate** is a **contract boundary** — a versioned interface owned by the upstream Pod and consumed by the downstream one.
+Telemetry flows top-to-bottom through the Pods. **Phase 1 builds the data path:** Pod 1 *generates* telemetry and defines the OTLP contract, Pod 2 *ingests, validates, transforms, and exports* it, and Pod 3 *consumes* Pod 2's output contract for data modelling (bronze → silver → read models). **Watchers, detection, CrewAI-driven reasoning, and remediation are a future phase** layered on top. Alongside the path — not in it — **`flow-ui` observes the pipeline** from the collector's `/metrics` and read-only views of bronze and silver; nothing in the path depends on it being up. Each **gold gate** is a **contract boundary** — a versioned interface owned by the upstream Pod and consumed by the downstream one.
 
 ```mermaid
 flowchart TB

--- a/services/flow-ui/ARCHITECTURE.md
+++ b/services/flow-ui/ARCHITECTURE.md
@@ -1,0 +1,262 @@
+# flow-ui — architecture
+
+What this service is made of, and how a number gets from the pipeline to the screen.
+
+For *what the page shows and why it shows it that way*, see [DESIGN.md](DESIGN.md). This
+document is the machinery under it.
+
+## In one sentence
+
+A **FastAPI** process that polls two sources on three cadences, keeps one in-memory snapshot,
+renders it into HTML server-side, and pushes each subsequent tick over **SSE** to a
+**dependency-free** browser page that redraws an SVG.
+
+## The stack, and what is deliberately absent
+
+| Layer | Choice | Why this and not the obvious alternative |
+|---|---|---|
+| Language | Python 3.12 | Pod 1 is already Python; this is a *reader*, not a hot path. The 730–18,000 signals/s never pass through here — only counters do |
+| Web | FastAPI + Uvicorn | Async is the requirement: one SSE connection per viewer, held open, while two pollers run |
+| Templating | Jinja2 | Every figure is in the HTML **before any script runs**. A blocked script costs the motion, never the reading |
+| Transport | SSE (`text/event-stream`) | One-directional, server→client. WebSockets buy a return channel this page has no use for, and cost reconnection logic the browser gives SSE for free |
+| HTTP client | httpx (async) | Both sources speak HTTP: the collector's `/metrics`, ClickHouse's `:8123` |
+| Config | PyYAML | Reads Pod 1's `topology.yaml` and the collector's `config.docker.yaml` — *read*, never redrawn, so the picture cannot drift from what emits the telemetry |
+| Front end | **none** | ~1.7k lines of plain ES2020 + SVG. No React, no D3, no bundler, no `package.json`, no build step |
+| Styling | one hand-written stylesheet | Two palettes switched by one attribute. **Nothing in the CSS names a colour** — every value is a token, so the switch re-tests every colour decision against a second ground |
+
+**Why no front-end framework.** The page is one graph that is never replaced — boxes grow in
+place and the particles keep flowing through. React's model is to re-render a tree; this
+page's core invariant is that the SVG elements carrying `animateMotion` **must not be
+recreated**, or every dot restarts from the mouth of its pipe. Working against that is more
+code than the DOM calls it replaces. `asset_v()` cache-busts on file mtime, so there is a
+dev loop without a bundler.
+
+## Components
+
+```mermaid
+flowchart LR
+    subgraph src["sources — flow-ui is the only reader of any of them"]
+        direction TB
+        COL["collector-rust<br/>:9090/metrics"]
+        CLICK[("ClickHouse :8123<br/>bronze.* ⇒ silver.*")]
+        YAML["topology.yaml<br/>config.docker.yaml<br/>mounted read-only"]
+    end
+
+    subgraph svc["flow-ui — FastAPI :8080"]
+        direction TB
+        PROM["prom.py<br/>Prometheus text parser"]
+        CH["clickhouse.py<br/>HTTP + TSV"]
+        TOPO["topology.py<br/>YAML readers"]
+        POLL["pipeline.py · Poller<br/>the only writer of Snapshot"]
+        SNAP[("Snapshot<br/>one, in memory")]
+        MAIN["main.py<br/>routes · Jinja2 render"]
+    end
+
+    subgraph browser["browser — no framework, no build step"]
+        direction TB
+        SVG["app.js · SVG canvas<br/>4 boards · 5 zoom levels"]
+        CSS["app.css · 2 palettes<br/>no colour is named"]
+    end
+
+    COL -->|"poll 1 s"| PROM --> POLL
+    CLICK -->|"poll 5 s / 30 s"| CH --> POLL
+    YAML --> TOPO --> MAIN
+    POLL --> SNAP --> MAIN
+    MAIN ==>|"HTML · pre-rendered"| SVG
+    MAIN -.->|"SSE /stream · 1 frame/s"| SVG
+    CSS -.- SVG
+```
+
+**The browser never talks to the collector or to ClickHouse.** Not a preference — a
+constraint. The collector's `/metrics` server sets exactly one response header
+(`Content-Type`; see `collector-rust/src/metrics_server.rs`) and ClickHouse has no CORS header
+configured under `infra/`, so a cross-origin fetch from the page is blocked with no visible
+error. This service is the only reader of either, which also means the page works unchanged
+wherever those two move to. A test pins it.
+
+## Three cadences, because the queries cost three different things
+
+The Poller runs one fast loop and two slow tasks. They are separate because sharing a cadence
+would make the cheapest reading wait on the most expensive one.
+
+```mermaid
+flowchart LR
+    F["fast · 1 s<br/>/metrics → mode · rates · verdict"]
+    L["lineage · 5 s<br/>count() · GROUP BY ServiceName · volume band<br/>call_edges · service_health · silver_state"]
+    C["contract · 30 s<br/>contract_violations"]
+
+    F --> SNAP[("Snapshot<br/>one, in memory")]
+    L --> SNAP
+    C --> SNAP
+    SNAP --> OUT["GET /<br/>GET /stream<br/>GET /api/*"]
+```
+
+| Lane | Env | Cost |
+|---|---|---|
+| fast · 1 s | `FLOW_UI_POLL_INTERVAL` | counters only — constant |
+| lineage · 5 s | `FLOW_UI_LINEAGE_INTERVAL` | `count()` and `system.tables` read part metadata; no scan |
+| contract · 30 s | `FLOW_UI_CONTRACT_INTERVAL` | probes the **unindexed** `ResourceAttributes` Map — 1.26 s measured |
+
+Each slow task owns its own `while True` and swallows its own exceptions, so a failing
+ClickHouse degrades the boards it feeds and never stops the tick. `stop()` cancels and awaits
+both, so a reload does not leak them.
+
+**Why the contract lane is 30 s and alone.** `contract_violations()` counts rows missing each
+required `sentinel.*` key across every live table. The `ARRAY JOIN` form multiplies every row
+by five before filtering — 6.4 s against 1.26 s for `countIf`, over the same ~6M rows. Even at
+1.26 s it must not share the 5 s lane.
+
+**Why bronze growth is `count()` deltas and never a time window.** Bronze stores *event* time
+— the read contract (§2) defines `Timestamp` as the signal's own timestamp and there is no
+ingest-time column. In backfill the generator writes five minutes of history in thirteen
+seconds, so `WHERE Timestamp > now() - INTERVAL 10 SECOND` answers "what *happened* recently",
+which is a different question. It is also 40,000× the rows: bare `count()` reads 1 row of part
+metadata (3.7 ms measured); the windowed form scans the table.
+
+## A tick, end to end
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant B as Browser
+    participant A as main.py
+    participant P as Poller
+    participant M as collector /metrics
+    participant C as ClickHouse
+
+    Note over B,A: first load — nothing is empty
+    B->>A: GET /
+    A->>A: Jinja2 renders poller.latest into the HTML
+    A-->>B: page with every figure already printed
+    B->>A: GET /api/history
+    A-->>B: server-side rolling window (60 pts)
+    B->>A: GET /api/graph
+    A-->>B: declared topology + table datasheets (fetched once)
+    B->>A: EventSource /stream
+
+    loop every 1 s
+        P->>M: GET /metrics
+        M-->>P: Prometheus text
+        P->>P: parse · detect mode · reject matrix · verdict
+        P->>P: publish(Snapshot) to each subscriber queue
+        A-->>B: data: {...}
+        B->>B: repaint SVG · re-seed particle pools
+    end
+
+    loop every 5 s / 30 s
+        P->>C: count() · GROUP BY · system.tables
+        C-->>P: TSV
+        P->>P: mutate Snapshot in place
+    end
+```
+
+**A full subscriber queue drops its own frames, never the publisher's tick.** One slow tab
+must not stall the poll loop or the other viewers; `publish()` discards into a full queue and
+moves on. A test pins that too.
+
+## Modules
+
+```mermaid
+flowchart TB
+    MAIN["main.py — 179<br/>6 routes, Jinja2 globals, lifespan"]
+    PIPE["pipeline.py — 530<br/>Poller, Snapshot, volume_state, _verdict"]
+    CH["clickhouse.py — 468<br/>every SQL string in the service"]
+    PROM["prom.py — 171<br/>Prometheus text → Sample"]
+    TOPO["topology.py — 217<br/>topology.yaml + collector config"]
+    CFG["config.py — 49<br/>env only, no config file"]
+
+    MAIN --> PIPE
+    MAIN --> TOPO
+    PIPE --> CH
+    PIPE --> PROM
+    PIPE --> CFG
+    CH --> CFG
+```
+
+The split is by **source**, not by feature: one module per thing that can be unreachable.
+`prom.py` and `clickhouse.py` each own their failure mode, and `pipeline.py` decides what an
+unreachable source means for the verdict.
+
+Two parsing rules worth knowing before changing either reader:
+
+- **An absent metric family is a normal state, not an error.** The collector's labelled
+  counters are `IntCounterVec`s, and a `*Vec` exposes nothing until a label combination is
+  instantiated. A freshly started collector serves three families; the other five appear when
+  traffic does. `Sample.value()` returns `0.0` for anything absent.
+- **`Sample.sum_over_pair`, because two separate reads cannot recover a cross-product.**
+  `signals_rejected_total` is labelled by both `signal` and `reason`. Reading it once by
+  `signal` and once by `reason` loses which type failed which way — which is exactly what
+  colours the dot leaving the chain.
+
+## Where the data comes from
+
+```mermaid
+flowchart LR
+    subgraph measured["measured"]
+        M1["collector /metrics<br/>rates · flush cadence · rejections · export latency"]
+        M2["bronze.*<br/>row counts · per-service lineage · contract violations · volume band · call edges"]
+        M3["silver.service_health_1m<br/>observed p50 latency · error rate"]
+    end
+    subgraph declared["declared"]
+        D1["topology.yaml<br/>the service graph, and each component's claimed latency"]
+        D2["config.docker.yaml<br/>contract.grpc_validation — off / warn / strict"]
+        D3["pod2-pod3-read-contract v1.0.0.1<br/>the bronze datasheets"]
+    end
+    M3 --> J{"declared → measured<br/>drawn as two claims"}
+    D1 --> J
+```
+
+The whole point of the ORIGIN board is that seam: `topology.yaml` says what a component's
+latency *should* be, `silver.service_health_1m` says what its operations *took*. The two
+agreeing is the baseline; the two diverging is the finding. Declared-but-never-traced edges
+are drawn dashed rather than at a width that would imply traffic they do not carry.
+
+## Deployment
+
+One container, one process, no state on disk.
+
+```mermaid
+flowchart LR
+    subgraph compose["docker compose — one network"]
+        G["generator<br/>python"] -->|"OTLP gRPC :4317"| CO["collector-rust"]
+        CO -->|"HTTP insert"| CH[("clickhouse<br/>:8123 · :9000")]
+        CH -.->|"MVs, on insert"| CH
+        FU["flow-ui :8080"] -->|":9090/metrics"| CO
+        FU -->|":8123"| CH
+    end
+    U(("browser")) -->|":8080"| FU
+```
+
+Configuration is environment only — there is no config file for this service:
+
+| Env | Default |
+|---|---|
+| `COLLECTOR_METRICS_URL` | `http://localhost:9090/metrics` (compose: `http://collector:9090/metrics`) |
+| `CLICKHOUSE_URL` | `http://localhost:8123` (compose: `http://clickhouse:8123`) |
+| `CLICKHOUSE_DATABASE` | `bronze` |
+| `GENERATOR_CONFIG_DIR` | `/app/generator-config` — Pod 1's config, mounted read-only |
+| `FLOW_UI_POLL_INTERVAL` | `1.0` — matches the stream-mode flush cadence |
+| `FLOW_UI_LINEAGE_INTERVAL` | `5.0` |
+| `FLOW_UI_CONTRACT_INTERVAL` | `30.0` |
+| `FLOW_UI_VOLUME_WINDOW_MIN` | `60` |
+| `FLOW_UI_HISTORY` | `60` — points in the server-side rolling window |
+
+Scaling note: the Snapshot is **per process**, so more than one replica behind a load balancer
+gives two viewers two different pictures a second apart. That is fine for one crew and wrong
+for a shared deployment; the fix is a shared store, and nothing here needs it yet.
+
+## What is not tested, and it is the same gap every time
+
+63 tests cover the parsing, the poller's inferences and the pure verdict logic. They cover
+**nothing about SVG geometry** — where things land on the canvas is checked by looking, and
+that gap has cost real defects: a detail panel drawn over the nodes it described, two header
+collisions, and a pipe routed out from under the box it was meant to reach. A geometry test is
+on the roadmap in [STATUS.md](STATUS.md).
+
+## See also
+
+- [README.md](README.md) — run it, break it on purpose, endpoints
+- [DESIGN.md](DESIGN.md) — the visual grammar and the rules it holds to
+- [STATUS.md](STATUS.md) — what shipped, in order, and what is next
+- [`contracts/collector/v1/pod2-pod3-read-contract.md`](../../contracts/collector/v1/pod2-pod3-read-contract.md) — the bronze semantics this reads
+- [ADR-0010](../../docs/adr/0010-silver-v1-operational-model.md) — the Silver models and their materialized views

--- a/services/flow-ui/ARCHITECTURE.md
+++ b/services/flow-ui/ARCHITECTURE.md
@@ -196,6 +196,7 @@ flowchart LR
         M1["collector /metrics<br/>rates · flush cadence · rejections · export latency"]
         M2["bronze.*<br/>row counts · per-service lineage · contract violations · volume band · call edges"]
         M3["silver.service_health_1m<br/>observed p50 latency · error rate"]
+        M4["system.tables · system.columns<br/>Silver's own shape — kinds, columns, lineage"]
     end
     subgraph declared["declared"]
         D1["topology.yaml<br/>the service graph, and each component's claimed latency"]
@@ -204,6 +205,7 @@ flowchart LR
     end
     M3 --> J{"declared → measured<br/>drawn as two claims"}
     D1 --> J
+    M4 --> S["the SILVER board draws itself<br/>from the database, not from a list"]
 ```
 
 The whole point of the ORIGIN board is that seam: `topology.yaml` says what a component's

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -34,6 +34,7 @@ is something the page does on its own — nothing tells it.
 | | |
 |---|---|
 | **Flow**, closed | three lanes in, one trunk out. One dot is 100 signals of that type |
+| **Flow** → open `ORIGIN`, latency | each producer shows `declared → measured` — `topology.yaml`'s claim beside Silver's observed p50 |
 | **Flow** → open `ORIGIN` | the declared service graph, each producer carrying its fused state; pipe width is what was actually traced on that edge |
 | **Flow** → open `COLLECTOR-RUST` | `receive → validate → buffer`, and the three ways a signal does not simply arrive |
 | **Flow** → open `BRONZE` | the four tables, each strand carrying the type that lands in it |

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -42,7 +42,7 @@ is something the page does on its own — nothing tells it.
 | **Flow** → open `ORIGIN` | the declared service graph, each producer carrying its fused state; pipe width is what was actually traced on that edge |
 | **Flow** → open `COLLECTOR-RUST` | `receive → validate → buffer`, and the three ways a signal does not simply arrive |
 | **Flow** → open `BRONZE` | the four tables, each strand carrying the type that lands in it. Pick a table for its datasheet, pick it again to close |
-| **Flow** → open `SILVER` | the three models and the six read views ADR-0010 derives from bronze |
+| **Flow** → open `SILVER` | every object in the database as its own box — materialized views, tables, read views — with the lineage between them |
 | **Flow** → open `BRONZE` **and** `SILVER` | which table becomes which model — 4 → 3, because gauge and sum share one |
 | **Health** | the verdict and the sentence behind it, over a 120s window |
 | **Contract** | the receive boundary: what would be dropped under `strict`, and who is violating |
@@ -133,8 +133,8 @@ streaming or backfilling — the buffer's flush cadence is the tell, and the two
 | **Origin** | the seven services as a graph, **declared config beside observed row counts** | `topology.yaml` + bronze |
 | **Collector** | where a signal comes from and where it goes, with the three outcomes | `/metrics` |
 | **Bronze** | the four tables; pick one for the read contract as its datasheet | contract v1.0.0.1 |
-| **Silver** | the models, their row counts, and the six read views with what each answers | `system.tables` |
-| **Silver** → pick a model | its columns and sort key, read live so they cannot drift | `system.columns` |
+| **Silver** | the whole `silver` DAG: 4 MVs → 3 tables → 6 read views, drawn from the database itself | `system.tables` |
+| **Silver** → pick any node | what kind it is, what it reads and writes, its columns and sort key | `system.columns` |
 | **Bronze + Silver** | the per-table derivation, drawn from the MV definitions | silver DDL |
 
 `Esc` returns to the overview. The legend at the bottom is rebuilt on every level change,
@@ -221,6 +221,9 @@ not for this service.
   columns §2 guarantees are shown, absent optional IDs are `''` per §4, grouping is by
   `ServiceName` because §5.6 makes that the one index-accelerated axis, and the unindexed
   `ResourceAttributes` Map probes (§3, §6) stay off the per-tick path.
+- **`system.tables` / `system.columns`** — Silver's shape is read from ClickHouse, never
+  restated here: engine gives the kind, `create_table_query` gives the lineage. Add a model or
+  a view to `02-silver-layer.sql` and it appears on the board with no code change.
 - **`silver.service_health_1m`** (ADR-0010) — per-producer latency quantiles and error rate,
   the *measured* half of each ORIGIN node's `declared → measured`. Read on the slow lane and
   optional: absent Silver means the node shows the declared figure alone.

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -133,7 +133,8 @@ streaming or backfilling — the buffer's flush cadence is the tell, and the two
 | **Origin** | the seven services as a graph, **declared config beside observed row counts** | `topology.yaml` + bronze |
 | **Collector** | where a signal comes from and where it goes, with the three outcomes | `/metrics` |
 | **Bronze** | the tables, and the read contract as each one's datasheet | contract v1.0.0.1 |
-| **Silver** | the models, their row counts, and which read views exist | `system.tables` |
+| **Silver** | the models, their row counts, and the six read views with what each answers | `system.tables` |
+| **Silver** → pick a model | its columns and sort key, read live so they cannot drift | `system.columns` |
 | **Bronze + Silver** | the per-table derivation, drawn from the MV definitions | silver DDL |
 
 `Esc` returns to the overview. The legend at the bottom is rebuilt on every level change,

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -43,6 +43,7 @@ is something the page does on its own — nothing tells it.
 | **Flow** → open `COLLECTOR-RUST` | `receive → validate → buffer`, and the three ways a signal does not simply arrive |
 | **Flow** → open `BRONZE` | the four tables, each strand carrying the type that lands in it |
 | **Flow** → open `SILVER` | the three models and the six read views ADR-0010 derives from bronze |
+| **Flow** → open `BRONZE` **and** `SILVER` | which table becomes which model — 4 → 3, because gauge and sum share one |
 | **Health** | the verdict and the sentence behind it, over a 120s window |
 | **Contract** | the receive boundary: what would be dropped under `strict`, and who is violating |
 | **Watchers** | rows per minute per producer against a band — and the band drawn *is* the alerting rule |
@@ -133,6 +134,7 @@ streaming or backfilling — the buffer's flush cadence is the tell, and the two
 | **Collector** | where a signal comes from and where it goes, with the three outcomes | `/metrics` |
 | **Bronze** | the tables, and the read contract as each one's datasheet | contract v1.0.0.1 |
 | **Silver** | the models, their row counts, and which read views exist | `system.tables` |
+| **Bronze + Silver** | the per-table derivation, drawn from the MV definitions | silver DDL |
 
 `Esc` returns to the overview. The legend at the bottom is rebuilt on every level change,
 because **a particle means something different at each one** — see [DESIGN.md](DESIGN.md).

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -41,7 +41,7 @@ is something the page does on its own — nothing tells it.
 | **Flow** → open `ORIGIN`, latency | each producer shows `declared → measured` — `topology.yaml`'s claim beside Silver's observed p50 |
 | **Flow** → open `ORIGIN` | the declared service graph, each producer carrying its fused state; pipe width is what was actually traced on that edge |
 | **Flow** → open `COLLECTOR-RUST` | `receive → validate → buffer`, and the three ways a signal does not simply arrive |
-| **Flow** → open `BRONZE` | the four tables, each strand carrying the type that lands in it |
+| **Flow** → open `BRONZE` | the four tables, each strand carrying the type that lands in it. Pick a table for its datasheet, pick it again to close |
 | **Flow** → open `SILVER` | the three models and the six read views ADR-0010 derives from bronze |
 | **Flow** → open `BRONZE` **and** `SILVER` | which table becomes which model — 4 → 3, because gauge and sum share one |
 | **Health** | the verdict and the sentence behind it, over a 120s window |
@@ -132,7 +132,7 @@ streaming or backfilling — the buffer's flush cadence is the tell, and the two
 | **Pipeline** | origin → collector → bronze, three lanes in and one out | `/metrics` |
 | **Origin** | the seven services as a graph, **declared config beside observed row counts** | `topology.yaml` + bronze |
 | **Collector** | where a signal comes from and where it goes, with the three outcomes | `/metrics` |
-| **Bronze** | the tables, and the read contract as each one's datasheet | contract v1.0.0.1 |
+| **Bronze** | the four tables; pick one for the read contract as its datasheet | contract v1.0.0.1 |
 | **Silver** | the models, their row counts, and the six read views with what each answers | `system.tables` |
 | **Silver** → pick a model | its columns and sort key, read live so they cannot drift | `system.columns` |
 | **Bronze + Silver** | the per-table derivation, drawn from the MV definitions | silver DDL |

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -133,7 +133,7 @@ streaming or backfilling — the buffer's flush cadence is the tell, and the two
 | **Origin** | the seven services as a graph, **declared config beside observed row counts** | `topology.yaml` + bronze |
 | **Collector** | where a signal comes from and where it goes, with the three outcomes | `/metrics` |
 | **Bronze** | the four tables; pick one for the read contract as its datasheet | contract v1.0.0.1 |
-| **Silver** | the whole `silver` DAG: 4 MVs → 3 tables → 6 read views, drawn from the database itself | `system.tables` |
+| **Silver** | the whole `silver` DAG, laid out by dependency depth — add an object to the DDL and it finds its own column | `system.tables` |
 | **Silver** → pick any node | what kind it is, what it reads and writes, its columns and sort key | `system.columns` |
 | **Bronze + Silver** | the per-table derivation, drawn from the MV definitions | silver DDL |
 

--- a/services/flow-ui/README.md
+++ b/services/flow-ui/README.md
@@ -5,12 +5,16 @@ and what is landing in `bronze.*`. Two boards — **Flow** (how data moves) and 
 (what is breaking) — over one semantic zoom.
 
 ```
-generator ──OTLP :4317──▶ collector-rust ──HTTP──▶ ClickHouse bronze.*
+generator ──OTLP :4317──▶ collector-rust ──HTTP──▶ ClickHouse bronze.* ⇒ silver.*
                               │ :9090/metrics          │ :8123
                               └──────────┬─────────────┘
                                       flow-ui  ──SSE──▶ browser
                                        :8080
 ```
+
+`⇒` is not a hop: ADR-0010's materialized views fire inside ClickHouse on the same insert
+that writes bronze. The board draws it that way too — see [ARCHITECTURE.md](ARCHITECTURE.md)
+for what this service is made of and how a number reaches the screen.
 
 ## Run it
 
@@ -38,6 +42,7 @@ is something the page does on its own — nothing tells it.
 | **Flow** → open `ORIGIN` | the declared service graph, each producer carrying its fused state; pipe width is what was actually traced on that edge |
 | **Flow** → open `COLLECTOR-RUST` | `receive → validate → buffer`, and the three ways a signal does not simply arrive |
 | **Flow** → open `BRONZE` | the four tables, each strand carrying the type that lands in it |
+| **Flow** → open `SILVER` | the three models and the six read views ADR-0010 derives from bronze |
 | **Health** | the verdict and the sentence behind it, over a 120s window |
 | **Contract** | the receive boundary: what would be dropped under `strict`, and who is violating |
 | **Watchers** | rows per minute per producer against a band — and the band drawn *is* the alerting rule |
@@ -86,7 +91,7 @@ From the repo root, in Docker, with no host toolchain — and wired into the agg
 so `make test` and `make lint` cover this service too:
 
 ```bash
-make test-flow-ui     # 57 tests
+make test-flow-ui     # 63 tests
 make lint-flow-ui     # ruff over src, tests and scripts
 ```
 
@@ -119,7 +124,7 @@ streaming or backfilling — the buffer's flush cadence is the tell, and the two
 | records per flush | 500–1,000 | ~2,534 |
 | export latency | — | 45.3 ms avg |
 
-**Semantic zoom.** Level 0 is three boxes. Click one and it opens:
+**Semantic zoom.** Level 0 is four boxes. Click one and it opens:
 
 | Level | Shows | Source |
 |---|---|---|
@@ -127,6 +132,7 @@ streaming or backfilling — the buffer's flush cadence is the tell, and the two
 | **Origin** | the seven services as a graph, **declared config beside observed row counts** | `topology.yaml` + bronze |
 | **Collector** | where a signal comes from and where it goes, with the three outcomes | `/metrics` |
 | **Bronze** | the tables, and the read contract as each one's datasheet | contract v1.0.0.1 |
+| **Silver** | the models, their row counts, and which read views exist | `system.tables` |
 
 `Esc` returns to the overview. The legend at the bottom is rebuilt on every level change,
 because **a particle means something different at each one** — see [DESIGN.md](DESIGN.md).
@@ -212,17 +218,22 @@ not for this service.
   columns §2 guarantees are shown, absent optional IDs are `''` per §4, grouping is by
   `ServiceName` because §5.6 makes that the one index-accelerated axis, and the unindexed
   `ResourceAttributes` Map probes (§3, §6) stay off the per-tick path.
+- **`silver.service_health_1m`** (ADR-0010) — per-producer latency quantiles and error rate,
+  the *measured* half of each ORIGIN node's `declared → measured`. Read on the slow lane and
+  optional: absent Silver means the node shows the declared figure alone.
 - **`services/generator-python/config/topology/default.yaml`** — the declared service graph.
   Read, not redrawn, so the picture cannot drift from what emits the telemetry. Edges point
   the way data *flows*: `depends_on: [a]` on `b` means the edge is `a → b`.
 
 ## Status
 
-**V2.3.** Pod 2 self-observability plus the bronze read side, four boards, four zoom levels, two
-palettes. 37 tests. Verified end to end against a live pipeline on 2026-09-01: mode detection
-correct across stream, batch and idle; 1,015,100 signals stored, 0 rejected, 0 export errors.
+**V2.3 + Silver.** Pod 2 self-observability plus the bronze read side, four boards, five zoom
+levels, two palettes, and Silver drawn as a derivation of bronze rather than a hop after it.
+63 tests. Verified end to end against a live pipeline on 2026-09-02: mode detection correct
+across stream, batch and idle; 10.1M bronze rows against 536.6k in Silver's three models,
+0 rejected, 0 export errors.
 
 **Known gaps, deliberate:** no language selector yet (V1 ships English; the selector lands with
-the demo) · the *observed* topology is not yet derived from `ParentSpanId` and compared against
-the declared one · the look has not been reviewed by anyone but the owner, because headless
-capture cannot hold an SSE page still.
+the demo) · Silver's three read models are shown but only `service_health_1m` is *consumed* —
+the other Bronze queries stay on Bronze until Silver has history (#37) · the look has not been
+reviewed by anyone but the owner, because headless capture cannot hold an SSE page still.

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -435,6 +435,19 @@ Measured with both boxes open, over 14 ticks: four lanes with a moving count bef
 and that one changes by a single dot three times, which is the metrics rate genuinely drifting
 across a boundary rather than a beat.
 
+**And that fix shipped broken for one commit**, in a way worth writing down. The new helper
+was called `moving` only after the event: it was named `live`, and `density` already declares
+`const live = total > 0 ? 1 : 0` for its has-any-traffic flag. The local shadowed the module
+function for that whole scope, so every call to it hit a number and threw — and the shows
+*before* that line kept working while everything from BRONZE onward went dark. Reported as
+"the dots stopped appearing from bronze onward", which is exactly what it looked like.
+
+Nothing caught it: no exception reached the console capture, the tests do not touch `density`,
+and the pools were being created correctly — three of the four things that usually reveal a
+bug all said the code was fine. What found it was measuring the *inputs* to the gate rather
+than reasoning about the gate: the pools existed, the rates were 82/s, so the only thing left
+was the function itself.
+
 **One lane was still a metronome.** BRONZE's internal fan builds its circles in its own loop
 rather than through `flow`, so the scatter never reached it: all twelve ran at exactly 3.20s
 while every other lane had been broken up. Now 10 distinct durations across 3.00–3.38s.

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -233,6 +233,31 @@ amber over 1 of 14. It now takes at least two buckets *and* 10% of the estate's.
 against a 13px standard gauge, so a service dependency drew fatter than the feeders and the
 bronze fan. What those edges carry is relative, so the range tops out *at* the standard gauge.
 
+## Shipped: Silver, as an addition rather than a migration
+
+`silver.service_health_1m` gives per-producer latency quantiles and error rate, and each
+ORIGIN node now draws **declared → measured**: what `topology.yaml` claims a component's
+latency is, beside what its operations actually took. The two agreeing is the baseline; the
+two diverging is the finding. flow-ui had no per-service latency at all before this — the
+Health board's quantiles are the collector's *export* latency, a different question.
+
+**The three Bronze queries did not move, and should not have.** Measured on the stack the day
+Silver landed: `bronze.otel_traces` held 1,703,050 rows over 36 hours, `silver.
+operation_executions` held 12,849 over 12 minutes, because ADR-0010's materialized views do
+not `POPULATE`. Migrating `contract_violations` would have reported nothing and lost the
+`legacy-billing-api` finding — 104,610 rows missing four required keys. Migrating
+`volume_band` would have left every producer below `MIN_BUCKETS` and shown the whole Watchers
+board grey. #37 stays open for the half that needs a backfill first.
+
+Silver also cannot answer one question Bronze can: `is_synthetic` is materialized as
+`lower(...) = 'true'`, so an **absent** `sentinel.synthetic` key is indistinguishable from an
+explicit `false`. Contract violation counting needs the key's absence, so it belongs on the
+retained Map either way.
+
+`service_health()` returns `[]` when `silver.*` is missing, which is the normal state of any
+stack whose ClickHouse volume predates the DDL. The node then shows the declared figure
+alone, as it always did.
+
 ## Next planned step
 
 Tier 1 is now closed to the limit of the data. What remains:

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -306,10 +306,29 @@ pairs typed into `app.js`, was a fourth copy of the DDL after the SQL, the MV de
 `system.tables`; it is now computed. The box's own footprint is measured from the graph rather
 than typed in.
 
-**Verified the way the claim deserves:** a `CREATE VIEW silver.error_budget_1m AS SELECT …
-FROM silver.operation_executions` run against the live database appeared on the board — in the
-READ VIEWS column, placed next to the table it reads, wired to it by an edge in that table's
-colour, with the box grown to seven rows — with **no code edited**. Then dropped again.
+**Columns are DAG depth, not kind.** Kind decided the column first and it was wrong the
+moment the schema stopped being a straight line, which is what "what if a new MV is born in
+the middle?" was really asking. A second-stage MV — one reading a *silver* table rather than a
+bronze one, which is how an hourly rollup is built — belongs between two tables; by kind it
+landed back in column 0 and its edge ran right to left, drawing a dependency that reads
+backwards. Depth puts every node after everything it reads, whatever it happens to be, and the
+kind moved to the border style with a key to explain it. The walk is guarded against cycles:
+ClickHouse will let you build one.
+
+**Verified against the live database three times, by creating the awkward cases and looking:**
+
+| Case | Result |
+|---|---|
+| `CREATE VIEW silver.error_budget_1m … FROM silver.operation_executions` | appeared beside the table it reads, wired in that table's colour, box grown a row — **no code edited** |
+| A second-stage MV: `silver.log_events → silver.log_events_hourly` | landed in a **fourth column** that did not exist before, after the table it reads |
+| A table nothing feeds (`manual_annotations`) | column 0 with the sources, no incoming edge — correct: nothing produces it |
+
+**Two defects that only a real object could have found**, and they were the same defect twice:
+`SummingMergeTree` — the obvious engine for a rollup — did not match the literal string
+`"MergeTree"`, so the table was **invisible** in `silver_graph` and **absent from `models`** in
+`silver_state`, leaving the board drawing a table it had no count for. Anything that is not one
+of the two view engines stores rows. Both readings now classify identically, and a test pins
+that they agree.
 
 ### Silver's models have datasheets too — read from ClickHouse, not restated
 

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -323,6 +323,17 @@ ClickHouse will let you build one.
 | A second-stage MV: `silver.log_events → silver.log_events_hourly` | landed in a **fourth column** that did not exist before, after the table it reads |
 | A table nothing feeds (`manual_annotations`) | column 0 with the sources, no incoming edge — correct: nothing produces it |
 
+**Kind is on two channels, and neither is hue.** Hue is spoken for: `--pri`, `--sec` and
+`--ter` mean logs, traces and metrics everywhere on this canvas, and a box borrowing one would
+make the same channel say two things. The **ground** was free, and there the difference is
+literal rather than a code to memorise — a table is *filled* because it holds something, an MV
+is *hollow* because rows pass through it and it stores nothing, a view is *sunk* because it is
+a window onto the rows below. Border style is the redundant second channel, so the distinction
+survives a colour-blind reader and greyscale, which this repo's own rule requires. Strokes stay
+inside the structural family (`--dim2` / `--viaS` / `--rule-arrow`), defined per palette, so
+both worlds keep their own version. The key swatches wear the real classes, so the legend
+cannot drift from what it describes.
+
 **Two defects that only a real object could have found**, and they were the same defect twice:
 `SummingMergeTree` — the obvious engine for a rollup — did not match the literal string
 `"MergeTree"`, so the table was **invisible** in `silver_graph` and **absent from `models`** in

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -301,6 +301,15 @@ and is a query over the models above. They are on two lines each because side by
 22-character name and a 43-character answer need 455 units against 278 of usable width, and
 the first version simply drew them on top of each other.
 
+**Both sheets toggle, and both start closed.** BRONZE opened with `otel_logs` selected and no
+way to deselect it, so its sheet was a permanent fixture of the open box rather than an answer
+to a question the reader asked. Click a row for its sheet, click it again to put it away.
+
+**And ⌂ was resetting a stale list.** It cleared `origin`, `collector`, `bronze` and the table
+selection, and knew nothing about `silver` or the selected model — the same defect as the
+`repaint()` key, in a second hand-maintained list of the same boxes. Both now enumerate every
+expandable box and every selection.
+
 ### Open, the derivation becomes per-table — because the mapping is not 1:1
 
 Closed, one double bar is the honest summary. Open, the reader is asking a lineage question —

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -323,7 +323,31 @@ ClickHouse will let you build one.
 | A second-stage MV: `silver.log_events → silver.log_events_hourly` | landed in a **fourth column** that did not exist before, after the table it reads |
 | A table nothing feeds (`manual_annotations`) | column 0 with the sources, no incoming edge — correct: nothing produces it |
 
-**Kind is on two channels, and neither is hue.** Hue is spoken for: `--pri`, `--sec` and
+**Kind is on the GROUND, and the first attempt at it was measurably fake.** The channel is
+right — a filled area beats a 1px stroke as a signal, so a reader sees the kind before reading
+the name — but the first version used `--raise` / transparent / `--sunk`, which measure
+**1.03:1 apart**. Three names for one colour, with the border doing all the work while the
+comment claimed otherwise. Contrast ratio is a poor guide this close to black, so the fix was
+picked by rendering candidates and looking, then checked against the numbers:
+
+| | command | substrate |
+|---|---|---|
+| `--k-table` lit — the rows are in here | `#1B2614` | `#12283A` |
+| `--k-mv` dim — a trigger; rows pass through | `#0E1309` | `#0A121C` |
+| `--k-view` dark — a query, run when read | `#050703` | `#020407` |
+
+Hue is still not the channel: `--pri`, `--sec` and `--ter` mean logs, traces and metrics on
+every edge and particle here, and a box borrowing one would make the same channel say two
+things. Border style stays as the redundant second reading, so the distinction survives
+greyscale and a colour-blind reader.
+
+**And it surfaced a contrast bug that predates it.** Substrate's `--dim` was `#3D5A72`, putting
+every `.sub` label at **2.8:1** on the old panel and 2.09 on the new lit ground — under the 3:1
+floor for small text, on labels that are not decoration: `on insert`, `stored`, `per minute`,
+each producer's declared latency, the volume band's reason. Raised to `#57748F`, where the
+worst case on this board is 3.09. Command's was already above the line.
+
+**Kind was on two channels, and neither is hue.** Hue is spoken for: `--pri`, `--sec` and
 `--ter` mean logs, traces and metrics everywhere on this canvas, and a box borrowing one would
 make the same channel say two things. The **ground** was free, and there the difference is
 literal rather than a code to memorise — a table is *filled* because it holds something, an MV

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -365,6 +365,13 @@ with every dot at opacity 0 — bronze fed the MVs and then the board went still
 the growth of the bronze table the chain started from, resolved **through the graph**, so a
 second-stage MV reading a silver table finds its root instead of guessing.
 
+*Opening a box blacked the board out for a second.* `render` creates every dot at opacity 0
+and the tick read `if (repaint()) return`, skipping the `density` call that reveals them — so a
+structural change left the whole canvas empty until the next frame arrived, then filled it all
+at once. Read as every particle restarting, and reported as exactly that. Every structural
+repaint outside the tick now goes through `repaintNow`, which re-applies the current density
+immediately: 69 dots are visible the instant the click completes, not a second later.
+
 *Clicking a row restarted every dot on the board.* Selection went through `repaint`, which
 rebuilds the whole stage; rebuilding recreates every `animateMotion`, and an `animateMotion`
 keeps its progress on the node itself, so each dot jumped back to the mouth of its pipe. That
@@ -373,6 +380,17 @@ by its own click handler. A selection changes no geometry (the sheets sit below 
 are narrower than it, so nothing moves), so it now redraws only the sheet layer, the `.sel`
 classes and the key. Verified by **object identity**, not by counting: the same 89 circle nodes
 survive both a model click and a table click.
+
+**The two still edges now carry dots, which reverses a call I made twice.** The collapsed
+`bronze ⇒ silver` bar and the `table → view` reads were drawn motionless on the argument that
+neither is a hop. The argument holds for the *shape* — the bar keeps its rails and no bore, the
+reads keep their dashes — but not for the stillness: both counts climb while the stream runs,
+and a dead line between two rising numbers says the opposite of what is happening. The bar's
+dots run down a `.track`, a path with no stroke that exists only for `animateMotion` to follow,
+so the rails stay two rails. A read's dots are smaller and slower than a pipe's, so the
+difference in claim survives as a difference in weight. Each read edge is gated on the growth
+of the table being *read*, resolved back to its bronze root: a view over a silent table has
+nothing new to answer with.
 
 **Every run is capped at both ends now.** The `collector → bronze` trunk had lips at
 departure and arrival from the start; every run added after it got one only where it landed,

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -276,6 +276,49 @@ not imply flow-ui reads six things it does not read. Six tests pin the parsing, 
 present-but-empty vs absent split and an unreachable ClickHouse reading as absent rather than
 taking the board down.
 
+### Open, the derivation becomes per-table — because the mapping is not 1:1
+
+Closed, one double bar is the honest summary. Open, the reader is asking a lineage question —
+*which bronze table becomes which silver model* — and that question has an answer worth
+drawing, because it is 4 → 3:
+
+```
+otel_logs          → log_events
+otel_traces        → operation_executions
+otel_metrics_gauge ─┐
+otel_metrics_sum   ─┴→ metric_observations
+```
+
+Nothing else on the board says that gauge and sum both land in one model. The four strands
+carry particles in the type colours, and each strand runs on the growth of *its own* bronze
+table — a silent source is a still strand, the same rule the bronze fan already follows.
+The dots depart on the same batch arrival that fills the bronze row, because the MVs fire on
+that insert; they are not a second hop after it. The mapping is read off the four
+`CREATE MATERIALIZED VIEW … TO silver.x … FROM bronze.y` statements in the DDL, not inferred
+from the names, and each silver row also states its source in text so a reader who never
+opens both boxes still gets the answer.
+
+**The rows are ordered by their source, not by `system.tables`.** In the catalogue's order
+the four strands crossed inside a 52px gap, and a crossing is a claim about routing this
+mapping does not make. In source order they run essentially straight across, and the two
+metrics strands visibly converge — the merge reads as a merge.
+
+**Three defects this surfaced, all found by looking:**
+
+- **The datasheet covered SILVER.** Drawn 40px right of BRONZE, it landed exactly where the
+  new box sits — a detail panel over the nodes it explains, the third time that class of
+  defect has reached the reader. Moving it past SILVER cleared the overlap and cost more:
+  at 320 wide it took the canvas from 1080 to 1682 units, and `fit()` scales to the widest
+  thing, so every box shrank to 58% to make room for a panel. It now sits **below** BRONZE,
+  directly under the table it describes, where at 320 against bronze's own 318 it adds no
+  width at all.
+- **SILVER's rows did not answer the pointer.** They were plain rects next to a BRONZE box
+  whose every row lit up, so the box read as inert. They are `.hit` groups now, with the
+  source named in the `aria-label`.
+- **`open.silver` was missing from `repaint()`'s key.** The click flipped the state, the key
+  did not change, repaint returned early and the box never opened — a dead click with no
+  error. That key is a dependency list maintained by hand; every expandable box belongs in it.
+
 ## Next planned step
 
 Tier 1 is now closed to the limit of the data. What remains:

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -357,6 +357,13 @@ applied — which it was. The class being right is not the question a reader ask
 verified at the pixel level instead: the swatch's computed stroke goes from `rgb(46,110,136)`
 to `rgb(255,197,61)` and its opacity from 0.5 to 1, while the other two do not move.
 
+**And adding the kind strokes silently took the selected border away from every silver node.**
+`.nd.sel` and `.sub-nd.k-mv` are both two classes, so the cascade falls back to source order,
+and the kind rules were written below. Selection now comes after them. The same trap as the
+presentation-attribute-versus-stylesheet one the pipes hit months earlier: equal specificity is
+decided by position, and position is easy to move by accident. The selected border keeps its
+dash pattern, so picking a node does not hide what kind it is.
+
 **A silent failure mode worth knowing:** `el(tag, attrs, text)`'s third argument is text, not
 children. Passing elements there sets the group's `textContent` and the child is never created
 — no error, no warning, just a legend with no swatches in it.

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -276,6 +276,31 @@ not imply flow-ui reads six things it does not read. Six tests pin the parsing, 
 present-but-empty vs absent split and an unreachable ClickHouse reading as absent rather than
 taking the board down.
 
+### Silver's models have datasheets too — read from ClickHouse, not restated
+
+Clicking a silver model opens a sheet under the box, the same shape as bronze's. The
+provenance is deliberately different, and the asymmetry is the point:
+
+- **Bronze's sheet is hand-written** in `topology.TABLE_DOCS` because the read contract makes
+  a *subset* claim — only some columns are populated, the rest sit at their ClickHouse default
+  by design (§2) — and no DDL can express that.
+- **Silver makes no such claim.** The DDL is the whole definition, so its columns come live
+  from `system.columns` and cannot drift from the deployed schema. Restating them in Python
+  would only create something to go stale.
+
+Only the one-line purpose per model is written by hand, because a type is metadata and a
+purpose is a claim. `system.columns` is filtered in Python rather than in the query:
+ClickHouse 24.3 rejects `IN (SELECT … FROM system.tables)` with *"Not-ready Set is passed as
+the second argument for function 'in'"*, and unfiltered it returned each model's schema three
+times, once under each materialized view that writes it.
+
+**And the six read views now say what they are.** A bare list of names is a list, not
+information — a reader cannot tell a view from a table, or guess that `run_summary` is one row
+per run. Each carries its grain and what it answers, under a line saying a view stores nothing
+and is a query over the models above. They are on two lines each because side by side a
+22-character name and a 43-character answer need 455 units against 278 of usable width, and
+the first version simply drew them on top of each other.
+
 ### Open, the derivation becomes per-table — because the mapping is not 1:1
 
 Closed, one double bar is the honest summary. Open, the reader is asking a lineage question —

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -341,6 +341,20 @@ every edge and particle here, and a box borrowing one would make the same channe
 things. Border style stays as the redundant second reading, so the distinction survives
 greyscale and a colour-blind reader.
 
+**The key is a legend, and it was being read as three checkboxes.** A 12×12 rounded square
+beside a label is the shape of something you tick, so it invited a click it could not answer.
+It is a wide flat bar now — a miniature of the node it describes, which is what it actually is
+— and `pointer-events:none`, so it never takes a cursor either.
+
+It does answer the pointer, from the other end: **selecting a node lights the swatch for that
+node's kind**, and the other two stay dim. The legend stops being dead chrome and starts saying
+*the thing you just picked is one of these*. Verified across all three kinds and the
+nothing-selected state.
+
+**A silent failure mode worth knowing:** `el(tag, attrs, text)`'s third argument is text, not
+children. Passing elements there sets the group's `textContent` and the child is never created
+— no error, no warning, just a legend with no swatches in it.
+
 **And it surfaced a contrast bug that predates it.** Substrate's `--dim` was `#3D5A72`, putting
 every `.sub` label at **2.8:1** on the old panel and 2.09 on the new lit ground — under the 3:1
 floor for small text, on labels that are not decoration: `on insert`, `stored`, `per minute`,

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -392,6 +392,32 @@ difference in claim survives as a difference in weight. Each read edge is gated 
 of the table being *read*, resolved back to its bronze root: a view over a silent table has
 nothing new to answer with.
 
+**One pool per signal type on the bar**, through the existing `flow3`, each gated on the bronze
+tables feeding *its* materialized views. The first version passed a single hardcoded class and
+every dot came out amber — right by accident for metrics, wrong for logs and traces, and the
+same defect the collector's outcome rows had before `reject_matrix` fixed them. Twice in one
+service, reported both times by the person looking at it.
+
+**The arrowhead came off the bar.** Direction is carried by dots that move, which is the
+stronger of the two ways of saying it; a marker on top of them was the weaker one repeated.
+
+### The lanes stopped running on a metronome
+
+`flow` spaced departures at exactly `dur / n` and `flow3` added exactly a third of a slot per
+colour, so every lane read 1-2-3, 1-2-3 — a rhythm this pipeline does not have. Identical
+durations kept it forever, because every dot returns to its own slot each cycle.
+
+Departures are scattered inside their slot now, and each dot runs at its own slightly different
+speed: the spread breaks the pattern, the drift stops it re-forming, because dots at different
+speeds never return to the same relative positions. Measured on the derivation bar — gaps of
+`0.26 / 0.48 / 0.06 / 0.91 / 0.48` against a constant `0.43` before, and six distinct durations
+where there was one.
+
+The scatter is **seeded on the pool key and the dot index, never `Math.random`**: a structural
+repaint must not reshuffle a lane the reader is already watching. Verified — the same six
+`begin` values survive an open-and-close. Same constraint that made `order` use farthest-point
+insertion rather than a modular stride.
+
 **Every run is capped at both ends now.** The `collector → bronze` trunk had lips at
 departure and arrival from the start; every run added after it got one only where it landed,
 so a pipe grew out of a flat box edge at one end and met a lip at the other — on the bronze

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -347,9 +347,15 @@ It is a wide flat bar now — a miniature of the node it describes, which is wha
 — and `pointer-events:none`, so it never takes a cursor either.
 
 It does answer the pointer, from the other end: **selecting a node lights the swatch for that
-node's kind**, and the other two stay dim. The legend stops being dead chrome and starts saying
-*the thing you just picked is one of these*. Verified across all three kinds and the
-nothing-selected state.
+node's kind** in `--sec`, and the other two stay dim. The legend stops being dead chrome and
+starts saying *the thing you just picked is one of these*. Amber because that is already what
+selection means everywhere else here — `.nd.sel`, the hover border, the OPEN/CLOSE cue.
+
+**The first version of that highlight was invisible, and the test said it worked.** It only
+nudged `stroke-width` and the text fill, and the assertion checked that the `.on` class was
+applied — which it was. The class being right is not the question a reader asks. It is now
+verified at the pixel level instead: the swatch's computed stroke goes from `rgb(46,110,136)`
+to `rgb(255,197,61)` and its opacity from 0.5 to 1, while the other two do not move.
 
 **A silent failure mode worth knowing:** `el(tag, attrs, text)`'s third argument is text, not
 children. Passing elements there sets the group's `textContent` and the child is never created

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -357,6 +357,14 @@ applied — which it was. The class being right is not the question a reader ask
 verified at the pixel level instead: the swatch's computed stroke goes from `rgb(46,110,136)`
 to `rgb(255,197,61)` and its opacity from 0.5 to 1, while the other two do not move.
 
+**Every run is capped at both ends now.** The `collector → bronze` trunk had lips at
+departure and arrival from the start; every run added after it got one only where it landed,
+so a pipe grew out of a flat box edge at one end and met a lip at the other — on the bronze
+tables' exits, on the MVs' exits, and on the collapsed `bronze ⇒ silver` bar, which had none
+at all. A lip marks where a run *meets a box*: it is a termination, not a claim about what
+travels, so putting one on the derivation bar does not undo it carrying nothing. The dashed
+read edges still have none, because they are not pipes.
+
 **And adding the kind strokes silently took the selected border away from every silver node.**
 `.nd.sel` and `.sub-nd.k-mv` are both two classes, so the cascade falls back to source order,
 and the kind rules were written below. Selection now comes after them. The same trap as the

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -1,20 +1,13 @@
 # flow-ui — working state
 
-*2026-09-01 · branch `feat/flow-ui` · **nothing committed***
+*2026-09-02 · branch `feat/flow-ui-silver-read` · V1–V2.3 merged to `main` in PR #31*
 
 ## Where things are
 
-Working tree only. `git status`:
-
-```
- M Makefile                    generate-stream + ui targets
- M docker-compose.yml          flow-ui service + generator-config mount
-?? services/flow-ui/           the whole service
-   docs/research/data-observability-competitive-landscape.md   (the V2 roadmap)
-```
+On `main` since PR #31. In flight on this branch: Silver as the fourth box on the Flow board.
 
 Run: `make up` → `make ui` → `make generate-stream DURATION=20m`.
-Tests: `cd services/flow-ui && .venv/bin/python -m pytest tests -q` → 47 passing.
+Tests: `cd services/flow-ui && .venv/bin/python -m pytest tests -q` → 63 passing.
 
 ## What V1 does
 
@@ -258,6 +251,31 @@ retained Map either way.
 stack whose ClickHouse volume predates the DDL. The node then shows the declared figure
 alone, as it always did.
 
+## Shipped: Silver on the graph — and drawn as a derivation, not a hop
+
+Silver was being *read* and was nowhere on the picture, so the one board people look at
+claimed the pipeline ended at bronze. It is now the fourth box, and the link into it is
+deliberately **not a pipe**.
+
+Everything else on this canvas transports something: a pipe has a casing, a bore, mouths at
+both ends, and particles inside it, because a signal really does leave one place and arrive at
+another. Bronze to Silver moves nothing — ADR-0010's materialized views fire *inside*
+ClickHouse on the same insert that writes bronze. Drawing a run between them would claim a hop
+that never happens and invite the question that follows from it ("what is the latency of that
+hop?"), which has no answer. So it is a short double bar with a tip, captioned `derived` /
+`on insert`, and no particle ever enters it.
+
+**Three states, and the box says which.** Absent (no `silver` database — a volume older than
+the DDL), present and empty (the normal state of a stack nobody has streamed into: the MVs do
+not `POPULATE`), and populated. `silver_state()` reads `system.tables`, so it is metadata —
+0.025 s, never scans a row — and the same distinction `counts()` makes for the same reason.
+
+Open, it lists the three models with their row counts and the six read views, with
+`service_health_1m` marked as the only one this service actually consumes — so the panel does
+not imply flow-ui reads six things it does not read. Six tests pin the parsing, including the
+present-but-empty vs absent split and an unreachable ClickHouse reading as absent rather than
+taking the board down.
+
 ## Next planned step
 
 Tier 1 is now closed to the limit of the data. What remains:
@@ -268,7 +286,7 @@ Tier 1 is now closed to the limit of the data. What remains:
 * **V2.4 · freshness/arrival lag** and the **Arrival watcher**, both blocked on the same
   prerequisite: an arrival timestamp at the collector's write path. Worth an ADR, not UI work.
 * A **geometry test**. Two layout collisions and one overlap reached the reader today; the
-  57 tests cover the backend and the pure logic and nothing about where things land.
+  63 tests cover the backend and the pure logic and nothing about where things land.
 * **The rest of V2.3**, which is two pieces, not four: a per-node state timeline (needs
   per-service history retained, which nothing does today) and Grafana node-graph frames.
   Edge thickness by throughput and edge colour by violation rate are not pending — there is

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -418,6 +418,27 @@ repaint must not reshuffle a lane the reader is already watching. Verified — t
 `begin` values survive an open-and-close. Same constraint that made `order` use farthest-point
 insertion rather than a modular stride.
 
+### Dots that vanish and come back: the rate BEATS
+
+Reported as dots leaving, disappearing and reappearing, and it was not the animation. The
+generator emits on a 1s step and the poller samples on a 1s interval, so the two drift against
+each other and a window catches two of the generator's ticks or none. Sampled every 2s `logs`
+reads a steady 82/s; drawn per tick the lane ran **4,2,4,2,4,2**.
+
+A deadband alone could not fix it — a 2× swing is not a rounding boundary. The density is now
+smoothed with an EMA and *then* quantised with a deadband, and the on/off gates use the same
+smoothing: `rate > 0` reads false in whichever window catches nothing, so a run went still for
+one frame and came back — the same defect in binary. **Display only**; every printed figure is
+still the raw measurement and the smoothing never reaches the verdict.
+
+Measured with both boxes open, over 14 ticks: four lanes with a moving count before, one after —
+and that one changes by a single dot three times, which is the metrics rate genuinely drifting
+across a boundary rather than a beat.
+
+**One lane was still a metronome.** BRONZE's internal fan builds its circles in its own loop
+rather than through `flow`, so the scatter never reached it: all twelve ran at exactly 3.20s
+while every other lane had been broken up. Now 10 distinct durations across 3.00–3.38s.
+
 **Every run is capped at both ends now.** The `collector → bronze` trunk had lips at
 departure and arrival from the start; every run added after it got one only where it landed,
 so a pipe grew out of a flat box edge at one end and met a lip at the other — on the bronze

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -357,6 +357,23 @@ applied — which it was. The class being right is not the question a reader ask
 verified at the pixel level instead: the swatch's computed stroke goes from `rgb(46,110,136)`
 to `rgb(255,197,61)` and its opacity from 0.5 to 1, while the other two do not move.
 
+**Two bugs a running stream found that a still page could not.**
+
+*The MV → table runs had particles that were never revealed.* `spawn` fills `pools`, and
+nothing in the tick showed the `sv-*` ones, so the one real movement inside SILVER existed
+with every dot at opacity 0 — bronze fed the MVs and then the board went still. The gate is
+the growth of the bronze table the chain started from, resolved **through the graph**, so a
+second-stage MV reading a silver table finds its root instead of guessing.
+
+*Clicking a row restarted every dot on the board.* Selection went through `repaint`, which
+rebuilds the whole stage; rebuilding recreates every `animateMotion`, and an `animateMotion`
+keeps its progress on the node itself, so each dot jumped back to the mouth of its pipe. That
+invariant is [the reason this page has no framework](ARCHITECTURE.md) — and it was being broken
+by its own click handler. A selection changes no geometry (the sheets sit below their box and
+are narrower than it, so nothing moves), so it now redraws only the sheet layer, the `.sel`
+classes and the key. Verified by **object identity**, not by counting: the same 89 circle nodes
+survive both a model click and a table click.
+
 **Every run is capped at both ends now.** The `collector → bronze` trunk had lips at
 departure and arrival from the start; every run added after it got one only where it landed,
 so a pipe grew out of a flat box edge at one end and met a lip at the other — on the bronze

--- a/services/flow-ui/STATUS.md
+++ b/services/flow-ui/STATUS.md
@@ -276,6 +276,41 @@ not imply flow-ui reads six things it does not read. Six tests pin the parsing, 
 present-but-empty vs absent split and an unreachable ClickHouse reading as absent rather than
 taking the board down.
 
+### Silver is a DAG now, and the DAG is the database's shape — not a list in the code
+
+Three boxes and a list of six names said nothing about what separates them, and the question
+it produced was the right one: *what is the difference between a table and a view?* Every
+object in `silver` is now its own box, in three columns, with the lineage drawn between them.
+
+**Three kinds, and the confusion is worth naming.** ClickHouse puts all three in one database
+and the words mislead:
+
+| | | on the board |
+|---|---|---|
+| **MergeTree** | a table — stores rows, has a sort key and a TTL | solid border, a row count |
+| **MaterializedView** | *not* a stored result set. An **insert trigger**: rows land in its source, it runs its SELECT over that block and inserts into its target. Stores nothing | dashed border, `on insert`, no count |
+| **View** | a named query, run at read time. No rows exist until someone asks | dotted border, its grain, `—` |
+
+That distinction is why Silver only holds what arrived after the DDL did — the MVs do not
+`POPULATE` — and it is the thing this board had been hiding.
+
+**The edges are not all the same edge.** `bronze → mv → table` carries particles, because rows
+really do move on that insert. `table → view` carries none: nothing flows there until a reader
+runs the query, and animating it would draw a stream that does not exist. Colour is the source
+table's signal type throughout, so lineage stays followable either way.
+
+**Nothing here enumerates the schema.** `silver_graph()` reads `system.tables`, classifies by
+engine, and parses lineage out of `create_table_query` — `TO x.y` is an MV's target, every
+other `bronze.`/`silver.` reference is a source. The old `DERIVES` constant, four bronze→model
+pairs typed into `app.js`, was a fourth copy of the DDL after the SQL, the MV definitions and
+`system.tables`; it is now computed. The box's own footprint is measured from the graph rather
+than typed in.
+
+**Verified the way the claim deserves:** a `CREATE VIEW silver.error_budget_1m AS SELECT …
+FROM silver.operation_executions` run against the live database appeared on the board — in the
+READ VIEWS column, placed next to the table it reads, wired to it by an edge in that table's
+colour, with the box grown to seven rows — with **no code edited**. Then dropped again.
+
 ### Silver's models have datasheets too — read from ClickHouse, not restated
 
 Clicking a silver model opens a sheet under the box, the same shape as bronze's. The
@@ -289,10 +324,10 @@ provenance is deliberately different, and the asymmetry is the point:
   would only create something to go stale.
 
 Only the one-line purpose per model is written by hand, because a type is metadata and a
-purpose is a claim. `system.columns` is filtered in Python rather than in the query:
+purpose is a claim. An MV's columns are skipped, because they *are* its target's — listing
+them says the same thing twice. (An earlier version tried to filter this in SQL and could not:
 ClickHouse 24.3 rejects `IN (SELECT … FROM system.tables)` with *"Not-ready Set is passed as
-the second argument for function 'in'"*, and unfiltered it returned each model's schema three
-times, once under each materialized view that writes it.
+the second argument for function 'in'"*.)
 
 **And the six read views now say what they are.** A bare list of names is a list, not
 information — a reader cannot tell a view from a table, or guess that `run_summary` is one row

--- a/services/flow-ui/src/flow_ui/clickhouse.py
+++ b/services/flow-ui/src/flow_ui/clickhouse.py
@@ -438,12 +438,15 @@ class ClickHouse:
             except ValueError:
                 continue
             out["present"] = True
-            if engine == "MergeTree":
-                out["models"][name] = int(n)
+            # Same classification as `silver_graph`, and it has to stay the same: matching
+            # the literal "MergeTree" left a SummingMergeTree rollup out of `models`, so the
+            # board drew the table but had no count to put in it.
+            if engine == "MaterializedView":
+                out["mvs"] += 1
             elif engine == "View":
                 out["views"].append(name)
-            elif engine == "MaterializedView":
-                out["mvs"] += 1
+            else:
+                out["models"][name] = int(n)
         out["views"].sort()
         return out
 
@@ -510,9 +513,12 @@ class ClickHouse:
             if len(parts) != 4:
                 continue
             name, engine, sort, ddl = parts
-            kind = {"MergeTree": "table", "MaterializedView": "mv", "View": "view"}.get(engine)
-            if not kind:
-                continue
+            # Any *MergeTree is a table. Matching the literal string "MergeTree" made a
+            # SummingMergeTree rollup — the obvious engine for exactly this kind of model —
+            # invisible on the board, with its own MV left pointing at nothing. Everything
+            # that is not one of the two view engines stores rows, so it is a table.
+            kind = ("mv" if engine == "MaterializedView"
+                    else "view" if engine == "View" else "table")
             # `TO silver.x` is where an MV writes; everything else it names, it reads.
             to = re.search(r"\bTO\s+(?:bronze|silver)\.([a-z_0-9]+)", ddl)
             target = to.group(1) if to else ""

--- a/services/flow-ui/src/flow_ui/clickhouse.py
+++ b/services/flow-ui/src/flow_ui/clickhouse.py
@@ -404,6 +404,47 @@ class ClickHouse:
             log.info("silver service health unavailable (is silver deployed?): %s", exc)
         return out
 
+    #: Silver's three physical models, in the order the pipeline fills them.
+    SILVER_MODELS = ("operation_executions", "log_events", "metric_observations")
+
+    async def silver_state(self) -> dict:
+        """What Silver holds, and whether it is there at all.
+
+        Row counts come from `system.tables`, which is metadata — the same reason
+        :meth:`counts` reads `count()` rather than a windowed query. Cheap enough for the
+        slow lane and never scans a row.
+
+        `present` is the distinction the board needs: a ClickHouse volume created before the
+        Silver DDL landed has no `silver` database, and an empty Silver is a different
+        statement from an absent one. Both are normal — the DDL runs on ClickHouse boot, so a
+        fresh `make up` has Silver from the start and it stays empty until a stream runs,
+        because ADR-0010's materialized views do not `POPULATE`.
+        """
+        out = {"present": False, "models": {}, "views": [], "mvs": 0}
+        try:
+            rows = await self._query(
+                "SELECT engine, name, toUInt64(ifNull(total_rows, 0)) "
+                "FROM system.tables WHERE database = 'silver' FORMAT TSV")
+        except httpx.HTTPError as exc:
+            log.info("silver state unavailable: %s", exc)
+            return out
+        for line in rows.splitlines():
+            if not line.strip():
+                continue
+            try:
+                engine, name, n = line.split("\t")
+            except ValueError:
+                continue
+            out["present"] = True
+            if engine == "MergeTree":
+                out["models"][name] = int(n)
+            elif engine == "View":
+                out["views"].append(name)
+            elif engine == "MaterializedView":
+                out["mvs"] += 1
+        out["views"].sort()
+        return out
+
     async def scenario(self) -> str:
         """The most recent run's scenario, for the header.
 

--- a/services/flow-ui/src/flow_ui/clickhouse.py
+++ b/services/flow-ui/src/flow_ui/clickhouse.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import ClassVar
 
 import httpx
@@ -471,43 +472,60 @@ class ClickHouse:
         "run_summary": ("per run", "services, traces, operations, errors"),
     }
 
-    async def silver_schema(self) -> dict:
-        """Each Silver model's columns and keys, read from ClickHouse rather than restated.
+    async def silver_graph(self) -> dict:
+        """Every object in `silver`, what kind it is, and what it reads — from ClickHouse.
 
-        The asymmetry with :data:`topology.TABLE_DOCS` is the point. Bronze's datasheet is
-        hand-written because the read contract makes a *subset* claim — only some columns are
-        populated, the rest sit at their ClickHouse default by design (§2) — and no DDL can
-        say that. Silver makes no such claim: the DDL is the whole definition, so restating
-        it in Python would only create something that can drift from the deployed schema.
+        Three kinds live in that database and they are not the same thing, which is exactly
+        what a reader gets wrong:
 
-        `system.columns` and `system.tables` are both metadata; this scans no data.
+        * **MergeTree** — a real table. Stores rows, has a sort key and a TTL.
+        * **MaterializedView** — not a stored result set, the way Postgres uses the word. In
+          ClickHouse it is an *insert trigger*: when rows land in its source it runs its
+          SELECT over that block and inserts into its `TO` target. It stores nothing itself.
+          This is why Silver holds only what arrived after the DDL did — they do not
+          `POPULATE`.
+        * **View** — a named query, run at read time. Stores nothing, and has no row count
+          to show, because the rows do not exist until someone asks.
+
+        Lineage is parsed out of `create_table_query` rather than declared here. `TO x.y` is
+        an MV's target and `FROM x.y` its source; a plain view's sources are every table it
+        names. Written down by hand it would be a second copy of the DDL, free to drift from
+        the one ClickHouse is actually running.
         """
         out: dict[str, dict] = {}
         try:
-            keys = await self._query(
-                "SELECT name, sorting_key, partition_key FROM system.tables "
-                "WHERE database = 'silver' AND engine = 'MergeTree' FORMAT TSV")
+            rows = await self._query(
+                "SELECT name, engine, sorting_key, "
+                "replaceRegexpAll(create_table_query, '\\s+', ' ') "
+                "FROM system.tables WHERE database = 'silver' FORMAT TSV")
             cols = await self._query(
                 "SELECT table, name, type FROM system.columns "
                 "WHERE database = 'silver' ORDER BY table, position FORMAT TSV")
         except httpx.HTTPError as exc:
-            log.info("silver schema unavailable: %s", exc)
+            log.info("silver graph unavailable: %s", exc)
             return out
-        for line in keys.splitlines():
+        ref = re.compile(r"\b(bronze|silver)\.([a-z_0-9]+)")
+        for line in rows.splitlines():
             parts = line.split("\t")
-            if len(parts) != 3:
+            if len(parts) != 4:
                 continue
-            out[parts[0]] = {"columns": [], "order_by": parts[1], "partition": parts[2],
-                             "summary": self.SILVER_SUMMARY.get(parts[0], "")}
-        # Filtered here, not in the query: ClickHouse 24.3 rejects `IN (SELECT … FROM
-        # system.tables)` with "Not-ready Set is passed as the second argument for function
-        # 'in'". The names are already in hand from the query above, so the filter is free.
-        # It matters — `system.columns` also returns the four materialized views and six read
-        # views, and an MV's columns are its target's, so unfiltered each model's schema came
-        # back three times under three names.
+            name, engine, sort, ddl = parts
+            kind = {"MergeTree": "table", "MaterializedView": "mv", "View": "view"}.get(engine)
+            if not kind:
+                continue
+            # `TO silver.x` is where an MV writes; everything else it names, it reads.
+            to = re.search(r"\bTO\s+(?:bronze|silver)\.([a-z_0-9]+)", ddl)
+            target = to.group(1) if to else ""
+            seen = {f"{db}.{tbl}" for db, tbl in ref.findall(ddl)}
+            sources = sorted(r for r in seen
+                             if r.split(".")[1] not in (name, target))
+            out[name] = {"kind": kind, "sources": sources, "target": target,
+                         "order_by": sort, "columns": [],
+                         "summary": self.SILVER_SUMMARY.get(name, "")}
         for line in cols.splitlines():
             parts = line.split("\t")
-            if len(parts) != 3 or parts[0] not in out:
+            # An MV's columns are its target's; listing them would say the same thing twice.
+            if len(parts) != 3 or parts[0] not in out or out[parts[0]]["kind"] == "mv":
                 continue
             out[parts[0]]["columns"].append([parts[1], parts[2]])
         return out

--- a/services/flow-ui/src/flow_ui/clickhouse.py
+++ b/services/flow-ui/src/flow_ui/clickhouse.py
@@ -354,6 +354,56 @@ class ClickHouse:
             log.warning("call edges unavailable: %s", exc)
         return out
 
+    async def service_health(self, minutes: int = 30, limit: int = 12) -> list[dict]:
+        """Per-producer latency and error rate, from Silver.
+
+        The first thing this service reads out of `silver.*` rather than deriving from
+        Bronze. It is an **addition, not a migration**: Bronze keeps answering the questions
+        it already answers, because Silver's materialized views do not `POPULATE` (ADR-0010)
+        and only see inserts made after the DDL was applied. Measured on this stack the day
+        Silver landed: `bronze.otel_traces` held 1,703,050 rows going back 36 hours while
+        `silver.operation_executions` held 12,849 going back 12 minutes. Moving the contract
+        and volume queries across today would have silently dropped 36 hours of evidence.
+
+        What it adds is genuinely new: flow-ui had **no per-service latency at all**. The
+        Health board's quantiles are the collector's *export* latency — how long writing to
+        ClickHouse takes — which is a different question from how long a producer's own
+        operations take.
+
+        Returns `[]` when `silver.*` is absent, which is the normal state of any stack whose
+        ClickHouse volume predates the Silver DDL: the boards degrade to what Bronze answers
+        rather than erroring.
+        """
+        sql = f"""
+        SELECT service_name,
+               sum(operation_count) AS ops,
+               sum(error_count) AS errors,
+               round(avg(latency_p50_ms), 1) AS p50,
+               round(max(latency_p95_ms), 1) AS p95,
+               round(max(latency_p99_ms), 1) AS p99,
+               round(max(latency_max_ms), 1) AS worst
+        FROM silver.service_health_1m
+        WHERE window_start >= now() - INTERVAL {int(minutes)} MINUTE
+        GROUP BY service_name ORDER BY ops DESC LIMIT {int(limit)} FORMAT TSV
+        """
+        out: list[dict] = []
+        try:
+            for line in (await self._query(sql)).splitlines():
+                if not line.strip():
+                    continue
+                svc, ops, errs, p50, p95, p99, worst = line.split("\t")
+                ops_i, errs_i = int(ops), int(errs)
+                out.append({
+                    "service": svc, "ops": ops_i, "errors": errs_i,
+                    "error_rate": round(errs_i / ops_i, 5) if ops_i else 0.0,
+                    "p50": float(p50), "p95": float(p95),
+                    "p99": float(p99), "max": float(worst),
+                })
+        except (httpx.HTTPError, ValueError) as exc:
+            # `UNKNOWN_TABLE` arrives here when the Silver DDL was never applied.
+            log.info("silver service health unavailable (is silver deployed?): %s", exc)
+        return out
+
     async def scenario(self) -> str:
         """The most recent run's scenario, for the header.
 

--- a/services/flow-ui/src/flow_ui/clickhouse.py
+++ b/services/flow-ui/src/flow_ui/clickhouse.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import ClassVar
 
 import httpx
 
@@ -443,6 +444,72 @@ class ClickHouse:
             elif engine == "MaterializedView":
                 out["mvs"] += 1
         out["views"].sort()
+        return out
+
+    #: What each Silver model is *for*. The only hand-written part of its datasheet, and
+    #: deliberately so: a type is metadata, a purpose is a claim, and ClickHouse holds the
+    #: first and not the second.
+    SILVER_SUMMARY: ClassVar[dict[str, str]] = {
+        "operation_executions": "One row per span. Duration is milliseconds, already "
+                                "converted; the hot sentinel.* keys are columns, not Map "
+                                "probes.",
+        "log_events": "One row per log record, with severity normalized and is_error "
+                      "precomputed.",
+        "metric_observations": "One row per data point, gauge and sum unified — metric_kind "
+                               "says which table it came from.",
+    }
+
+    #: What each read view answers, in the words of its own SELECT. A view stores nothing —
+    #: it is a query over the models above, run at read time — and a bare list of six names
+    #: with no explanation is a puzzle, not information.
+    SILVER_VIEW_DOCS: ClassVar[dict[str, tuple[str, str]]] = {
+        "service_health_1m": ("per minute", "op count, error rate, latency p50/p95/p99"),
+        "log_health_1m": ("per minute", "log count, error rate, worst severity"),
+        "metric_rollup_1m": ("per minute", "count, sum, min/max/avg, stddev per name"),
+        "telemetry_coverage_1m": ("per minute", "spans, logs, metrics seen per component"),
+        "trace_summary": ("per trace", "duration, span count, entry/exit service"),
+        "run_summary": ("per run", "services, traces, operations, errors"),
+    }
+
+    async def silver_schema(self) -> dict:
+        """Each Silver model's columns and keys, read from ClickHouse rather than restated.
+
+        The asymmetry with :data:`topology.TABLE_DOCS` is the point. Bronze's datasheet is
+        hand-written because the read contract makes a *subset* claim — only some columns are
+        populated, the rest sit at their ClickHouse default by design (§2) — and no DDL can
+        say that. Silver makes no such claim: the DDL is the whole definition, so restating
+        it in Python would only create something that can drift from the deployed schema.
+
+        `system.columns` and `system.tables` are both metadata; this scans no data.
+        """
+        out: dict[str, dict] = {}
+        try:
+            keys = await self._query(
+                "SELECT name, sorting_key, partition_key FROM system.tables "
+                "WHERE database = 'silver' AND engine = 'MergeTree' FORMAT TSV")
+            cols = await self._query(
+                "SELECT table, name, type FROM system.columns "
+                "WHERE database = 'silver' ORDER BY table, position FORMAT TSV")
+        except httpx.HTTPError as exc:
+            log.info("silver schema unavailable: %s", exc)
+            return out
+        for line in keys.splitlines():
+            parts = line.split("\t")
+            if len(parts) != 3:
+                continue
+            out[parts[0]] = {"columns": [], "order_by": parts[1], "partition": parts[2],
+                             "summary": self.SILVER_SUMMARY.get(parts[0], "")}
+        # Filtered here, not in the query: ClickHouse 24.3 rejects `IN (SELECT … FROM
+        # system.tables)` with "Not-ready Set is passed as the second argument for function
+        # 'in'". The names are already in hand from the query above, so the filter is free.
+        # It matters — `system.columns` also returns the four materialized views and six read
+        # views, and an MV's columns are its target's, so unfiltered each model's schema came
+        # back three times under three names.
+        for line in cols.splitlines():
+            parts = line.split("\t")
+            if len(parts) != 3 or parts[0] not in out:
+                continue
+            out[parts[0]]["columns"].append([parts[1], parts[2]])
         return out
 
     async def scenario(self) -> str:

--- a/services/flow-ui/src/flow_ui/main.py
+++ b/services/flow-ui/src/flow_ui/main.py
@@ -157,7 +157,7 @@ async def graph() -> dict:
     return {
         "topology": topology.service_graph(),
         "tables": topology.TABLE_DOCS,
-        "silver_tables": await poller.clickhouse.silver_schema(),
+        "silver_graph": await poller.clickhouse.silver_graph(),
         "silver_views": ClickHouse.SILVER_VIEW_DOCS,
         "empty_by_contract": topology.EMPTY_BY_CONTRACT,
         "derived": topology.DERIVED,

--- a/services/flow-ui/src/flow_ui/main.py
+++ b/services/flow-ui/src/flow_ui/main.py
@@ -31,7 +31,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from flow_ui import topology
-from flow_ui.clickhouse import EMPTY_BY_CONTRACT
+from flow_ui.clickhouse import EMPTY_BY_CONTRACT, ClickHouse
 from flow_ui.config import settings
 from flow_ui.pipeline import Poller
 
@@ -145,13 +145,20 @@ def snapshot() -> dict:
 
 
 @app.get("/api/graph")
-def graph() -> dict:
+async def graph() -> dict:
     """The static half of the picture: the producer's declared topology and what each
-    bronze table holds. Cheap and unchanging, so the page fetches it once at load and the
-    SSE stream carries only the numbers that move."""
+    bronze and silver table holds. Cheap and unchanging, so the page fetches it once at load
+    and the SSE stream carries only the numbers that move.
+
+    Silver's schema belongs here and not in the snapshot for the same reason the bronze
+    datasheets do: three models of seventeen columns each would be ~3 KB repeated on every
+    frame, once a second, to say what it said the tick before.
+    """
     return {
         "topology": topology.service_graph(),
         "tables": topology.TABLE_DOCS,
+        "silver_tables": await poller.clickhouse.silver_schema(),
+        "silver_views": ClickHouse.SILVER_VIEW_DOCS,
         "empty_by_contract": topology.EMPTY_BY_CONTRACT,
         "derived": topology.DERIVED,
         "contract": topology.CONTRACT,

--- a/services/flow-ui/src/flow_ui/pipeline.py
+++ b/services/flow-ui/src/flow_ui/pipeline.py
@@ -301,6 +301,11 @@ class Poller:
         #: querying an httpx client that had already been closed.
         self._slow: list[asyncio.Task] = []
 
+    @property
+    def clickhouse(self) -> ClickHouse:
+        """The client, for the one route that reads schema rather than a snapshot."""
+        return self._ch
+
     async def start(self) -> None:
         self._task = asyncio.create_task(self._run())
 

--- a/services/flow-ui/src/flow_ui/pipeline.py
+++ b/services/flow-ui/src/flow_ui/pipeline.py
@@ -206,6 +206,12 @@ class Snapshot:
     metrics_by_service: dict = field(default_factory=dict)
     scenario: str = "—"
 
+    #: What Silver holds — `{present, models, views, mvs}`. `present` is load-bearing: a
+    #: volume created before the Silver DDL has no `silver` database, and an absent Silver is
+    #: a different statement from an empty one. Empty is normal on a fresh stack, because the
+    #: MVs do not `POPULATE` and only see inserts made after the DDL was applied.
+    silver: dict = field(default_factory=dict)
+
     #: Per-producer latency and error rate, read from `silver.service_health_1m`. The first
     #: thing this service reads out of Silver rather than deriving from Bronze — and an
     #: addition, not a migration: Silver's MVs do not `POPULATE`, so it only knows what
@@ -445,6 +451,7 @@ class Poller:
         snap.volume = self.latest.volume
         snap.call_edges = self.latest.call_edges
         snap.service_health = self.latest.service_health
+        snap.silver = self.latest.silver
         self.latest = snap
         self.broadcaster.publish(snap)
 
@@ -488,12 +495,14 @@ class Poller:
                 band = await self._ch.volume_band(self._s.volume_window_min)
                 edges = await self._ch.call_edges()
                 health = await self._ch.service_health()
+                silver = await self._ch.silver_state()
                 self.latest.lineage = lineage
                 self.latest.scenario = scenario
                 self.latest.metrics_by_service = inventory
                 self.latest.volume = [volume_state(r) for r in band]
                 self.latest.call_edges = edges
                 self.latest.service_health = health
+                self.latest.silver = silver
             except Exception as exc:                      # noqa: BLE001 — never kill the loop
                 log.debug("lineage refresh failed: %s", exc)
             await asyncio.sleep(self._s.lineage_interval_s)

--- a/services/flow-ui/src/flow_ui/pipeline.py
+++ b/services/flow-ui/src/flow_ui/pipeline.py
@@ -206,6 +206,12 @@ class Snapshot:
     metrics_by_service: dict = field(default_factory=dict)
     scenario: str = "—"
 
+    #: Per-producer latency and error rate, read from `silver.service_health_1m`. The first
+    #: thing this service reads out of Silver rather than deriving from Bronze — and an
+    #: addition, not a migration: Silver's MVs do not `POPULATE`, so it only knows what
+    #: arrived after its DDL was applied. Empty when Silver is not deployed.
+    service_health: list[dict] = field(default_factory=list)
+
     #: The call graph as traced: `{src, dst, spans, errors}`. The only per-edge measurement
     #: in the pipeline — it exists because a child span carries its parent, so the two rows
     #: join and the two `ServiceName`s are the edge. Compared against the *declared* topology
@@ -438,6 +444,7 @@ class Poller:
         snap.contract_violations = self.latest.contract_violations
         snap.volume = self.latest.volume
         snap.call_edges = self.latest.call_edges
+        snap.service_health = self.latest.service_health
         self.latest = snap
         self.broadcaster.publish(snap)
 
@@ -480,11 +487,13 @@ class Poller:
                 inventory = await self._ch.metric_inventory()
                 band = await self._ch.volume_band(self._s.volume_window_min)
                 edges = await self._ch.call_edges()
+                health = await self._ch.service_health()
                 self.latest.lineage = lineage
                 self.latest.scenario = scenario
                 self.latest.metrics_by_service = inventory
                 self.latest.volume = [volume_state(r) for r in band]
                 self.latest.call_edges = edges
+                self.latest.service_health = health
             except Exception as exc:                      # noqa: BLE001 — never kill the loop
                 log.debug("lineage refresh failed: %s", exc)
             await asyncio.sleep(self._s.lineage_interval_s)

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -298,7 +298,6 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
    as the presentation-attribute-vs-stylesheet one the pipes hit: equal specificity is decided
    by position, and position is easy to change by accident. */
 .sub-nd.sel{stroke:var(--sec);stroke-width:1.6}
-.derive.tip{opacity:1}
 
 /* A mouth is a LIP, and a lip is pipe-shaped: a short section perpendicular to the run,
    wider than the casing it caps. It was a circle, which read as a bead threaded onto the

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -240,9 +240,22 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
 .lin.e1{stroke:var(--pri)} .lin.e2{stroke:var(--ter)} .lin.e3{stroke:var(--sec)}
 /* Kind is carried by the left edge of the box, so it survives the colour-blind test the
    particle palette is already held to: three kinds, three border weights, one label each. */
-.sub-nd.k-mv{stroke-dasharray:4 3}
-.sub-nd.k-view{stroke-dasharray:1 3}
-.sub-nd.k-table{stroke-dasharray:none}
+/* Kind on TWO channels, and neither of them is hue.
+   Hue is spoken for: --pri, --sec and --ter mean logs, traces and metrics everywhere on this
+   canvas, and a box borrowing one would make the same channel say two things. The GROUND is
+   free, and there the difference is literal rather than a code to memorise:
+
+     table  filled and raised   — it holds something
+     mv     hollow              — an insert trigger holds nothing; rows pass through it
+     view   sunk                — a window onto the rows below, computed when looked through
+
+   Border style is the redundant second channel, so the distinction survives a colour-blind
+   reader and a greyscale print, per this repo's own rule against colour-only encoding. The
+   strokes stay inside the structural family (--dim2 / --viaS / --rule-arrow), which is
+   defined per palette, so both worlds keep their own version of it. */
+.sub-nd.k-table{fill:var(--raise);stroke:var(--dim2);stroke-dasharray:none}
+.sub-nd.k-mv{fill:none;stroke:var(--viaS);stroke-dasharray:4 3}
+.sub-nd.k-view{fill:var(--sunk);stroke:var(--rule-arrow);stroke-dasharray:1 3}
 .derive.tip{opacity:1}
 
 /* A mouth is a LIP, and a lip is pipe-shaped: a short section perpendicular to the run,

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -276,10 +276,14 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
    Body text stays above 10:1 on all three, and the sub-labels above 3:1, in both worlds. */
 /* The key. Never a target — no cursor, no hover, no hit area — and dimmed until the
    selection makes one of the three relevant. */
-.key{pointer-events:none;opacity:.62;transition:opacity .16s}
+.key{pointer-events:none;opacity:.5;transition:opacity .16s}
 .key.on{opacity:1}
-.key.on .sw{stroke-width:1.6}
-.key.on .sub{fill:var(--txt)}
+/* --sec, because that is already what selection means everywhere else on this board
+   (`.nd.sel`, the hover border, the OPEN/CLOSE cue). The first version only nudged
+   stroke-width and text fill, which passed a test asserting the class was applied and was
+   still invisible to the person looking at it — the class being right is not the question. */
+.key.on .sw{stroke:var(--sec);stroke-width:2}
+.key.on .sub{fill:var(--sec)}
 .sw{stroke-width:1}
 .sub-nd.k-table{fill:var(--k-table);stroke:var(--dim2);stroke-dasharray:none}
 .sub-nd.k-mv{fill:var(--k-mv);stroke:var(--dim);stroke-dasharray:4 3}

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -242,6 +242,10 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
    asks, so it gets no casing, no bore and no particles — only the colour of the table it
    reads, so lineage is still followable. Dashed says "on demand". */
 .lin{fill:none;stroke-width:1.4;opacity:.5;stroke-dasharray:3 3}
+/* A motion track: geometry for `animateMotion` to follow, never drawn. The collapsed
+   BRONZE ⇒ SILVER bar is two rails with nothing between them, and the dots run down the
+   middle — so the path they follow has to exist without being a third rail. */
+.track{fill:none;stroke:none}
 /* Its own tone classes, NOT the particle ones: `.p1{fill:var(--pri)}` is a FILL rule, and
    a path wearing it renders as a filled triangle rather than a line — ten read edges came
    out as one solid smear. */

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -230,6 +230,18 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
    on the same insert. A double bar says "what this becomes", a pipe would say "where this
    goes", and only one of those is true. No mouths, no particles, on purpose. */
 .derive{fill:none;stroke:var(--rule-arrow);stroke-width:1.6;opacity:.75}
+/* A READ dependency, not a run. A view is a query: nothing travels this edge until someone
+   asks, so it gets no casing, no bore and no particles — only the colour of the table it
+   reads, so lineage is still followable. Dashed says "on demand". */
+.lin{fill:none;stroke-width:1.4;opacity:.5;stroke-dasharray:3 3}
+/* Its own tone classes, NOT the particle ones: `.p1{fill:var(--pri)}` is a FILL rule, and
+   a path wearing it renders as a filled triangle rather than a line — ten read edges came
+   out as one solid smear. */
+.lin.e1{stroke:var(--pri)} .lin.e2{stroke:var(--ter)} .lin.e3{stroke:var(--sec)}
+/* Kind is carried by the left edge of the box, so it survives the colour-blind test the
+   particle palette is already held to: three kinds, three border weights, one label each. */
+.sub-nd.k-mv{stroke-dasharray:4 3}
+.sub-nd.k-view{stroke-dasharray:1 3}
 .derive.tip{opacity:1}
 
 /* A mouth is a LIP, and a lip is pipe-shaped: a short section perpendicular to the run,

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -225,6 +225,13 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
 /* Same 1.5px wall. Only the bore grows, because only the payload did. */
 .pw.trunk{stroke-width:24}
 .pb.trunk{stroke-width:21}
+/* BRONZE ⇒ SILVER is a DERIVATION, not a run. Everything else on the canvas transports
+   something along a bore; this moves nothing — the materialized views fire inside ClickHouse
+   on the same insert. A double bar says "what this becomes", a pipe would say "where this
+   goes", and only one of those is true. No mouths, no particles, on purpose. */
+.derive{fill:none;stroke:var(--rule-arrow);stroke-width:1.6;opacity:.75}
+.derive.tip{opacity:1}
+
 /* A mouth is a LIP, and a lip is pipe-shaped: a short section perpendicular to the run,
    wider than the casing it caps. It was a circle, which read as a bead threaded onto the
    line — the one shape that says "not a pipe". Sized to the casing at each site, so the

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -24,15 +24,23 @@
   --rule-arrow:#4E6B39;
   --grid:rgba(127,224,74,.045); --scan:rgba(127,224,74,.03);
   --knob:#7FE04A;
+  /* Ground per object kind. A filled area is a far stronger channel than a 1px border, so
+     this is where the distinction lives; the border style is the redundant second reading. */
+  --k-table:#1B2614; --k-mv:#0E1309; --k-view:#050703;
 }
 :root[data-world="substrate"]{
   --bg:#04060B; --panel:#070B12; --raise:#091019; --sunk:#03050A;
   --pri:#22D3EE; --sec:#FFC53D; --ter:#DCE9F5; --alarm:#FF5C7A;
-  --txt:#C3D6E6; --dim:#3D5A72; --dim2:#6C8AA6;
+  /* --dim was #3D5A72 and put every small label under 3:1 — 2.8 on the panel, 2.09 on the
+     new lit table ground. `.sub` is not decoration here: it carries "on insert", "stored",
+     "per minute", the volume band's reason and each producer's declared latency. Raised
+     until the worst case on this board clears 3:1. Command's --dim was already above it. */
+  --txt:#C3D6E6; --dim:#57748F; --dim2:#6C8AA6;
   --rule:#153446; --rule2:#0E2230; --via:#0B1B26; --viaS:#1E5468;
   --rule-arrow:#2E6E88;
   --grid:rgba(34,211,238,.05); --scan:rgba(34,211,238,.014);
   --knob:#22D3EE;
+  --k-table:#12283A; --k-mv:#0A121C; --k-view:#020407;
 }
 /* The two reachability LEDs are a semaphore, and a semaphore is not part of a palette.
    Green means reachable and red means not, in BOTH worlds — that convention is older and
@@ -253,9 +261,22 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
    reader and a greyscale print, per this repo's own rule against colour-only encoding. The
    strokes stay inside the structural family (--dim2 / --viaS / --rule-arrow), which is
    defined per palette, so both worlds keep their own version of it. */
-.sub-nd.k-table{fill:var(--raise);stroke:var(--dim2);stroke-dasharray:none}
-.sub-nd.k-mv{fill:none;stroke:var(--viaS);stroke-dasharray:4 3}
-.sub-nd.k-view{fill:var(--sunk);stroke:var(--rule-arrow);stroke-dasharray:1 3}
+/* Kind on the GROUND first, border style second — and hue is still not the channel, because
+   --pri/--sec/--ter mean logs, traces and metrics on every edge and particle here.
+
+   The first attempt put kind on --raise / transparent / --sunk and measured 1.03:1 between
+   adjacent grounds: three names for one colour. A filled area beats a 1px stroke as a signal,
+   so the grounds are now stepped far enough apart to actually read, brightest to darkest in
+   the order of how much each thing holds:
+
+     table  lit    — the rows are in here
+     mv     dim    — an insert trigger; rows pass through and it keeps none
+     view   near   — a query, nothing to light up until someone runs it
+
+   Body text stays above 10:1 on all three, and the sub-labels above 3:1, in both worlds. */
+.sub-nd.k-table{fill:var(--k-table);stroke:var(--dim2);stroke-dasharray:none}
+.sub-nd.k-mv{fill:var(--k-mv);stroke:var(--dim);stroke-dasharray:4 3}
+.sub-nd.k-view{fill:var(--k-view);stroke:var(--rule-arrow);stroke-dasharray:1 3}
 .derive.tip{opacity:1}
 
 /* A mouth is a LIP, and a lip is pipe-shaped: a short section perpendicular to the run,

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -242,6 +242,7 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
    particle palette is already held to: three kinds, three border weights, one label each. */
 .sub-nd.k-mv{stroke-dasharray:4 3}
 .sub-nd.k-view{stroke-dasharray:1 3}
+.sub-nd.k-table{stroke-dasharray:none}
 .derive.tip{opacity:1}
 
 /* A mouth is a LIP, and a lip is pipe-shaped: a short section perpendicular to the run,

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -274,6 +274,13 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
      view   near   — a query, nothing to light up until someone runs it
 
    Body text stays above 10:1 on all three, and the sub-labels above 3:1, in both worlds. */
+/* The key. Never a target — no cursor, no hover, no hit area — and dimmed until the
+   selection makes one of the three relevant. */
+.key{pointer-events:none;opacity:.62;transition:opacity .16s}
+.key.on{opacity:1}
+.key.on .sw{stroke-width:1.6}
+.key.on .sub{fill:var(--txt)}
+.sw{stroke-width:1}
 .sub-nd.k-table{fill:var(--k-table);stroke:var(--dim2);stroke-dasharray:none}
 .sub-nd.k-mv{fill:var(--k-mv);stroke:var(--dim);stroke-dasharray:4 3}
 .sub-nd.k-view{fill:var(--k-view);stroke:var(--rule-arrow);stroke-dasharray:1 3}

--- a/services/flow-ui/src/flow_ui/static/app.css
+++ b/services/flow-ui/src/flow_ui/static/app.css
@@ -288,6 +288,12 @@ main[role="tabpanel"]:not([hidden]){flex:1;display:flex;flex-direction:column;mi
 .sub-nd.k-table{fill:var(--k-table);stroke:var(--dim2);stroke-dasharray:none}
 .sub-nd.k-mv{fill:var(--k-mv);stroke:var(--dim);stroke-dasharray:4 3}
 .sub-nd.k-view{fill:var(--k-view);stroke:var(--rule-arrow);stroke-dasharray:1 3}
+/* Selection has to come AFTER the kind rules, not before. `.nd.sel` and `.sub-nd.k-mv` are
+   both two classes, so the cascade falls back to source order — and adding the kind strokes
+   below `.nd.sel` silently took the selected border away from every silver node. Same trap
+   as the presentation-attribute-vs-stylesheet one the pipes hit: equal specificity is decided
+   by position, and position is easy to change by accident. */
+.sub-nd.sel{stroke:var(--sec);stroke-width:1.6}
 .derive.tip{opacity:1}
 
 /* A mouth is a LIP, and a lip is pipe-shaped: a short section perpendicular to the run,

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -57,6 +57,7 @@
   const view = { k: 1, x: 0, y: 0 };   // viewport transform
   let root = null;                      // the <g> everything pans inside
   let vias = null;                      // the layer mouths are drawn into
+  let sheets = null;                    // the datasheets, redrawn without a full render
 
   /* ── helpers ───────────────────────────────────────────────── */
   const fmt = (n) => {
@@ -1296,8 +1297,9 @@
          silver: silverBody }[id])(g, b, edges, fx);
     }
     derivations(edges, fx, B);
-    if (L.sheet) datasheet(nodes, L.sheet);
-    if (L.mSheet) modelsheet(nodes, L.mSheet);
+    sheets = el("g", { class: "sheets" });
+    nodes.append(sheets);
+    drawSheets();
     nodesLater.forEach((n) => nodes.append(n));
     // The burst only means something when a batch is actually arriving.
     show("burst", 0);
@@ -1317,14 +1319,14 @@
       n.addEventListener("click", (e) => {
         e.stopPropagation();
         table = table === n.dataset.table ? null : n.dataset.table;
-        repaint();
+        reselect();
       });
     });
     stage.querySelectorAll("[data-model]").forEach((n) => {
       n.addEventListener("click", (e) => {
         e.stopPropagation();
         model = model === n.dataset.model ? null : n.dataset.model;
-        repaint();
+        reselect();
       });
     });
     stage.querySelectorAll("[data-service]").forEach((n) => {
@@ -1929,6 +1931,27 @@
     // means a still strand, not a strand animating over nothing.
     derives().forEach(([from], i) =>
       show(`dv${i}`, ((s.bronze_rate || {})[from] || 0) > 0 ? 2 : 0));
+    // An MV writing its target is the one real movement inside SILVER, and its pool was
+    // being created and never shown — `spawn` fills `pools`, but nothing here revealed them,
+    // so the run existed with every dot at opacity 0. The gate is the growth of the bronze
+    // table the chain started from, resolved through the graph so a second-stage MV reading
+    // a silver table still finds its root rather than guessing.
+    const SG = graph?.silver_graph || {};
+    const rootRate = (name, seen = new Set()) => {
+      if (seen.has(name)) return 0;
+      seen.add(name);
+      for (const src of (SG[name]?.sources || [])) {
+        const [db, tbl] = src.split(".");
+        if (db === "bronze") return (s.bronze_rate || {})[tbl] || 0;
+        // A silver source is written by whichever MV targets it.
+        const feeder = Object.keys(SG).find((k) => SG[k].target === tbl);
+        if (feeder) return rootRate(feeder, seen);
+      }
+      return 0;
+    };
+    Object.keys(SG).forEach((name) => {
+      if (SG[name].kind === "mv") show(`sv-${name}`, rootRate(name) > 0 ? 2 : 0);
+    });
     // Each tap runs only while its own outcome is happening. A pipeline losing nothing
     // should have three still lines, not three animations implying otherwise.
     //
@@ -1960,13 +1983,46 @@
     show("h-drop", (s.drop_rate || 0) > 0 ? 2 : 0);
   }
 
+  /** Redraw only what a selection changes: the two sheets and which rows read as picked.
+   *
+   *  Selecting a row changes no geometry — the sheets sit below their box and are narrower
+   *  than it, so no box moves — but it used to go through `repaint`, which rebuilds the
+   *  whole stage. Rebuilding recreates every `animateMotion`, and an `animateMotion` keeps
+   *  its progress on the node itself, so every dot on the board jumped back to the mouth of
+   *  its pipe on every click. That invariant is the reason this page has no framework; it
+   *  should not be broken by its own click handler.
+   */
+  function drawSheets() {
+    if (!sheets) return;
+    sheets.replaceChildren();
+    const L = layout();
+    if (L.sheet) datasheet(sheets, L.sheet);
+    if (L.mSheet) modelsheet(sheets, L.mSheet);
+  }
+
+  function reselect() {
+    if (!sheets) return repaint();
+    drawSheets();
+    const stage = $("stage");
+    stage.querySelectorAll("[data-table]").forEach((n) =>
+      n.querySelector("rect")?.classList.toggle("sel", n.dataset.table === table));
+    stage.querySelectorAll("[data-model]").forEach((n) =>
+      n.querySelector("rect")?.classList.toggle("sel", n.dataset.model === model));
+    // The key follows the selection, so it has to be updated with it.
+    const kind = (graph?.silver_graph || {})[model]?.kind;
+    stage.querySelectorAll(".key").forEach((k) =>
+      k.classList.toggle("on",
+        !!kind && k.querySelector(".sw")?.classList.contains("k-" + kind)));
+    fit();
+  }
+
   /* ── structural repaint ────────────────────────────────────── */
   function repaint() {
     // Every box that can expand belongs in this key. Leaving one out does not fail loudly:
     // the click flips `open[id]`, the key does not change, repaint returns early and the box
     // simply never opens. `silver` was missing and the bug looked like a dead click.
     const key = [snap?.mode || "", graph ? 1 : 0, open.origin, open.collector, open.bronze,
-                 open.silver, table, model, service].join("|");
+                 open.silver, service].join("|");
     if (key === painted) return false;
     const first = painted === "";
     painted = key;

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -58,6 +58,9 @@
   let root = null;                      // the <g> everything pans inside
   let vias = null;                      // the layer mouths are drawn into
   let sheets = null;                    // the datasheets, redrawn without a full render
+  //: [pathId, silverTableItReads] for each read edge, so the tick can gate each one on the
+  //: growth of the table behind it rather than on the estate.
+  let readEdges = [];
 
   /* ── helpers ───────────────────────────────────────────────── */
   const fmt = (n) => {
@@ -874,8 +877,13 @@
           spawn(fx, id, cls);
         } else {
           // `p1..p3` are particle FILL classes; an edge wearing one renders filled.
-          edges.append(el("path", { class: "lin " + cls.replace("p", "e"),
+          const rid = `rd${lane}`;
+          edges.append(el("path", { id: rid, class: "lin " + cls.replace("p", "e"),
             d: fan(from.x + SB.w, from.cy, n.x, n.cy, 10 + (lane++ % 10) * 6) }));
+          // Smaller and slower than a pipe's dots, because the claim is different: a view
+          // is read, not fed. The weight carries what the dashed line already says.
+          spawn(fx, rid, cls, 2, 1.9);
+          readEdges.push([rid, up]);
         }
       }
     }
@@ -914,12 +922,12 @@
   };
 
   //: Particles for one strand, on the batch arrival that feeds it.
-  function spawn(fx, id, cls, r = 2.6) {
+  function spawn(fx, id, cls, r = 2.6, slow = 1) {
     const { dur, n } = pools.__batch || { dur: 3.2, n: 3 };
     const pool = [];
     for (let k = 0; k < n; k++) {
       const c = el("circle", { class: cls, r, opacity: 0 });
-      const a = el("animateMotion", { dur: `${(dur * 0.55).toFixed(2)}s`,
+      const a = el("animateMotion", { dur: `${(dur * 0.55 * slow).toFixed(2)}s`,
         repeatCount: "indefinite", begin: `${(k * dur / n + dur).toFixed(2)}s` });
       a.append(el("mpath", { href: `#${id}` }));
       c.append(a); fx.append(c); pool.push(c);
@@ -1183,6 +1191,7 @@
     const stage = $("stage");
     pools = {};
     ports = { bronze: {}, silver: {} };
+    readEdges = [];
     const L = layout(), B = L.boxes;
     const svg = el("svg", { viewBox: `0 0 ${VW} ${VH}`, preserveAspectRatio: "xMidYMid meet" });
     const defs = el("defs");
@@ -1241,6 +1250,12 @@
       // claim about what travels — so it does not undo this bar carrying nothing.
       mouth(x1, my, dy * 2 + 4);
       mouth(x2, my, dy * 2 + 4);
+      // Dots down the middle of the bar. The rails stay a derivation mark — no casing, no
+      // bore — but rows really do move on that insert, and a still bar between two boxes
+      // whose counts are both climbing says the opposite.
+      edges.append(el("path", { id: "derive-track", class: "track",
+        d: `M${x1} ${my} L${x2} ${my}` }));
+      spawn(fx, "derive-track", "p3", 3);
       nodesLater.push(el("text", { class: "sub", x: (x1 + x2) / 2, y: my - 12,
         style: "text-anchor:middle" }, "derived"),
         el("text", { class: "sub", x: (x1 + x2) / 2, y: my + 20,
@@ -1306,7 +1321,10 @@
 
     stage.replaceChildren(svg);
     stage.querySelectorAll("[data-node]").forEach((n) => {
-      n.addEventListener("click", () => { open[n.dataset.node] = !open[n.dataset.node]; repaint(); });
+      n.addEventListener("click", () => {
+        open[n.dataset.node] = !open[n.dataset.node];
+        repaintNow();
+      });
       n.addEventListener("keydown", (e) => {
         if (e.key === "Enter" || e.key === " ") { e.preventDefault(); n.click(); }
       });
@@ -1333,7 +1351,7 @@
       const pick = (e) => {
         e.stopPropagation();
         service = service === n.dataset.service ? null : n.dataset.service;
-        repaint();
+        repaintNow();
       };
       n.addEventListener("click", pick);
       n.addEventListener("keydown", (e) => {
@@ -1467,7 +1485,7 @@
     $("z-home").addEventListener("click", () => {
       open.origin = open.collector = open.bronze = open.silver = false;
       table = model = service = null;
-      repaint();
+      repaintNow();
       fit();
     });
   }
@@ -1952,6 +1970,16 @@
     Object.keys(SG).forEach((name) => {
       if (SG[name].kind === "mv") show(`sv-${name}`, rootRate(name) > 0 ? 2 : 0);
     });
+    // The collapsed bar runs on the estate: it stands for all four derivations at once.
+    show("derive-track", sum2(s.bronze_rate) > 0 ? 3 : 0);
+    // A read edge runs on the growth of the table being READ — a view over a silent table
+    // has nothing new to answer with. A silver table grows at the rate of whatever MV
+    // writes it, which resolves back to a bronze table through the same walk.
+    const tableRate = (tbl) => {
+      const feeder = Object.keys(SG).find((k) => SG[k].target === tbl);
+      return feeder ? rootRate(feeder) : 0;
+    };
+    readEdges.forEach(([id, src]) => show(id, tableRate(src) > 0 ? 2 : 0));
     // Each tap runs only while its own outcome is happening. A pipeline losing nothing
     // should have three still lines, not three animations implying otherwise.
     //
@@ -2017,6 +2045,16 @@
   }
 
   /* ── structural repaint ────────────────────────────────────── */
+  /** Repaint and immediately re-apply the current density.
+   *
+   *  Anything that rebuilds the stage outside the tick has to do both: `render` creates
+   *  every dot at opacity 0, so a repaint on its own hands back an empty board that stays
+   *  empty until the next frame arrives.
+   */
+  function repaintNow() {
+    if (repaint() && snap) density(snap);
+  }
+
   function repaint() {
     // Every box that can expand belongs in this key. Leaving one out does not fail loudly:
     // the click flips `open[id]`, the key does not change, repaint returns early and the box
@@ -2056,7 +2094,11 @@
     // A board only draws when it is on screen. Neither has animation to preserve, but
     // rebuilding a chart nobody is looking at, once a second, is work for nothing.
     drawBoards();
-    if (repaint()) return;          // structural only; throughput never rebuilds
+    // `density` runs whether or not the stage was rebuilt. It used to be skipped on a
+    // structural repaint — `if (repaint()) return` — and `render` creates every dot at
+    // opacity 0, so opening a box left the whole board blank until the NEXT tick a second
+    // later, then filled it again all at once. That reads as every particle restarting.
+    repaint();
     density(s);
   }
   const sum2 = (o) => Object.values(o || {}).reduce((a, b) => a + b, 0);
@@ -2103,7 +2145,7 @@
     ceiling = h.ceiling_ms || ceiling;
     drawBoards();
   }).catch(() => {});
-  fetch("/api/graph").then((r) => r.json()).then((g) => { graph = g; painted = ""; repaint(); fit(); })
+  fetch("/api/graph").then((r) => r.json()).then((g) => { graph = g; painted = ""; repaintNow(); fit(); })
     .catch(() => {});
   const es = new EventSource("/stream");
   es.onmessage = (e) => { try { apply(JSON.parse(e.data)); } catch (_) { /* bad frame */ } };

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -38,10 +38,10 @@
     origin:    { closed: [212, 196], open: [742, 248], openSel: [742, 386] },
     collector: { closed: [252, 152], open: [500, 344] },
     bronze:    { closed: [176, 136], open: [318, 252] },
-    silver:    { closed: [186, 136], open: [268, 252] },
+    silver:    { closed: [186, 136], open: [330, 392] },
   };
 
-  let graph = null, snap = null, table = "otel_logs";
+  let graph = null, snap = null, table = "otel_logs", model = null;
   //: A selected service filters what the graph reports about bronze. It cannot filter the
   //: live rates: `sentinel_signals_ingested_total` carries a `signal` label and no service
   //: label, so per-service throughput simply does not exist upstream of ClickHouse. The
@@ -228,11 +228,17 @@
     const sheet = open.bronze
       ? { x: boxes.bronze.x, y: boxes.bronze.y + boxes.bronze.h + 30, w: SHEET_W, h: 236 }
       : null;
+    // SILVER's sheet sits under SILVER for the same reason, and only when a model is picked:
+    // bronze always has a selected table, silver starts with none.
+    const mSheet = open.silver && model
+      ? { x: boxes.silver.x, y: boxes.silver.y + boxes.silver.h + 30, w: SHEET_W, h: 236 }
+      : null;
     // Not a box, so it was absent from these bounds and `fit()` scaled to an extent that
     // excluded it — the sheet ran off the canvas whenever bronze was open.
-    const x1 = Math.max(x - GAP, sheet ? sheet.x + sheet.w : 0);
-    return { boxes, sheet, x0: 40, y0,
-             width: x1 - 40, height: Math.max(y1, sheet ? sheet.y + sheet.h : 0) - y0 };
+    const btm = [sheet, mSheet].filter(Boolean);
+    const x1 = Math.max(x - GAP, ...btm.map((z) => z.x + z.w));
+    return { boxes, sheet, mSheet, x0: 40, y0, width: x1 - 40,
+             height: Math.max(y1, ...btm.map((z) => z.y + z.h)) - y0 };
   }
 
   /* ── particle pools ────────────────────────────────────────── */
@@ -756,7 +762,7 @@
     const rank = (n) => { const i = DERIVES.findIndex(([, to]) => to === n);
                           return i < 0 ? DERIVES.length : i; };
     const names = Object.keys(models).sort((a, z) => rank(a) - rank(z) || a.localeCompare(z));
-    const TW = 218, TH = 34;
+    const TW = b.w - 52, TH = 34;
     names.forEach((n, i) => {
       const y = b.y + 46 + i * (TH + 6), x = b.x + 26;
       // A `.hit` group, like BRONZE's tables: the rows are the thing the pointer is for, so
@@ -764,7 +770,9 @@
       // bronze box whose every row lit up.
       const node = el("g", { class: "hit", tabindex: "0", role: "button",
         "aria-label": `${n}, ${fmt(models[n])} rows, derived from ${FEEDS[n] || "bronze"}` });
-      node.append(el("rect", { class: "nd sub-nd", x, y, width: TW, height: TH, rx: 3 }),
+      node.dataset.model = n;
+      node.append(el("rect", { class: "nd sub-nd" + (n === model ? " sel" : ""), x, y,
+          width: TW, height: TH, rx: 3 }),
         el("text", { class: "txt", x: x + 10, y: y + 15 }, clip(n, 24)),
         el("text", { class: "val", x: x + TW - 10, y: y + 15 }, fmt(models[n])),
         el("text", { class: "sub", x: x + 10, y: y + 28 },
@@ -772,18 +780,32 @@
       g.append(node);
       ports.silver[n] = { x, y: y + TH / 2 };
     });
-    const vy = b.y + 46 + names.length * (TH + 6) + 10;
-    g.append(el("text", { class: "lbl", x: b.x + 26, y: vy }, "READ VIEWS"));
-    (sv.views || []).forEach((v, i) => g.append(
-      el("text", { class: "sub", x: b.x + 26 + (i % 2) * 118, y: vy + 15 + Math.floor(i / 2) * 12,
-        // The one flow-ui actually consumes today, so the panel does not imply it uses six.
-        style: v === "service_health_1m" ? "fill:var(--sec)" : null },
-        (v === "service_health_1m" ? "▸ " : "· ") + clip(v, 17))));
+    // READ VIEWS, one per line with what each one answers. Two columns of bare names fit,
+    // and six names with no explanation is a list, not information — a reader cannot tell a
+    // view from a table, or guess that `run_summary` is one row per run.
+    // Name and answer on two lines, not one. Side by side they collided: a 22-character
+    // name and a 43-character answer need 455 units and the box has 278 of usable width, so
+    // the two runs of text overlapped each other and the panel was unreadable.
+    const vd = graph?.silver_views || {};
+    const vy = b.y + 46 + names.length * (TH + 6) + 14;
+    g.append(el("text", { class: "lbl", x: b.x + 26, y: vy }, "READ VIEWS"),
+      el("text", { class: "sub", x: b.x + 26, y: vy + 15 },
+        "stored nowhere — a query over the models above"));
+    (sv.views || []).forEach((v, i) => {
+      const vyy = vy + 37 + i * 25, read = v === "service_health_1m";
+      const [grain, what] = vd[v] || ["", ""];
+      g.append(el("text", { class: "sub", x: b.x + 26, y: vyy,
+          // The one flow-ui actually consumes today, so the panel does not imply it reads six.
+          style: read ? "fill:var(--sec)" : null },
+        (read ? "▸ " : "· ") + clip(v, 26)),
+        el("text", { class: "sub", x: b.x + 38, y: vyy + 12, style: "opacity:.6" },
+          grain ? `${grain} · ${clip(what, 41)}` : ""));
+    });
     // Marking one item in a second colour is a claim, and an unexplained claim is a puzzle.
     // The legend rebuilds per level and this mark only exists here, so it is said here.
     g.append(el("text", { class: "sub", x: b.x + 26,
-      y: vy + 15 + Math.ceil((sv.views || []).length / 2) * 12 + 6,
-      style: "fill:var(--sec)" }, "\u25b8 read by this board"));
+      y: vy + 37 + (sv.views || []).length * 25 + 4,
+      style: "fill:var(--sec)" }, "▸ the only one this board reads"));
   }
 
   /** BRONZE ⇒ SILVER, per table, once both boxes are open.
@@ -899,6 +921,47 @@
     parent.append(el("text", { class: "sub", x: x + 16, y: y + h - 12 },
       `TTL ${d.ttl} · ${d.section}`));
   }
+
+  /** The datasheet for a SILVER model — same shape as bronze's, different provenance.
+   *
+   *  Bronze's is hand-written in `topology.TABLE_DOCS` because the read contract makes a
+   *  *subset* claim: only some columns are populated, the rest sit at their ClickHouse
+   *  default by design (§2), and no DDL can express that. Silver makes no such claim — the
+   *  DDL is the whole definition — so its columns are read live from `system.columns` and
+   *  cannot drift from the deployed schema. Only the one-line summary is written by hand,
+   *  because a type is metadata and a purpose is a claim.
+   */
+  function modelsheet(parent, sheet) {
+    const d = (graph?.silver_tables || {})[model];
+    if (!d || !sheet) return;
+    const { x, y, w, h } = sheet;
+    parent.append(el("rect", { class: "nd sheet", x, y, width: w, height: h, rx: 4 }),
+      el("text", { class: "lbl", x: x + 16, y: y + 24, style: "fill:var(--sec)" },
+        model.toUpperCase()));
+    (d.summary.match(/.{1,48}(\s|$)/g) || []).slice(0, 2).forEach((line, i) =>
+      parent.append(el("text", { class: "sub", x: x + 16, y: y + 42 + i * 13 }, line.trim())));
+    // Two columns: 16 to 19 columns will not fit one, and truncating the list would hide
+    // exactly the normalized fields that are the reason this layer exists.
+    const cols = d.columns || [], half = Math.ceil(cols.length / 2);
+    cols.forEach(([name, type], i) => {
+      const cx = x + 16 + (i < half ? 0 : w / 2 - 8);
+      const cy = y + 78 + (i % half) * 13;
+      parent.append(el("text", { class: "sub", x: cx, y: cy }, clip(name, 20)),
+        el("text", { class: "sub", x: cx + w / 2 - 24, y: cy,
+          style: "text-anchor:end;opacity:.55" }, clip(shortType(type), 13)));
+    });
+    parent.append(el("text", { class: "sub", x: x + 16, y: y + h - 12 },
+      `ORDER BY ${clip(d.order_by, 56)}`));
+  }
+
+  //: ClickHouse spells types in full; the sheet has 13 characters. The distinction that
+  //: matters to a reader is the family, not the codec or the key type.
+  const shortType = (t) => t
+    .replace(/LowCardinality\((.*)\)/, "$1 (lc)")
+    .replace(/Map\(.*\)/, "Map")
+    .replace(/DateTime64\(\d+\)/, "DateTime64")
+    // Enum8('gauge' = 1, 'sum' = 2) is 30 characters of quoting to say "Enum8".
+    .replace(/Enum(\d+)\(.*\)/, "Enum$1");
 
   /* ── render ────────────────────────────────────────────────── */
   const TITLE = { origin: "ORIGIN", collector: "COLLECTOR-RUST", bronze: "BRONZE",
@@ -1019,6 +1082,7 @@
     }
     derivations(edges, fx, B);
     if (open.bronze) datasheet(nodes, L.sheet);
+    if (L.mSheet) modelsheet(nodes, L.mSheet);
     nodesLater.forEach((n) => nodes.append(n));
     // The burst only means something when a batch is actually arriving.
     show("burst", 0);
@@ -1032,6 +1096,16 @@
     });
     stage.querySelectorAll("[data-table]").forEach((n) => {
       n.addEventListener("click", (e) => { e.stopPropagation(); table = n.dataset.table; repaint(); });
+    });
+    // A silver model toggles, unlike a bronze table: bronze always has one selected and
+    // clicking the selected one again should not blank a sheet that has nowhere to fall
+    // back to. Silver starts with none, so closing the sheet is a state it can return to.
+    stage.querySelectorAll("[data-model]").forEach((n) => {
+      n.addEventListener("click", (e) => {
+        e.stopPropagation();
+        model = model === n.dataset.model ? null : n.dataset.model;
+        repaint();
+      });
     });
     stage.querySelectorAll("[data-service]").forEach((n) => {
       const pick = (e) => {
@@ -1673,7 +1747,7 @@
     // the click flips `open[id]`, the key does not change, repaint returns early and the box
     // simply never opens. `silver` was missing and the bug looked like a dead click.
     const key = [snap?.mode || "", graph ? 1 : 0, open.origin, open.collector, open.bronze,
-                 open.silver, table, service].join("|");
+                 open.silver, table, model, service].join("|");
     if (key === painted) return false;
     const first = painted === "";
     painted = key;

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -253,12 +253,37 @@
   }
 
   /* ── particle pools ────────────────────────────────────────── */
+  /** A deterministic scatter, keyed by the pool and the dot index.
+   *
+   *  Telemetry does not arrive on a metronome and the board should not draw one. Evenly
+   *  spaced departures read as 1-2-3, 1-2-3 — a rhythm the pipeline does not have — and
+   *  identical durations keep it forever, because every dot returns to its slot each cycle.
+   *
+   *  Seeded rather than `Math.random`, so a pool laid out twice lands the same way: a
+   *  structural repaint must not reshuffle a lane the reader is already watching, which is
+   *  the same reason `order` uses farthest-point insertion instead of a modular stride.
+   */
+  const jitter = (key, i) => {
+    let h = 2166136261;
+    const str = `${key}#${i}`;
+    for (let k = 0; k < str.length; k++) { h ^= str.charCodeAt(k); h = Math.imul(h, 16777619); }
+    return ((h >>> 0) % 10000) / 10000;                       // [0, 1)
+  };
+
+  //: How far a departure may slide inside its own slot, and how much two dots' speeds may
+  //: differ. The spread is what breaks the pattern; the drift is what stops it re-forming,
+  //: because dots at slightly different speeds never return to the same relative positions.
+  const SPREAD = 0.55, DRIFT = 0.14;
+
   const flow = (parent, pathId, key, cls, dur = 2.4, r = 3.2, n = MAX_DOTS) => {
     const pool = [];
     for (let i = 0; i < n; i++) {
+      const slot = dur / n;
+      const off = (jitter(key, i) - 0.5) * SPREAD * slot;
+      const own = dur * (1 + (jitter(key, i + 500) - 0.5) * DRIFT);
       const c = el("circle", { class: cls, r, opacity: 0 });
-      const a = el("animateMotion", { dur: `${dur}s`, repeatCount: "indefinite",
-        begin: `${((dur / n) * i).toFixed(2)}s` });
+      const a = el("animateMotion", { dur: `${own.toFixed(2)}s`, repeatCount: "indefinite",
+        begin: `${Math.max(0, slot * i + off).toFixed(2)}s` });
       a.append(el("mpath", { href: `#${pathId}` }));
       c.append(a); parent.append(c); pool.push(c);
     }
@@ -313,10 +338,15 @@
   const flow3 = (parent, pathId, keyBase, dur = 2.4, r = 3.2, n = 2) =>
     LANES.forEach(([name, cls], k) => {
       flow(parent, pathId, `${keyBase}-${name}`, cls, dur, r, n);
-      // stagger each colour by a third of a slot so they do not overlap exactly
+      // A third of a slot per colour was the other half of the metronome: three colours
+      // marching a fixed distance apart reads as 1-2-3 even once each colour is scattered.
+      // The colour's share of the slot is now scattered too, around that same third.
       (pools[`${keyBase}-${name}`] || []).forEach((c, i) => {
         const a = c.querySelector("animateMotion");
-        if (a) a.setAttribute("begin", `${((dur / n) * i + (dur / n / 3) * k).toFixed(2)}s`);
+        if (!a) return;
+        const slot = dur / n;
+        const lane = slot * (k / LANES.length + (jitter(`${keyBase}${name}`, i) - 0.5) * 0.5);
+        a.setAttribute("begin", `${Math.max(0, slot * i + lane).toFixed(2)}s`);
       });
     });
   /** A batch, drawn as what it contains. The buffer flushes ONE mixed batch — the
@@ -927,8 +957,11 @@
     const pool = [];
     for (let k = 0; k < n; k++) {
       const c = el("circle", { class: cls, r, opacity: 0 });
-      const a = el("animateMotion", { dur: `${(dur * 0.55 * slow).toFixed(2)}s`,
-        repeatCount: "indefinite", begin: `${(k * dur / n + dur).toFixed(2)}s` });
+      const own = dur * 0.55 * slow * (1 + (jitter(id, k + 500) - 0.5) * DRIFT);
+      const off = (jitter(id, k) - 0.5) * SPREAD * (dur / n);
+      const a = el("animateMotion", { dur: `${own.toFixed(2)}s`,
+        repeatCount: "indefinite",
+        begin: `${Math.max(0, k * dur / n + dur + off).toFixed(2)}s` });
       a.append(el("mpath", { href: `#${id}` }));
       c.append(a); fx.append(c); pool.push(c);
     }

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -387,8 +387,42 @@
     pools[key] = pool;
   };
 
-  const dots = (rate) => rate <= 0 ? 0
-    : Math.max(1, Math.min(MAX_DOTS, Math.round(Math.pow(rate / QUANTUM, .62) * 2.6)));
+  //: Lane density, smoothed then quantised — and it needs both.
+  //:
+  //: The rate arriving each tick BEATS. The generator emits on a 1s step and the poller
+  //: samples on a 1s interval, so the two drift against each other and a window catches two
+  //: of the generator's ticks or none: `logs` reads a steady 82/s sampled every 2s while the
+  //: per-second series alternates. Drawn straight, the logs lane ran 4,2,4,2,4,2 — dots
+  //: appearing and vanishing on the beat, which is what a reader sees and reports.
+  //:
+  //: An EMA absorbs the beat without hiding a real change; a deadband on top of it stops the
+  //: rounding boundary flickering the last dot. Display only — every figure printed on the
+  //: page is still the raw measurement, and the smoothing never reaches the verdict.
+  const ALPHA = 0.35, DEADBAND = 0.65;
+  const ema = {}, held = {};
+
+  /** Is this lane moving? Same smoothing, for the gates that are on/off rather than a count.
+   *
+   *  `rate > 0` on a beating series reads 0 in whichever window catches none of the
+   *  generator's ticks, so a run went still for one frame and came back — the same defect as
+   *  the flickering dot, in binary. The threshold sits below one signal per second: a lane
+   *  that has genuinely stopped decays past it within a few ticks, one that is merely being
+   *  sampled badly does not.
+   */
+  const live = (key, rate) => {
+    ema[key] = ema[key] === undefined ? rate : ema[key] * (1 - ALPHA) + rate * ALPHA;
+    return ema[key] > 0.5;
+  };
+
+  const dots = (key, rate) => {
+    if (rate <= 0) { ema[key] = 0; held[key] = 0; return 0; }
+    ema[key] = ema[key] === undefined ? rate : ema[key] * (1 - ALPHA) + rate * ALPHA;
+    const raw = Math.max(1, Math.min(MAX_DOTS, Math.pow(ema[key] / QUANTUM, .62) * 2.6));
+    const prev = held[key];
+    const n = prev === undefined || Math.abs(raw - prev) > DEADBAND ? Math.round(raw) : prev;
+    held[key] = n;
+    return n;
+  };
 
   /* ── per-service health, fused ─────────────────────────────
    *
@@ -1128,9 +1162,14 @@
       const { dur, n: inFlight } = pools.__batch || { dur: 3.2, n: 3 };
       const pool = [];
       for (let k = 0; k < inFlight; k++) {
+        // Scattered like every other lane. This loop builds its circles inline rather than
+        // through `flow`, so it kept marching in lockstep at exactly 3.20s after the others
+        // were broken up — the one lane still running on a metronome.
+        const own = dur * (1 + (jitter(id, k + 500) - 0.5) * DRIFT);
+        const off = (jitter(id, k) - 0.5) * SPREAD * (dur / inFlight);
         const c = el("circle", { class: cls, r: 3.2, opacity: 0 });
-        const a = el("animateMotion", { dur: `${dur}s`, repeatCount: "indefinite",
-          begin: `${(k * dur / inFlight + dur).toFixed(2)}s` });
+        const a = el("animateMotion", { dur: `${own.toFixed(2)}s`, repeatCount: "indefinite",
+          begin: `${Math.max(0, k * dur / inFlight + dur + off).toFixed(2)}s` });
         a.append(el("mpath", { href: `#${id}` }));
         c.append(a); fx.append(c); pool.push(c);
       }
@@ -1960,10 +1999,12 @@
   /* ── per-tick visibility ───────────────────────────────────── */
   function density(s) {
     const ing = s.ingest_rate || {};
-    show("logs", dots(ing.logs || 0));
-    show("trace", dots(ing.trace || 0));
-    show("metrics", dots(ing.metrics || 0));
-    const inFlight = Math.min(3, Math.round((s.flush_rate || 0) * 3.2 / 2));
+    show("logs", dots("logs", ing.logs || 0));
+    show("trace", dots("trace", ing.trace || 0));
+    show("metrics", dots("metrics", ing.metrics || 0));
+    ema.__flush = ema.__flush === undefined ? (s.flush_rate || 0)
+      : ema.__flush * (1 - ALPHA) + (s.flush_rate || 0) * ALPHA;
+    const inFlight = Math.min(3, Math.round(ema.__flush * 3.2 / 2));
     show("blk", inFlight);
     show("burst", inFlight);
     const total = Object.values(ing).reduce((a, z) => a + z, 0);
@@ -1980,12 +2021,12 @@
     // scenario — the same defect as a hard-coded colour, moved into the gate.
     const tnames = Object.keys(graph?.tables || {});
     for (let i = 0; i < 6; i++)
-      show(`be${i}`, ((s.bronze_rate || {})[tnames[i]] || 0) > 0 ? 3 : 0);
+      show(`be${i}`, live(`be${i}`, (s.bronze_rate || {})[tnames[i]] || 0) ? 3 : 0);
     // A derivation strand runs on the growth of the bronze table it reads, for the same
     // reason: the MV fires on that table's insert and on nothing else. A silent source
     // means a still strand, not a strand animating over nothing.
     derives().forEach(([from], i) =>
-      show(`dv${i}`, ((s.bronze_rate || {})[from] || 0) > 0 ? 2 : 0));
+      show(`dv${i}`, live(`dv${i}`, (s.bronze_rate || {})[from] || 0) ? 2 : 0));
     // An MV writing its target is the one real movement inside SILVER, and its pool was
     // being created and never shown — `spawn` fills `pools`, but nothing here revealed them,
     // so the run existed with every dot at opacity 0. The gate is the growth of the bronze
@@ -2005,7 +2046,8 @@
       return 0;
     };
     Object.keys(SG).forEach((name) => {
-      if (SG[name].kind === "mv") show(`sv-${name}`, rootRate(name) > 0 ? 2 : 0);
+      if (SG[name].kind === "mv")
+        show(`sv-${name}`, live(`sv-${name}`, rootRate(name)) ? 2 : 0);
     });
     // Each type on the bar runs on the bronze tables that feed ITS materialized views,
     // read from the graph so a new MV joins the right lane on its own.
@@ -2013,7 +2055,8 @@
     derives().forEach(([from, , cls]) => {
       byTone[cls] = (byTone[cls] || 0) + ((s.bronze_rate || {})[from] || 0);
     });
-    LANES.forEach(([name, cls]) => show(`dt-${name}`, (byTone[cls] || 0) > 0 ? 2 : 0));
+    LANES.forEach(([name, cls]) =>
+      show(`dt-${name}`, live(`dt-${name}`, byTone[cls] || 0) ? 2 : 0));
     // A read edge runs on the growth of the table being READ — a view over a silent table
     // has nothing new to answer with. A silver table grows at the rate of whatever MV
     // writes it, which resolves back to a bronze table through the same walk.
@@ -2021,7 +2064,7 @@
       const feeder = Object.keys(SG).find((k) => SG[k].target === tbl);
       return feeder ? rootRate(feeder) : 0;
     };
-    readEdges.forEach(([id, src]) => show(id, tableRate(src) > 0 ? 2 : 0));
+    readEdges.forEach(([id, src]) => show(id, live(id, tableRate(src)) ? 2 : 0));
     // Each tap runs only while its own outcome is happening. A pipeline losing nothing
     // should have three still lines, not three animations implying otherwise.
     //

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -30,6 +30,7 @@
   const QUANTUM = 100;            // signals per dot at the overview
   const MAX_DOTS = 14;            // per lane; beyond this the eye reads a line, not a count
   const GAP = 110;                // between columns
+  const SHEET_W = 320;            // the bronze datasheet, which layout() must make room for
 
   //: Collapsed and expanded footprints. Layout is computed from these, so a box growing
   //: pushes its neighbours rather than overlapping them.
@@ -48,6 +49,9 @@
   let service = null;
   const open = { origin: false, collector: false, bronze: false, silver: false };
   let painted = "", pools = {};
+  //: Where an open box's rows meet its edge, so the BRONZE ⇒ SILVER strands can be drawn
+  //: after both bodies have run. Reset on every render; empty whenever a box is closed.
+  let ports = { bronze: {}, silver: {} };
   const view = { k: 1, x: 0, y: 0 };   // viewport transform
   let root = null;                      // the <g> everything pans inside
   let vias = null;                      // the layer mouths are drawn into
@@ -212,11 +216,23 @@
     // about 200 of it — on a tall window the graph sat small in the middle of empty space.
     const bs = Object.values(boxes);
     const y0 = Math.min(...bs.map((b) => b.y)), y1 = Math.max(...bs.map((b) => b.y + b.h));
-    // The datasheet is drawn 40px past BRONZE and is 320 wide. It is not a box, so it was
-    // absent from these bounds and `fit()` scaled to a width that did not include it — the
-    // sheet ran off the right edge of the canvas whenever bronze was open.
-    const x1 = (x - GAP) + (open.bronze ? 40 + 320 : 0);
-    return { boxes, x0: 40, y0, width: x1 - 40, height: y1 - y0 };
+    // The datasheet goes BELOW bronze, directly under the table it describes.
+    //
+    // To the right it landed exactly where SILVER now sits and covered it — a detail panel
+    // over the nodes it is meant to explain, the third time that defect has reached the
+    // reader. Past SILVER it cleared the overlap and cost more: at 320 wide it took the
+    // canvas from 1080 to 1682 units, and `fit()` scales to the widest thing, so every box
+    // on the board shrank to 58% to make room for a panel. Below bronze it is 320 against
+    // bronze's own 318, so it adds no width at all — only height, on an arrangement that is
+    // far wider than it is tall and had the room to spare.
+    const sheet = open.bronze
+      ? { x: boxes.bronze.x, y: boxes.bronze.y + boxes.bronze.h + 30, w: SHEET_W, h: 236 }
+      : null;
+    // Not a box, so it was absent from these bounds and `fit()` scaled to an extent that
+    // excluded it — the sheet ran off the canvas whenever bronze was open.
+    const x1 = Math.max(x - GAP, sheet ? sheet.x + sheet.w : 0);
+    return { boxes, sheet, x0: 40, y0,
+             width: x1 - 40, height: Math.max(y1, sheet ? sheet.y + sheet.h : 0) - y0 };
   }
 
   /* ── particle pools ────────────────────────────────────────── */
@@ -691,6 +707,20 @@
     });
   }
 
+  /** Which bronze table each silver model is materialized FROM. Read off the four
+   *  `CREATE MATERIALIZED VIEW ... TO silver.x ... FROM bronze.y` statements in
+   *  `infra/clickhouse/init.d/02-silver-layer.sql`, not inferred from the names — and it is
+   *  not 1:1: gauge and sum both land in `metric_observations`, which is the one thing about
+   *  this layer a reader cannot get from anywhere else on the board.
+   */
+  const FEEDS = { log_events: "otel_logs",
+                  operation_executions: "otel_traces",
+                  metric_observations: "otel_metrics gauge + sum" };
+  const DERIVES = [["otel_logs", "log_events", "p1"],
+                   ["otel_traces", "operation_executions", "p2"],
+                   ["otel_metrics_gauge", "metric_observations", "p3"],
+                   ["otel_metrics_sum", "metric_observations", "p3"]];
+
   /** SILVER — what Bronze becomes, not where Bronze goes.
    *
    *  The link from bronze is NOT a pipe, and that is the point. Everything else on this
@@ -719,13 +749,28 @@
           total ? `${sv.mvs} materialized views feeding` : "empty — run a stream"));
       return;
     }
-    const names = Object.keys(models), TW = 218, TH = 34;
+    // Ordered by the bronze table each model is derived FROM, not by whatever order
+    // `system.tables` returned. With the rows in source order the four strands run
+    // essentially straight across; in the catalogue's order they crossed in the 52px gap,
+    // and a crossing is a claim about routing that this mapping does not make.
+    const rank = (n) => { const i = DERIVES.findIndex(([, to]) => to === n);
+                          return i < 0 ? DERIVES.length : i; };
+    const names = Object.keys(models).sort((a, z) => rank(a) - rank(z) || a.localeCompare(z));
+    const TW = 218, TH = 34;
     names.forEach((n, i) => {
       const y = b.y + 46 + i * (TH + 6), x = b.x + 26;
-      g.append(el("rect", { class: "nd sub-nd", x, y, width: TW, height: TH, rx: 3 }),
+      // A `.hit` group, like BRONZE's tables: the rows are the thing the pointer is for, so
+      // they have to answer it. Plain rects did not, and the box read as inert next to a
+      // bronze box whose every row lit up.
+      const node = el("g", { class: "hit", tabindex: "0", role: "button",
+        "aria-label": `${n}, ${fmt(models[n])} rows, derived from ${FEEDS[n] || "bronze"}` });
+      node.append(el("rect", { class: "nd sub-nd", x, y, width: TW, height: TH, rx: 3 }),
         el("text", { class: "txt", x: x + 10, y: y + 15 }, clip(n, 24)),
         el("text", { class: "val", x: x + TW - 10, y: y + 15 }, fmt(models[n])),
-        el("text", { class: "sub", x: x + 10, y: y + 28 }, "one row per bronze record"));
+        el("text", { class: "sub", x: x + 10, y: y + 28 },
+          FEEDS[n] ? `from ${FEEDS[n]}` : "one row per bronze record"));
+      g.append(node);
+      ports.silver[n] = { x, y: y + TH / 2 };
     });
     const vy = b.y + 46 + names.length * (TH + 6) + 10;
     g.append(el("text", { class: "lbl", x: b.x + 26, y: vy }, "READ VIEWS"));
@@ -734,6 +779,50 @@
         // The one flow-ui actually consumes today, so the panel does not imply it uses six.
         style: v === "service_health_1m" ? "fill:var(--sec)" : null },
         (v === "service_health_1m" ? "▸ " : "· ") + clip(v, 17))));
+    // Marking one item in a second colour is a claim, and an unexplained claim is a puzzle.
+    // The legend rebuilds per level and this mark only exists here, so it is said here.
+    g.append(el("text", { class: "sub", x: b.x + 26,
+      y: vy + 15 + Math.ceil((sv.views || []).length / 2) * 12 + 6,
+      style: "fill:var(--sec)" }, "\u25b8 read by this board"));
+  }
+
+  /** BRONZE ⇒ SILVER, per table, once both boxes are open.
+   *
+   *  Closed, this is one double bar: the honest summary of a derivation that moves nothing
+   *  across a network. Open, the reader is asking a lineage question — *which table becomes
+   *  which* — and that question has an answer only a drawing gives cheaply, because the
+   *  mapping is not 1:1. `otel_metrics_gauge` and `otel_metrics_sum` both land in
+   *  `metric_observations`; nothing else on this board says so.
+   *
+   *  The strands carry particles and the strands are short, which is the point: the dots
+   *  depart on the SAME batch arrival that fills the bronze row, because ADR-0010's
+   *  materialized views fire inside ClickHouse on that insert. They are not a second hop
+   *  after it. The two vertical channels for the metrics pair are deliberately offset so the
+   *  merge is visible as a merge rather than as one line drawn twice.
+   */
+  function derivations(edges, fx, B) {
+    if (!(open.bronze && open.silver)) return;
+    const { dur, n: inFlight } = pools.__batch || { dur: 3.2, n: 3 };
+    let seen = 0;
+    DERIVES.forEach(([from, to, cls], i) => {
+      const a = ports.bronze[from], z = ports.silver[to];
+      if (!a || !z) return;
+      const id = `dv${i}`;
+      // Same target, two sources: separate the channels so both runs are legible.
+      const stub = to === "metric_observations" ? (from.endsWith("gauge") ? 18 : 32) : 24;
+      pipe(edges, id, fan(a.x, a.y, z.x, z.y, stub), "", {}, 7);
+      mouth(z.x, z.y, 7);
+      const pool = [];
+      for (let k = 0; k < inFlight; k++) {
+        const c = el("circle", { class: cls, r: 2.6, opacity: 0 });
+        const an = el("animateMotion", { dur: `${(dur * 0.55).toFixed(2)}s`,
+          repeatCount: "indefinite", begin: `${(k * dur / inFlight + dur).toFixed(2)}s` });
+        an.append(el("mpath", { href: `#${id}` }));
+        c.append(an); fx.append(c); pool.push(c);
+      }
+      pools[id] = pool;
+      seen++;
+    });
   }
 
   function bronzeBody(g, b, edges, fx) {
@@ -768,6 +857,7 @@
         el("text", { class: "sub", x: x + 10, y: y + 32 },
           row ? `${service.slice(0, 22)} only` : `${tables[n].section} · +${fmt((r.bronze_rate || {})[n])}/s`));
       g.append(node);
+      ports.bronze[n] = { x: x + TW, y: y + TH / 2 };
       // One lane in, fanning to each table — and each strand carries the colour of what
       // actually lands there. Routing is by data-point TYPE, so a log only ever reaches
       // otel_logs; painting every strand the same colour said the opposite.
@@ -792,10 +882,10 @@
   }
 
   /* ── the datasheet, only when bronze is open ───────────────── */
-  function datasheet(parent, b) {
+  function datasheet(parent, sheet) {
     const d = (graph?.tables || {})[table];
-    if (!d) return;
-    const x = b.x + b.w + 40, y = b.y, w = 320, h = b.h;
+    if (!d || !sheet) return;
+    const { x, y, w, h } = sheet;
     parent.append(el("rect", { class: "nd sheet", x, y, width: w, height: h, rx: 4 }),
       el("text", { class: "lbl", x: x + 16, y: y + 24, style: "fill:var(--sec)" },
         table.toUpperCase()));
@@ -817,6 +907,7 @@
   function render() {
     const stage = $("stage");
     pools = {};
+    ports = { bronze: {}, silver: {} };
     const L = layout(), B = L.boxes;
     const svg = el("svg", { viewBox: `0 0 ${VW} ${VH}`, preserveAspectRatio: "xMidYMid meet" });
     const defs = el("defs");
@@ -866,14 +957,16 @@
     // mark — the two rules a reader has to keep apart are "moved" and "derived from".
     const sb = B.bronze, sv = B.silver, dy = 5;
     const x1 = sb.x + sb.w, x2 = sv.x, my = sb.y + sb.h / 2;
-    [-dy, dy].forEach((o) => edges.append(el("path", { class: "derive",
-      d: `M${x1} ${my + o} L${x2} ${my + o}` })));
-    edges.append(el("path", { class: "derive tip", "marker-end": "url(#arrow-tap)",
-      d: `M${x2 - 12} ${my} L${x2 - 1} ${my}` }));
-    nodesLater.push(el("text", { class: "sub", x: (x1 + x2) / 2, y: my - 12,
-      style: "text-anchor:middle" }, "derived"),
-      el("text", { class: "sub", x: (x1 + x2) / 2, y: my + 20,
-        style: "text-anchor:middle" }, "on insert"));
+    if (!(open.bronze && open.silver)) {
+      [-dy, dy].forEach((o) => edges.append(el("path", { class: "derive",
+        d: `M${x1} ${my + o} L${x2} ${my + o}` })));
+      edges.append(el("path", { class: "derive tip", "marker-end": "url(#arrow-tap)",
+        d: `M${x2 - 12} ${my} L${x2 - 1} ${my}` }));
+      nodesLater.push(el("text", { class: "sub", x: (x1 + x2) / 2, y: my - 12,
+        style: "text-anchor:middle" }, "derived"),
+        el("text", { class: "sub", x: (x1 + x2) / 2, y: my + 20,
+          style: "text-anchor:middle" }, "on insert"));
+    }
     // Three batches in flight, evenly spaced. Each one's ARRIVAL time is what the burst
     // and the per-table fan below are keyed to, so the unpacking is not decorative timing
     // — it happens when the batch actually gets there.
@@ -924,7 +1017,8 @@
       ({ origin: originBody, collector: collectorBody, bronze: bronzeBody,
          silver: silverBody }[id])(g, b, edges, fx);
     }
-    if (open.bronze) datasheet(nodes, B.bronze);
+    derivations(edges, fx, B);
+    if (open.bronze) datasheet(nodes, L.sheet);
     nodesLater.forEach((n) => nodes.append(n));
     // The burst only means something when a batch is actually arriving.
     show("burst", 0);
@@ -1537,6 +1631,11 @@
     const tnames = Object.keys(graph?.tables || {});
     for (let i = 0; i < 6; i++)
       show(`be${i}`, ((s.bronze_rate || {})[tnames[i]] || 0) > 0 ? 3 : 0);
+    // A derivation strand runs on the growth of the bronze table it reads, for the same
+    // reason: the MV fires on that table's insert and on nothing else. A silent source
+    // means a still strand, not a strand animating over nothing.
+    DERIVES.forEach(([from], i) =>
+      show(`dv${i}`, ((s.bronze_rate || {})[from] || 0) > 0 ? 2 : 0));
     // Each tap runs only while its own outcome is happening. A pipeline losing nothing
     // should have three still lines, not three animations implying otherwise.
     //

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -38,7 +38,9 @@
     origin:    { closed: [212, 196], open: [742, 248], openSel: [742, 386] },
     collector: { closed: [252, 152], open: [500, 344] },
     bronze:    { closed: [176, 136], open: [318, 252] },
-    silver:    { closed: [186, 136], open: [330, 392] },
+    //: SILVER open has no fixed size — `silverSize()` measures the graph. Add a model or
+    //: a view to the DDL and the box grows to hold it.
+    silver:    { closed: [186, 136] },
   };
 
   let graph = null, snap = null, table = null, model = null;
@@ -172,11 +174,11 @@
     //: Silver sits close to bronze rather than a full GAP away, because nothing travels
     //: between them: the materialized views fire inside ClickHouse on the same insert that
     //: writes bronze. A long run would draw transport that does not happen.
-    const DERIVE_GAP = 52;
+    const DERIVE_GAP = open.bronze && open.silver ? 130 : 52;
     for (const id of ["origin", "collector", "bronze", "silver"]) {
       const key = !open[id] ? "closed"
         : (id === "origin" && service && SIZE[id].openSel) ? "openSel" : "open";
-      const [w, h] = SIZE[id][key];
+      const [w, h] = id === "silver" && open.silver ? silverSize() : SIZE[id][key];
       boxes[id] = { id, x, y: CY - h / 2, w, h };
       x += w + (id === "bronze" ? DERIVE_GAP : GAP);
     }
@@ -230,8 +232,13 @@
       : null;
     // SILVER's sheet sits under SILVER, on the same rule: a sheet exists only while its own
     // row is selected.
-    const mSheet = open.silver && model
-      ? { x: boxes.silver.x, y: boxes.silver.y + boxes.silver.h + 30, w: SHEET_W, h: 236 }
+    // Height follows the content: an MV has no columns of its own, so a 236-tall panel to
+    // hold three lines is mostly empty box.
+    const mDoc = (graph?.silver_graph || {})[model];
+    const mSheet = open.silver && model && mDoc
+      ? { x: boxes.silver.x, y: boxes.silver.y + boxes.silver.h + 30, w: SHEET_W,
+          h: mDoc.kind === "mv" ? 108
+            : 108 + Math.ceil((mDoc.columns?.length || 0) / 2) * 13 }
       : null;
     // Not a box, so it was absent from these bounds and `fit()` scaled to an extent that
     // excluded it — the sheet ran off the canvas whenever bronze was open.
@@ -719,13 +726,34 @@
    *  not 1:1: gauge and sum both land in `metric_observations`, which is the one thing about
    *  this layer a reader cannot get from anywhere else on the board.
    */
-  const FEEDS = { log_events: "otel_logs",
-                  operation_executions: "otel_traces",
-                  metric_observations: "otel_metrics gauge + sum" };
-  const DERIVES = [["otel_logs", "log_events", "p1"],
-                   ["otel_traces", "operation_executions", "p2"],
-                   ["otel_metrics_gauge", "metric_observations", "p3"],
-                   ["otel_metrics_sum", "metric_observations", "p3"]];
+  /** Which signal colour a bronze table carries. Bronze routes on data-point TYPE, so the
+   *  four names are the four types; the fallback exists so an added table is drawn in the
+   *  neutral lane rather than crashing the render or silently reading as logs. */
+  const toneOf = (t) => /log/.test(t) ? "p1" : /trace|span/.test(t) ? "p2"
+    : /metric/.test(t) ? "p3" : "p1";
+
+  /** Every strand from BRONZE into SILVER, READ from the lineage rather than listed here.
+   *
+   *  It is one entry per materialized view that reads a bronze table — which is what a
+   *  strand *is*. Written as a constant it was a fourth copy of the DDL, after the SQL, the
+   *  MV definitions and `system.tables`, and the first thing to go stale the day someone
+   *  adds a model. Add an MV to `02-silver-layer.sql` and a strand appears; nothing here
+   *  needs editing.
+   */
+  const derives = () => {
+    const G = graph?.silver_graph || {};
+    return Object.entries(G)
+      .filter(([, n]) => n.kind === "mv")
+      .flatMap(([name, n]) => (n.sources || [])
+        .filter((src) => src.startsWith("bronze."))
+        .map((src) => [src.split(".")[1], name, toneOf(src.split(".")[1])]))
+      .sort((a, z) => bronzeOrder().indexOf(a[0]) - bronzeOrder().indexOf(z[0]));
+  };
+  //: The order bronze draws its own tables in, so the strands leave in the order they
+  //: arrive. Read from the same `graph.tables` bronzeBody iterates, never listed twice.
+  const bronzeOrder = () => Object.keys(graph?.tables || {});
+
+  const FEEDS_FALLBACK = "bronze";
 
   /** SILVER — what Bronze becomes, not where Bronze goes.
    *
@@ -734,6 +762,46 @@
    *  Bronze to Silver moves nothing — ADR-0010's materialized views fire inside ClickHouse
    *  on the same insert that writes bronze. Drawing a run between them would claim a hop
    *  that never happens, so it is drawn as a derivation: a short double bar, no particles.
+   */
+  //: Inside SILVER: three columns, one per kind, in the order data reaches them.
+  //: `colGap` is routing room, not decoration: ten table→view edges have to pass between
+  //: those two columns, and at 26 they shared one channel and rendered as a smear.
+  const SB = { w: 180, h: 34, gap: 6, colGap: 72, pad: 26, head: 78 };
+
+  /** SILVER's open footprint, measured from the graph rather than typed in.
+   *
+   *  Three columns because there are three kinds of object in ClickHouse, and that is a
+   *  property of ClickHouse, not of this schema. Height is however many rows the tallest
+   *  column needs. Add a model or a read view to `02-silver-layer.sql` and the box grows to
+   *  hold it with no edit here — which is the whole point of reading `system.tables`
+   *  instead of restating it.
+   */
+  function silverSize() {
+    const G = graph?.silver_graph || {};
+    const n = (k) => Object.values(G).filter((z) => z.kind === k).length;
+    const rows = Math.max(1, n("mv"), n("table"), n("view"));
+    return [SB.pad * 2 + SB.w * 3 + SB.colGap * 2,
+            SB.head + rows * (SB.h + SB.gap) + 18];
+  }
+
+  /** SILVER, opened: every object in the database as its own box, and the lineage between.
+   *
+   *  Three kinds live in `silver` and collapsing them was the confusion this fixes — the
+   *  first version drew three boxes and a list of six names, which said nothing about what
+   *  separates them:
+   *
+   *  - **table** (MergeTree) — stores rows. It has a count, a sort key and a TTL.
+   *  - **mv** (MaterializedView) — stores nothing. In ClickHouse this is an *insert
+   *    trigger*, not a stored result set: rows land in its source, it runs its SELECT over
+   *    that block and inserts into its target. It is why Silver holds only what arrived
+   *    after the DDL did.
+   *  - **view** — a named query, run when read. No rows exist until someone asks, so there
+   *    is no count to show and never will be.
+   *
+   *  Which is why the edges are not all the same edge. Bronze → mv → table carries
+   *  particles: rows really do move, on the insert. table → view carries none: nothing
+   *  flows there until a reader runs the query, and animating it would claim a stream that
+   *  does not exist. Colour is the source table's signal type throughout.
    */
   function silverBody(g, b, edges, fx) {
     const sv = snap?.silver || {};
@@ -755,57 +823,133 @@
           total ? `${sv.mvs} materialized views feeding` : "empty — run a stream"));
       return;
     }
-    // Ordered by the bronze table each model is derived FROM, not by whatever order
-    // `system.tables` returned. With the rows in source order the four strands run
-    // essentially straight across; in the catalogue's order they crossed in the 52px gap,
-    // and a crossing is a claim about routing that this mapping does not make.
-    const rank = (n) => { const i = DERIVES.findIndex(([, to]) => to === n);
-                          return i < 0 ? DERIVES.length : i; };
-    const names = Object.keys(models).sort((a, z) => rank(a) - rank(z) || a.localeCompare(z));
-    const TW = b.w - 52, TH = 34;
-    names.forEach((n, i) => {
-      const y = b.y + 46 + i * (TH + 6), x = b.x + 26;
-      // A `.hit` group, like BRONZE's tables: the rows are the thing the pointer is for, so
-      // they have to answer it. Plain rects did not, and the box read as inert next to a
-      // bronze box whose every row lit up.
+    const G = graph?.silver_graph || {};
+    const lay = silverLayout(G, b);
+    if (!lay) return;
+
+    // Column captions. A reader who has never met a ClickHouse MV needs to be told that the
+    // middle column is the only one holding anything.
+    [["MATERIALIZED VIEWS", "insert triggers · store nothing"],
+     ["TABLES", "the rows live here"],
+     ["READ VIEWS", "queries · run when read"]].forEach(([t, sub], c) => {
+      const x = lay.colX[c];
+      g.append(el("text", { class: "lbl", x, y: b.y + 48 }, t),
+        el("text", { class: "sub", x, y: b.y + 61, style: "opacity:.55" }, sub));
+    });
+
+    // Lineage inside SILVER, drawn before the boxes so the boxes cap the runs. Each read
+    // edge gets its own vertical channel in the gap; sharing one turned ten dependencies
+    // into a single unreadable smear.
+    let lane = 0;
+    for (const [name, n] of Object.entries(lay.nodes)) {
+      for (const src of (G[name].sources || [])) {
+        const from = lay.nodes[src.split(".")[1]];
+        if (!from) continue;                       // a bronze source; drawn by derivations()
+        // `p1..p3` are particle FILL classes; an edge wearing one renders filled.
+        const cls = (lay.tone[src.split(".")[1]] || "p1").replace("p", "e");
+        edges.append(el("path", { class: "lin " + cls,
+          d: fan(from.x + SB.w, from.cy, n.x, n.cy, 10 + (lane++ % 10) * 6) }));
+      }
+      // An MV writes into its target, and that write is the only real movement in here.
+      const tgt = G[name].target && lay.nodes[G[name].target];
+      if (tgt) {
+        const id = `sv-${name}`;
+        pipe(edges, id, fan(n.x + SB.w, n.cy, tgt.x, tgt.cy, 12), "", {}, 7);
+        mouth(tgt.x, tgt.cy, 7);
+        spawn(fx, id, lay.tone[name] || "p1");
+      }
+    }
+
+    for (const [name, n] of Object.entries(lay.nodes)) {
+      const kind = G[name].kind, sel = name === model;
       const node = el("g", { class: "hit", tabindex: "0", role: "button",
-        "aria-label": `${n}, ${fmt(models[n])} rows, derived from ${FEEDS[n] || "bronze"}` });
-      node.dataset.model = n;
-      node.append(el("rect", { class: "nd sub-nd" + (n === model ? " sel" : ""), x, y,
-          width: TW, height: TH, rx: 3 }),
-        el("text", { class: "txt", x: x + 10, y: y + 15 }, clip(n, 24)),
-        el("text", { class: "val", x: x + TW - 10, y: y + 15 }, fmt(models[n])),
-        el("text", { class: "sub", x: x + 10, y: y + 28 },
-          FEEDS[n] ? `from ${FEEDS[n]}` : "one row per bronze record"));
+        "aria-label": `${name}, ${KIND_SAYS[kind]}` });
+      node.dataset.model = name;
+      const rows = models[name];
+      node.append(el("rect", { class: "nd sub-nd" + (sel ? " sel" : "") + " k-" + kind,
+          x: n.x, y: n.y, width: SB.w, height: SB.h, rx: 3 }),
+        el("text", { class: "txt", x: n.x + 9, y: n.y + 15, style: "font-size:9px" },
+          clip(name, 28)),
+        el("text", { class: "sub", x: n.x + 9, y: n.y + 27, style: "opacity:.6" },
+          kind === "view" ? (graph?.silver_views?.[name]?.[0] || "query")
+            : kind === "mv" ? "on insert" : "stored"),
+        // Only a table has a count. A view's rows do not exist until it is read, and an MV
+        // holds none at all — printing 0 there would be a different claim from "none".
+        el("text", { class: rows === undefined ? "sub" : "val", x: n.x + SB.w - 9, y: n.y + 21,
+            style: rows === undefined ? "text-anchor:end;opacity:.4" : "text-anchor:end" },
+          rows === undefined ? "—" : fmt(rows)));
       g.append(node);
-      ports.silver[n] = { x, y: y + TH / 2 };
+      if (kind === "mv") ports.silver[name] = { x: n.x, y: n.cy };
+    }
+  }
+
+  //: The short form, for the sheet header where there are 320 units to share with a title.
+  const KIND_SHORT = { table: "table", mv: "materialized view", view: "read view" };
+  //: The long form, for the screen reader, which has no width limit and needs the whole
+  //: distinction spelled out — it cannot see the border style that carries it visually.
+  const KIND_SAYS = {
+    table: "a table — stores rows",
+    mv: "a materialized view — an insert trigger, stores nothing",
+    view: "a read view — a query, run when read, stores nothing",
+  };
+
+  //: Particles for one strand, on the batch arrival that feeds it.
+  function spawn(fx, id, cls, r = 2.6) {
+    const { dur, n } = pools.__batch || { dur: 3.2, n: 3 };
+    const pool = [];
+    for (let k = 0; k < n; k++) {
+      const c = el("circle", { class: cls, r, opacity: 0 });
+      const a = el("animateMotion", { dur: `${(dur * 0.55).toFixed(2)}s`,
+        repeatCount: "indefinite", begin: `${(k * dur / n + dur).toFixed(2)}s` });
+      a.append(el("mpath", { href: `#${id}` }));
+      c.append(a); fx.append(c); pool.push(c);
+    }
+    pools[id] = pool;
+  }
+
+  /** Rows and columns for SILVER's objects, ordered so the lineage runs mostly straight.
+   *
+   *  Each column is ordered by where its own source sits in the column before it, which is
+   *  the same rule that took the four bronze strands from crossing to flat. A view with
+   *  three sources cannot be placed without crossing something, so those go last.
+   */
+  function silverLayout(G, b) {
+    const names = Object.keys(G);
+    if (!names.length) return null;
+    const kind = (k) => names.filter((n) => G[n].kind === k);
+    const bare = (r) => r.split(".")[1];
+    // MVs in the order BRONZE draws the tables they read, so the strands arrive in the
+    // order they left. An MV reading something bronze does not draw goes last, in place.
+    const rankMv = (m) => {
+      const order = bronzeOrder();
+      const i = order.indexOf(bare(G[m].sources[0] || ""));
+      return i < 0 ? order.length : i;
+    };
+    const mvs = kind("mv").sort((a, z) => rankMv(a) - rankMv(z) || a.localeCompare(z));
+    const tone = {};
+    mvs.forEach((m) => { tone[m] = toneOf(bare(G[m].sources[0] || "")); });
+    const tables = [];
+    mvs.forEach((m) => {
+      const t = G[m].target;
+      if (t && G[t] && !tables.includes(t)) { tables.push(t); tone[t] = tone[m]; }
     });
-    // READ VIEWS, one per line with what each one answers. Two columns of bare names fit,
-    // and six names with no explanation is a list, not information — a reader cannot tell a
-    // view from a table, or guess that `run_summary` is one row per run.
-    // Name and answer on two lines, not one. Side by side they collided: a 22-character
-    // name and a 43-character answer need 455 units and the box has 278 of usable width, so
-    // the two runs of text overlapped each other and the panel was unreadable.
-    const vd = graph?.silver_views || {};
-    const vy = b.y + 46 + names.length * (TH + 6) + 14;
-    g.append(el("text", { class: "lbl", x: b.x + 26, y: vy }, "READ VIEWS"),
-      el("text", { class: "sub", x: b.x + 26, y: vy + 15 },
-        "stored nowhere — a query over the models above"));
-    (sv.views || []).forEach((v, i) => {
-      const vyy = vy + 37 + i * 25, read = v === "service_health_1m";
-      const [grain, what] = vd[v] || ["", ""];
-      g.append(el("text", { class: "sub", x: b.x + 26, y: vyy,
-          // The one flow-ui actually consumes today, so the panel does not imply it reads six.
-          style: read ? "fill:var(--sec)" : null },
-        (read ? "▸ " : "· ") + clip(v, 26)),
-        el("text", { class: "sub", x: b.x + 38, y: vyy + 12, style: "opacity:.6" },
-          grain ? `${grain} · ${clip(what, 41)}` : ""));
+    kind("table").forEach((t) => { if (!tables.includes(t)) tables.push(t); });
+    // Views by their first source's row, multi-source ones after — they cross whatever
+    // order they are given, so they are not allowed to displace the ones that do not.
+    const views = kind("view").sort((a, z) => {
+      const rank = (v) => (G[v].sources.length > 1 ? 900
+        : tables.indexOf(bare(G[v].sources[0] || "")));
+      return rank(a) - rank(z) || a.localeCompare(z);
     });
-    // Marking one item in a second colour is a claim, and an unexplained claim is a puzzle.
-    // The legend rebuilds per level and this mark only exists here, so it is said here.
-    g.append(el("text", { class: "sub", x: b.x + 26,
-      y: vy + 37 + (sv.views || []).length * 25 + 4,
-      style: "fill:var(--sec)" }, "▸ the only one this board reads"));
+    tables.forEach((t) => { tone[t] ||= "p1"; });
+    const colX = [0, 1, 2].map((c) => b.x + SB.pad + c * (SB.w + SB.colGap));
+    const nodes = {};
+    [mvs, tables, views].forEach((col, c) => col.forEach((n, i) => {
+      const y = b.y + SB.head + i * (SB.h + SB.gap);
+      nodes[n] = { x: colX[c], y, cy: y + SB.h / 2, col: c, row: i };
+    }));
+    return { nodes, colX, tone,
+             rows: Math.max(mvs.length, tables.length, views.length) };
   }
 
   /** BRONZE ⇒ SILVER, per table, once both boxes are open.
@@ -824,25 +968,14 @@
    */
   function derivations(edges, fx, B) {
     if (!(open.bronze && open.silver)) return;
-    const { dur, n: inFlight } = pools.__batch || { dur: 3.2, n: 3 };
     let seen = 0;
-    DERIVES.forEach(([from, to, cls], i) => {
+    derives().forEach(([from, to, cls], i) => {
       const a = ports.bronze[from], z = ports.silver[to];
       if (!a || !z) return;
       const id = `dv${i}`;
-      // Same target, two sources: separate the channels so both runs are legible.
-      const stub = to === "metric_observations" ? (from.endsWith("gauge") ? 18 : 32) : 24;
-      pipe(edges, id, fan(a.x, a.y, z.x, z.y, stub), "", {}, 7);
+      pipe(edges, id, fan(a.x, a.y, z.x, z.y, 30 + i * 8), "", {}, 7);
       mouth(z.x, z.y, 7);
-      const pool = [];
-      for (let k = 0; k < inFlight; k++) {
-        const c = el("circle", { class: cls, r: 2.6, opacity: 0 });
-        const an = el("animateMotion", { dur: `${(dur * 0.55).toFixed(2)}s`,
-          repeatCount: "indefinite", begin: `${(k * dur / inFlight + dur).toFixed(2)}s` });
-        an.append(el("mpath", { href: `#${id}` }));
-        c.append(an); fx.append(c); pool.push(c);
-      }
-      pools[id] = pool;
+      spawn(fx, id, cls);
       seen++;
     });
   }
@@ -932,26 +1065,44 @@
    *  because a type is metadata and a purpose is a claim.
    */
   function modelsheet(parent, sheet) {
-    const d = (graph?.silver_tables || {})[model];
+    const d = (graph?.silver_graph || {})[model];
     if (!d || !sheet) return;
     const { x, y, w, h } = sheet;
     parent.append(el("rect", { class: "nd sheet", x, y, width: w, height: h, rx: 4 }),
       el("text", { class: "lbl", x: x + 16, y: y + 24, style: "fill:var(--sec)" },
-        model.toUpperCase()));
-    (d.summary.match(/.{1,48}(\s|$)/g) || []).slice(0, 2).forEach((line, i) =>
+        model.toUpperCase()),
+      // What KIND it is, because that is the thing a reader gets wrong about a ClickHouse
+      // `silver` database. On its own line: the long form is 53 characters against a
+      // 320-wide sheet, so right-anchored beside the title it ran straight through it.
+      el("text", { class: "sub", x: x + w - 16, y: y + 24, style: "text-anchor:end" },
+        KIND_SHORT[d.kind] || ""));
+    // A view's own purpose comes from its grain and its answer; a table's is written down.
+    const vd = graph?.silver_views?.[model];
+    const say = d.summary || (vd ? `${vd[0]} · ${vd[1]}` : "");
+    (say.match(/.{1,48}(\s|$)/g) || []).slice(0, 2).forEach((line, i) =>
       parent.append(el("text", { class: "sub", x: x + 16, y: y + 42 + i * 13 }, line.trim())));
+    // Reads above, writes below. Both at the same y drew one on top of the other.
+    if (d.sources?.length)
+      parent.append(el("text", { class: "sub", x: x + 16, y: y + 70, style: "opacity:.6" },
+        "reads " + clip(d.sources.join(", "), 52)));
+    if (d.target)
+      parent.append(el("text", { class: "sub", x: x + 16, y: y + 83, style: "opacity:.6" },
+        `writes silver.${d.target}`));
     // Two columns: 16 to 19 columns will not fit one, and truncating the list would hide
     // exactly the normalized fields that are the reason this layer exists.
     const cols = d.columns || [], half = Math.ceil(cols.length / 2);
     cols.forEach(([name, type], i) => {
       const cx = x + 16 + (i < half ? 0 : w / 2 - 8);
-      const cy = y + 78 + (i % half) * 13;
+      const cy = y + 90 + (i % half) * 13;
       parent.append(el("text", { class: "sub", x: cx, y: cy }, clip(name, 20)),
         el("text", { class: "sub", x: cx + w / 2 - 24, y: cy,
           style: "text-anchor:end;opacity:.55" }, clip(shortType(type), 13)));
     });
+    // An MV has no columns and no sort key of its own; saying so beats an empty panel.
     parent.append(el("text", { class: "sub", x: x + 16, y: y + h - 12 },
-      `ORDER BY ${clip(d.order_by, 56)}`));
+      d.order_by ? `ORDER BY ${clip(d.order_by, 56)}`
+        : d.kind === "mv" ? "no storage of its own — the rows land in its target"
+        : "no sort key — computed at read time"));
   }
 
   //: ClickHouse spells types in full; the sheet has 13 characters. The distinction that
@@ -1712,7 +1863,7 @@
     // A derivation strand runs on the growth of the bronze table it reads, for the same
     // reason: the MV fires on that table's insert and on nothing else. A silent source
     // means a still strand, not a strand animating over nothing.
-    DERIVES.forEach(([from], i) =>
+    derives().forEach(([from], i) =>
       show(`dv${i}`, ((s.bronze_rate || {})[from] || 0) > 0 ? 2 : 0));
     // Each tap runs only while its own outcome is happening. A pipeline losing nothing
     // should have three still lines, not three animations implying otherwise.

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -409,7 +409,12 @@
    *  that has genuinely stopped decays past it within a few ticks, one that is merely being
    *  sampled badly does not.
    */
-  const live = (key, rate) => {
+  //: Named `moving`, not `live`: `density` declares its own `const live` for the
+  //: has-any-traffic flag, and a module-level `live` was shadowed by it for that entire
+  //: scope — every call after that line hit a number instead of a function and threw, so
+  //: every gate from BRONZE onward silently stopped. The shows before it kept working,
+  //: which is exactly how it looked from outside.
+  const moving = (key, rate) => {
     ema[key] = ema[key] === undefined ? rate : ema[key] * (1 - ALPHA) + rate * ALPHA;
     return ema[key] > 0.5;
   };
@@ -2021,12 +2026,12 @@
     // scenario — the same defect as a hard-coded colour, moved into the gate.
     const tnames = Object.keys(graph?.tables || {});
     for (let i = 0; i < 6; i++)
-      show(`be${i}`, live(`be${i}`, (s.bronze_rate || {})[tnames[i]] || 0) ? 3 : 0);
+      show(`be${i}`, moving(`be${i}`, (s.bronze_rate || {})[tnames[i]] || 0) ? 3 : 0);
     // A derivation strand runs on the growth of the bronze table it reads, for the same
     // reason: the MV fires on that table's insert and on nothing else. A silent source
     // means a still strand, not a strand animating over nothing.
     derives().forEach(([from], i) =>
-      show(`dv${i}`, live(`dv${i}`, (s.bronze_rate || {})[from] || 0) ? 2 : 0));
+      show(`dv${i}`, moving(`dv${i}`, (s.bronze_rate || {})[from] || 0) ? 2 : 0));
     // An MV writing its target is the one real movement inside SILVER, and its pool was
     // being created and never shown — `spawn` fills `pools`, but nothing here revealed them,
     // so the run existed with every dot at opacity 0. The gate is the growth of the bronze
@@ -2047,7 +2052,7 @@
     };
     Object.keys(SG).forEach((name) => {
       if (SG[name].kind === "mv")
-        show(`sv-${name}`, live(`sv-${name}`, rootRate(name)) ? 2 : 0);
+        show(`sv-${name}`, moving(`sv-${name}`, rootRate(name)) ? 2 : 0);
     });
     // Each type on the bar runs on the bronze tables that feed ITS materialized views,
     // read from the graph so a new MV joins the right lane on its own.
@@ -2056,7 +2061,7 @@
       byTone[cls] = (byTone[cls] || 0) + ((s.bronze_rate || {})[from] || 0);
     });
     LANES.forEach(([name, cls]) =>
-      show(`dt-${name}`, live(`dt-${name}`, byTone[cls] || 0) ? 2 : 0));
+      show(`dt-${name}`, moving(`dt-${name}`, byTone[cls] || 0) ? 2 : 0));
     // A read edge runs on the growth of the table being READ — a view over a silent table
     // has nothing new to answer with. A silver table grows at the rate of whatever MV
     // writes it, which resolves back to a bronze table through the same walk.
@@ -2064,7 +2069,7 @@
       const feeder = Object.keys(SG).find((k) => SG[k].target === tbl);
       return feeder ? rootRate(feeder) : 0;
     };
-    readEdges.forEach(([id, src]) => show(id, live(id, tableRate(src)) ? 2 : 0));
+    readEdges.forEach(([id, src]) => show(id, moving(id, tableRate(src)) ? 2 : 0));
     // Each tap runs only while its own outcome is happening. A pipeline losing nothing
     // should have three still lines, not three animations implying otherwise.
     //

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -474,10 +474,19 @@
     t.nodes.forEach((n) => {
       const p = pos[n.id], row = byName[n.service], sel = n.service === service;
       const h = serviceHealth(n.service);
+      //: Declared beside measured. `topology.yaml` says what a component's latency should be;
+      //: Silver's `service_health_1m` says what its operations actually took. The repo's rule
+      //: applies — the two disagreeing is the finding — and this is the first thing drawn from
+      //: `silver.*` rather than derived from Bronze. Absent whenever Silver is not deployed,
+      //: which is any stack whose ClickHouse volume predates the DDL; the node then shows the
+      //: declared figure alone, exactly as it always did.
+      const sh = (snap?.service_health || []).find((r) => r.service === n.service);
       const node = el("g", { class: "hit", tabindex: "0", role: "button",
         "aria-pressed": String(sel),
         // The reason travels with the node for anyone not reading colour.
-        "aria-label": `Trace ${n.service} through the pipeline — ${h.state}: ${h.why}` });
+        "aria-label": `Trace ${n.service} through the pipeline — ${h.state}: ${h.why}`
+          + (sh ? ` · measured p50 ${sh.p50} ms, p99 ${sh.p99} ms, ${(sh.error_rate * 100).toFixed(2)}% errors`
+                : "") });
       node.dataset.service = n.service;
       // Name on its own line, figure on the next: at 196px a 24-character service name
       // and a right-aligned count were landing on the same pixels.
@@ -494,7 +503,10 @@
         el("text", { class: "txt", x: p.x + 16, y: p.y + 17 },
           clip(n.service, n.roots ? 21 : 26)),
         el("text", { class: "sub", x: p.x + 16, y: p.y + 33 },
-          `${n.kind} · ${n.latency_ms ?? "?"} ms`),
+          `${n.kind} · ${n.latency_ms ?? "?"} ms`
+          // Not `fmt()`: it abbreviates 1796.6 to "1.8k", which is coarser than the declared
+          // "1800" it sits beside — and the comparison is the entire point of the pair.
+          + (sh ? ` \u2192 ${Math.round(sh.p50)} ms` : "")),
         el("text", { class: "val", x: p.x + NW - 12, y: p.y + 33 }, row ? fmt(row.total) : "—"));
       if (n.roots) node.append(el("text", { class: "cue end", x: p.x + NW - 12, y: p.y + 17 }, "ROOT"));
       g.append(node);

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -868,6 +868,7 @@
         if (G[up]?.target === name) {
           const id = `sv-${up}`;
           pipe(edges, id, fan(from.x + SB.w, from.cy, n.x, n.cy, 12), "", {}, 7);
+          mouth(from.x + SB.w, from.cy, 7);
           mouth(n.x, n.cy, 7);
           spawn(fx, id, cls);
         } else {
@@ -1029,6 +1030,10 @@
       if (!a || !z) return;
       const id = `dv${i}`;
       pipe(edges, id, fan(a.x, a.y, z.x, z.y, 30 + i * 8), "", {}, 7);
+      // Both ends. The collector→bronze trunk has always been capped at departure and
+      // arrival; every run added after it was capped only where it landed, so a pipe grew
+      // out of a flat box edge at one end and met a lip at the other.
+      mouth(a.x, a.y, 7);
       mouth(z.x, z.y, 7);
       spawn(fx, id, cls);
       seen++;
@@ -1231,6 +1236,10 @@
         d: `M${x1} ${my + o} L${x2} ${my + o}` })));
       edges.append(el("path", { class: "derive tip", "marker-end": "url(#arrow-tap)",
         d: `M${x2 - 12} ${my} L${x2 - 1} ${my}` }));
+      // Lips here too. A lip marks where a run meets a box — it is a termination, not a
+      // claim about what travels — so it does not undo this bar carrying nothing.
+      mouth(x1, my, dy * 2 + 4);
+      mouth(x2, my, dy * 2 + 4);
       nodesLater.push(el("text", { class: "sub", x: (x1 + x2) / 2, y: my - 12,
         style: "text-anchor:middle" }, "derived"),
         el("text", { class: "sub", x: (x1 + x2) / 2, y: my + 20,

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -829,11 +829,12 @@
     // A key, not column headings: the columns are DAG depth now, so any of them can hold
     // any kind. Kind is carried by the border, and a border style nobody explains is a
     // pattern, not information.
-    [["k-mv", "materialized view", "an insert trigger · stores nothing"],
-     ["k-tbl", "table", "the rows live here"],
-     ["k-view", "read view", "a query · run when read"]].forEach(([k, t, why], i) => {
-      const x = b.x + SB.pad + i * 200, y = b.y + 46;
-      g.append(el("rect", { class: "nd sub-nd " + (k === "k-tbl" ? "" : k),
+    // The swatch wears the real class, so the key cannot drift from what it describes.
+    [["k-table", "table", "filled — the rows live here"],
+     ["k-mv", "materialized view", "hollow — an insert trigger, stores nothing"],
+     ["k-view", "read view", "sunk — a query, run when read"]].forEach(([k, t, why], i) => {
+      const x = b.x + SB.pad + i * 210, y = b.y + 46;
+      g.append(el("rect", { class: "nd sub-nd " + k,
           x, y: y - 9, width: 12, height: 12, rx: 2 }),
         el("text", { class: "sub", x: x + 18, y }, t),
         el("text", { class: "sub", x: x + 18, y: y + 12, style: "opacity:.5" }, why));

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -830,9 +830,9 @@
     // any kind. Kind is carried by the border, and a border style nobody explains is a
     // pattern, not information.
     // The swatch wears the real class, so the key cannot drift from what it describes.
-    [["k-table", "table", "filled — the rows live here"],
-     ["k-mv", "materialized view", "hollow — an insert trigger, stores nothing"],
-     ["k-view", "read view", "sunk — a query, run when read"]].forEach(([k, t, why], i) => {
+    [["k-table", "table", "lit — the rows are in here"],
+     ["k-mv", "materialized view", "dim — a trigger; rows pass through"],
+     ["k-view", "read view", "dark — a query, run when read"]].forEach(([k, t, why], i) => {
       const x = b.x + SB.pad + i * 210, y = b.y + 46;
       g.append(el("rect", { class: "nd sub-nd " + k,
           x, y: y - 9, width: 12, height: 12, rx: 2 }),

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -1244,8 +1244,7 @@
     if (!(open.bronze && open.silver)) {
       [-dy, dy].forEach((o) => edges.append(el("path", { class: "derive",
         d: `M${x1} ${my + o} L${x2} ${my + o}` })));
-      edges.append(el("path", { class: "derive tip", "marker-end": "url(#arrow-tap)",
-        d: `M${x2 - 12} ${my} L${x2 - 1} ${my}` }));
+
       // Lips here too. A lip marks where a run meets a box — it is a termination, not a
       // claim about what travels — so it does not undo this bar carrying nothing.
       mouth(x1, my, dy * 2 + 4);
@@ -1255,7 +1254,12 @@
       // whose counts are both climbing says the opposite.
       edges.append(el("path", { id: "derive-track", class: "track",
         d: `M${x1} ${my} L${x2} ${my}` }));
-      spawn(fx, "derive-track", "p3", 3);
+      // `flow3`, not three `spawn`s: it already staggers the three colours by a third of a
+      // slot so they interleave instead of moving in lockstep. The bar stands for all four
+      // materialized views at once, so it carries whatever is actually moving — a single
+      // hardcoded class painted every dot amber, right by accident for metrics and wrong for
+      // the other two, which is the same defect the collector's outcome rows had.
+      flow3(fx, "derive-track", "dt", 2.6, 3, 2);
       nodesLater.push(el("text", { class: "sub", x: (x1 + x2) / 2, y: my - 12,
         style: "text-anchor:middle" }, "derived"),
         el("text", { class: "sub", x: (x1 + x2) / 2, y: my + 20,
@@ -1970,8 +1974,13 @@
     Object.keys(SG).forEach((name) => {
       if (SG[name].kind === "mv") show(`sv-${name}`, rootRate(name) > 0 ? 2 : 0);
     });
-    // The collapsed bar runs on the estate: it stands for all four derivations at once.
-    show("derive-track", sum2(s.bronze_rate) > 0 ? 3 : 0);
+    // Each type on the bar runs on the bronze tables that feed ITS materialized views,
+    // read from the graph so a new MV joins the right lane on its own.
+    const byTone = {};
+    derives().forEach(([from, , cls]) => {
+      byTone[cls] = (byTone[cls] || 0) + ((s.bronze_rate || {})[from] || 0);
+    });
+    LANES.forEach(([name, cls]) => show(`dt-${name}`, (byTone[cls] || 0) > 0 ? 2 : 0));
     // A read edge runs on the growth of the table being READ — a view over a silent table
     // has nothing new to answer with. A silver table grows at the rate of whatever MV
     // writes it, which resolves back to a bronze table through the same walk.

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -766,7 +766,7 @@
   //: Inside SILVER: three columns, one per kind, in the order data reaches them.
   //: `colGap` is routing room, not decoration: ten table→view edges have to pass between
   //: those two columns, and at 26 they shared one channel and rendered as a smear.
-  const SB = { w: 180, h: 34, gap: 6, colGap: 72, pad: 26, head: 78 };
+  const SB = { w: 180, h: 34, gap: 6, colGap: 72, pad: 26, head: 86 };
 
   /** SILVER's open footprint, measured from the graph rather than typed in.
    *
@@ -777,10 +777,9 @@
    *  instead of restating it.
    */
   function silverSize() {
-    const G = graph?.silver_graph || {};
-    const n = (k) => Object.values(G).filter((z) => z.kind === k).length;
-    const rows = Math.max(1, n("mv"), n("table"), n("view"));
-    return [SB.pad * 2 + SB.w * 3 + SB.colGap * 2,
+    const lay = silverLayout(graph?.silver_graph || {}, { x: 0, y: 0 });
+    const cols = Math.max(3, lay?.cols || 3), rows = Math.max(1, lay?.rows || 1);
+    return [SB.pad * 2 + SB.w * cols + SB.colGap * (cols - 1),
             SB.head + rows * (SB.h + SB.gap) + 18];
   }
 
@@ -827,14 +826,17 @@
     const lay = silverLayout(G, b);
     if (!lay) return;
 
-    // Column captions. A reader who has never met a ClickHouse MV needs to be told that the
-    // middle column is the only one holding anything.
-    [["MATERIALIZED VIEWS", "insert triggers · store nothing"],
-     ["TABLES", "the rows live here"],
-     ["READ VIEWS", "queries · run when read"]].forEach(([t, sub], c) => {
-      const x = lay.colX[c];
-      g.append(el("text", { class: "lbl", x, y: b.y + 48 }, t),
-        el("text", { class: "sub", x, y: b.y + 61, style: "opacity:.55" }, sub));
+    // A key, not column headings: the columns are DAG depth now, so any of them can hold
+    // any kind. Kind is carried by the border, and a border style nobody explains is a
+    // pattern, not information.
+    [["k-mv", "materialized view", "an insert trigger · stores nothing"],
+     ["k-tbl", "table", "the rows live here"],
+     ["k-view", "read view", "a query · run when read"]].forEach(([k, t, why], i) => {
+      const x = b.x + SB.pad + i * 200, y = b.y + 46;
+      g.append(el("rect", { class: "nd sub-nd " + (k === "k-tbl" ? "" : k),
+          x, y: y - 9, width: 12, height: 12, rx: 2 }),
+        el("text", { class: "sub", x: x + 18, y }, t),
+        el("text", { class: "sub", x: x + 18, y: y + 12, style: "opacity:.5" }, why));
     });
 
     // Lineage inside SILVER, drawn before the boxes so the boxes cap the runs. Each read
@@ -842,21 +844,23 @@
     // into a single unreadable smear.
     let lane = 0;
     for (const [name, n] of Object.entries(lay.nodes)) {
-      for (const src of (G[name].sources || [])) {
-        const from = lay.nodes[src.split(".")[1]];
-        if (!from) continue;                       // a bronze source; drawn by derivations()
-        // `p1..p3` are particle FILL classes; an edge wearing one renders filled.
-        const cls = (lay.tone[src.split(".")[1]] || "p1").replace("p", "e");
-        edges.append(el("path", { class: "lin " + cls,
-          d: fan(from.x + SB.w, from.cy, n.x, n.cy, 10 + (lane++ % 10) * 6) }));
-      }
-      // An MV writes into its target, and that write is the only real movement in here.
-      const tgt = G[name].target && lay.nodes[G[name].target];
-      if (tgt) {
-        const id = `sv-${name}`;
-        pipe(edges, id, fan(n.x + SB.w, n.cy, tgt.x, tgt.cy, 12), "", {}, 7);
-        mouth(tgt.x, tgt.cy, 7);
-        spawn(fx, id, lay.tone[name] || "p1");
+      for (const up of lay.feeds[name]) {
+        const from = lay.nodes[up];
+        if (!from) continue;
+        const cls = lay.tone[up] || "p1";
+        // An MV WRITING its target is real movement — rows land on that insert — so it gets
+        // a pipe with particles. Everything else here is a READ: a view's source, or an MV's
+        // input, where nothing travels until the query runs. Same lineage, different claim.
+        if (G[up]?.target === name) {
+          const id = `sv-${up}`;
+          pipe(edges, id, fan(from.x + SB.w, from.cy, n.x, n.cy, 12), "", {}, 7);
+          mouth(n.x, n.cy, 7);
+          spawn(fx, id, cls);
+        } else {
+          // `p1..p3` are particle FILL classes; an edge wearing one renders filled.
+          edges.append(el("path", { class: "lin " + cls.replace("p", "e"),
+            d: fan(from.x + SB.w, from.cy, n.x, n.cy, 10 + (lane++ % 10) * 6) }));
+        }
       }
     }
 
@@ -907,49 +911,86 @@
     pools[id] = pool;
   }
 
-  /** Rows and columns for SILVER's objects, ordered so the lineage runs mostly straight.
+  /** Rows and columns for SILVER's objects, laid out by DEPTH in the DAG, not by kind.
    *
-   *  Each column is ordered by where its own source sits in the column before it, which is
-   *  the same rule that took the four bronze strands from crossing to flat. A view with
-   *  three sources cannot be placed without crossing something, so those go last.
+   *  Kind decided the column in the first version and it was wrong the moment the schema
+   *  stopped being a straight line. A second-stage MV — one reading a silver table rather
+   *  than a bronze one, which is how you build an hourly rollup — belongs *between* two
+   *  tables; by kind it landed back in column 0 and its edge ran right to left, drawing a
+   *  dependency that reads backwards. A table nothing feeds belongs at the start, not in the
+   *  middle. Depth puts each node after everything it reads, whatever it happens to be, and
+   *  the kind is carried by the border and the sub-label instead.
+   *
+   *  Edges are the dependency, in both directions the DDL states them: an MV *reads* its
+   *  sources and *writes* its target, so a table's producers are the MVs pointing at it.
    */
   function silverLayout(G, b) {
     const names = Object.keys(G);
     if (!names.length) return null;
-    const kind = (k) => names.filter((n) => G[n].kind === k);
     const bare = (r) => r.split(".")[1];
-    // MVs in the order BRONZE draws the tables they read, so the strands arrive in the
-    // order they left. An MV reading something bronze does not draw goes last, in place.
-    const rankMv = (m) => {
-      const order = bronzeOrder();
-      const i = order.indexOf(bare(G[m].sources[0] || ""));
-      return i < 0 ? order.length : i;
+
+    // Who feeds whom. A table has no `sources` of its own — it is fed by the MVs whose
+    // `target` it is, so that edge has to be read backwards out of the MV.
+    const feeds = {};
+    names.forEach((n) => { feeds[n] = new Set(); });
+    names.forEach((n) => {
+      (G[n].sources || []).forEach((src) => {
+        if (feeds[bare(src)]) feeds[n].add(bare(src));      // reads a silver object
+      });
+      const t = G[n].target;
+      if (t && feeds[t]) feeds[t].add(n);                   // an MV writes this table
+    });
+
+    // Depth = one past the deepest thing it reads. `busy` guards a cycle: ClickHouse will
+    // let you build one, and an unguarded walk would recurse until the stack gives out.
+    const depth = {}, busy = new Set();
+    const walk = (n) => {
+      if (n in depth) return depth[n];
+      if (busy.has(n)) return 0;
+      busy.add(n);
+      const up = [...feeds[n]].map(walk);
+      busy.delete(n);
+      return (depth[n] = up.length ? Math.max(...up) + 1 : 0);
     };
-    const mvs = kind("mv").sort((a, z) => rankMv(a) - rankMv(z) || a.localeCompare(z));
+    names.forEach(walk);
+
+    const cols = [];
+    names.forEach((n) => { (cols[depth[n]] ||= []).push(n); });
+    // Within a column, follow the row of whatever feeds you, so runs stay short and mostly
+    // straight — the same rule that took the four bronze strands from crossing to flat.
+    const row = {};
+    cols.forEach((col, c) => {
+      col.sort((a, z) => {
+        const at = (n) => {
+          const up = [...feeds[n]].map((u) => row[u]).filter((r) => r !== undefined);
+          return up.length ? Math.min(...up) : (c === 0 ? -1 : 900);
+        };
+        return at(a) - at(z) || a.localeCompare(z);
+      });
+      col.forEach((n, i) => { row[n] = i; });
+    });
+
+    // Colour is the signal type of the bronze table the chain started from, carried forward
+    // so a rollup three hops down still reads as "this is the metrics lineage".
     const tone = {};
-    mvs.forEach((m) => { tone[m] = toneOf(bare(G[m].sources[0] || "")); });
-    const tables = [];
-    mvs.forEach((m) => {
-      const t = G[m].target;
-      if (t && G[t] && !tables.includes(t)) { tables.push(t); tone[t] = tone[m]; }
-    });
-    kind("table").forEach((t) => { if (!tables.includes(t)) tables.push(t); });
-    // Views by their first source's row, multi-source ones after — they cross whatever
-    // order they are given, so they are not allowed to displace the ones that do not.
-    const views = kind("view").sort((a, z) => {
-      const rank = (v) => (G[v].sources.length > 1 ? 900
-        : tables.indexOf(bare(G[v].sources[0] || "")));
-      return rank(a) - rank(z) || a.localeCompare(z);
-    });
-    tables.forEach((t) => { tone[t] ||= "p1"; });
-    const colX = [0, 1, 2].map((c) => b.x + SB.pad + c * (SB.w + SB.colGap));
+    const toneFor = (n) => {
+      if (tone[n]) return tone[n];
+      const ext = (G[n].sources || []).find((s) => s.startsWith("bronze."));
+      if (ext) return (tone[n] = toneOf(bare(ext)));
+      const up = [...feeds[n]];
+      return (tone[n] = up.length ? toneFor(up[0]) : "p1");
+    };
+    names.forEach((n) => { tone[n] = undefined; });
+    names.forEach(toneFor);
+
     const nodes = {};
-    [mvs, tables, views].forEach((col, c) => col.forEach((n, i) => {
+    cols.forEach((col, c) => col.forEach((n, i) => {
+      const x = b.x + SB.pad + c * (SB.w + SB.colGap);
       const y = b.y + SB.head + i * (SB.h + SB.gap);
-      nodes[n] = { x: colX[c], y, cy: y + SB.h / 2, col: c, row: i };
+      nodes[n] = { x, y, cy: y + SB.h / 2, col: c, row: i };
     }));
-    return { nodes, colX, tone,
-             rows: Math.max(mvs.length, tables.length, views.length) };
+    return { nodes, feeds, tone, cols: cols.length,
+             rows: Math.max(...cols.map((c) => c.length)) };
   }
 
   /** BRONZE ⇒ SILVER, per table, once both boxes are open.

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -41,7 +41,7 @@
     silver:    { closed: [186, 136], open: [330, 392] },
   };
 
-  let graph = null, snap = null, table = "otel_logs", model = null;
+  let graph = null, snap = null, table = null, model = null;
   //: A selected service filters what the graph reports about bronze. It cannot filter the
   //: live rates: `sentinel_signals_ingested_total` carries a `signal` label and no service
   //: label, so per-service throughput simply does not exist upstream of ClickHouse. The
@@ -225,11 +225,11 @@
     // on the board shrank to 58% to make room for a panel. Below bronze it is 320 against
     // bronze's own 318, so it adds no width at all — only height, on an arrangement that is
     // far wider than it is tall and had the room to spare.
-    const sheet = open.bronze
+    const sheet = open.bronze && table
       ? { x: boxes.bronze.x, y: boxes.bronze.y + boxes.bronze.h + 30, w: SHEET_W, h: 236 }
       : null;
-    // SILVER's sheet sits under SILVER for the same reason, and only when a model is picked:
-    // bronze always has a selected table, silver starts with none.
+    // SILVER's sheet sits under SILVER, on the same rule: a sheet exists only while its own
+    // row is selected.
     const mSheet = open.silver && model
       ? { x: boxes.silver.x, y: boxes.silver.y + boxes.silver.h + 30, w: SHEET_W, h: 236 }
       : null;
@@ -1081,7 +1081,7 @@
          silver: silverBody }[id])(g, b, edges, fx);
     }
     derivations(edges, fx, B);
-    if (open.bronze) datasheet(nodes, L.sheet);
+    if (L.sheet) datasheet(nodes, L.sheet);
     if (L.mSheet) modelsheet(nodes, L.mSheet);
     nodesLater.forEach((n) => nodes.append(n));
     // The burst only means something when a batch is actually arriving.
@@ -1094,12 +1094,17 @@
         if (e.key === "Enter" || e.key === " ") { e.preventDefault(); n.click(); }
       });
     });
+    // Both toggle, and both start unselected: a datasheet is the answer to a click, so it
+    // appears on one and goes away on the next. BRONZE used to open with `otel_logs`
+    // selected and no way to deselect it, which made the sheet a permanent fixture of the
+    // open box rather than something the reader asked for.
     stage.querySelectorAll("[data-table]").forEach((n) => {
-      n.addEventListener("click", (e) => { e.stopPropagation(); table = n.dataset.table; repaint(); });
+      n.addEventListener("click", (e) => {
+        e.stopPropagation();
+        table = table === n.dataset.table ? null : n.dataset.table;
+        repaint();
+      });
     });
-    // A silver model toggles, unlike a bronze table: bronze always has one selected and
-    // clicking the selected one again should not blank a sheet that has nowhere to fall
-    // back to. Silver starts with none, so closing the sheet is a state it can return to.
     stage.querySelectorAll("[data-model]").forEach((n) => {
       n.addEventListener("click", (e) => {
         e.stopPropagation();
@@ -1243,9 +1248,8 @@
     $("z-in").addEventListener("click", () => zoomAt(VW / 2, VH / 2, 1.25));
     $("z-out").addEventListener("click", () => zoomAt(VW / 2, VH / 2, 1 / 1.25));
     $("z-home").addEventListener("click", () => {
-      open.origin = open.collector = open.bronze = false;
-      table = "otel_logs";
-      service = null;
+      open.origin = open.collector = open.bronze = open.silver = false;
+      table = model = service = null;
       repaint();
       fit();
     });

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -829,16 +829,29 @@
     // A key, not column headings: the columns are DAG depth now, so any of them can hold
     // any kind. Kind is carried by the border, and a border style nobody explains is a
     // pattern, not information.
-    // The swatch wears the real class, so the key cannot drift from what it describes.
-    [["k-table", "table", "lit — the rows are in here"],
-     ["k-mv", "materialized view", "dim — a trigger; rows pass through"],
-     ["k-view", "read view", "dark — a query, run when read"]].forEach(([k, t, why], i) => {
-      const x = b.x + SB.pad + i * 210, y = b.y + 46;
-      g.append(el("rect", { class: "nd sub-nd " + k,
-          x, y: y - 9, width: 12, height: 12, rx: 2 }),
-        el("text", { class: "sub", x: x + 18, y }, t),
-        el("text", { class: "sub", x: x + 18, y: y + 12, style: "opacity:.5" }, why));
-    });
+    // The key is a legend, not a control, and it was being read as three checkboxes: a
+    // 12x12 rounded square beside a label is the shape of something you tick. It is a wide
+    // flat bar now — a miniature of the node it describes, which is what it actually is —
+    // and `pointer-events:none` means it never takes a cursor either.
+    //
+    // It does answer the pointer, though, just from the other end: selecting a node lights
+    // the swatch for that node's kind. The legend stops being dead chrome and starts saying
+    // "the thing you just picked is one of these".
+    const picked = (graph?.silver_graph || {})[model]?.kind;
+    [["k-table", "table", "table", "lit — the rows are in here"],
+     ["k-mv", "mv", "materialized view", "dim — a trigger; rows pass through"],
+     ["k-view", "view", "read view", "dark — a query, run when read"]]
+      .forEach(([k, kind, t, why], i) => {
+        const x = b.x + SB.pad + i * 210, y = b.y + 46, on = kind === picked;
+        // `el`'s third argument is TEXT, not children — passing elements there set the
+        // group's textContent and the swatch was never created at all.
+        const key = el("g", { class: "key" + (on ? " on" : "") });
+        key.append(
+          el("rect", { class: "sw sub-nd " + k, x, y: y - 8, width: 24, height: 11, rx: 2 }),
+          el("text", { class: "sub", x: x + 32, y }, t),
+          el("text", { class: "sub", x: x + 32, y: y + 12, style: "opacity:.5" }, why));
+        g.append(key);
+      });
 
     // Lineage inside SILVER, drawn before the boxes so the boxes cap the runs. Each read
     // edge gets its own vertical channel in the gap; sharing one turned ten dependencies

--- a/services/flow-ui/src/flow_ui/static/app.js
+++ b/services/flow-ui/src/flow_ui/static/app.js
@@ -37,6 +37,7 @@
     origin:    { closed: [212, 196], open: [742, 248], openSel: [742, 386] },
     collector: { closed: [252, 152], open: [500, 344] },
     bronze:    { closed: [176, 136], open: [318, 252] },
+    silver:    { closed: [186, 136], open: [268, 252] },
   };
 
   let graph = null, snap = null, table = "otel_logs";
@@ -45,7 +46,7 @@
   //: label, so per-service throughput simply does not exist upstream of ClickHouse. The
   //: legend says so rather than letting the lanes imply otherwise.
   let service = null;
-  const open = { origin: false, collector: false, bronze: false };
+  const open = { origin: false, collector: false, bronze: false, silver: false };
   let painted = "", pools = {};
   const view = { k: 1, x: 0, y: 0 };   // viewport transform
   let root = null;                      // the <g> everything pans inside
@@ -164,12 +165,16 @@
     const CY = 220;
     const boxes = {};
     let x = 40;
-    for (const id of ["origin", "collector", "bronze"]) {
+    //: Silver sits close to bronze rather than a full GAP away, because nothing travels
+    //: between them: the materialized views fire inside ClickHouse on the same insert that
+    //: writes bronze. A long run would draw transport that does not happen.
+    const DERIVE_GAP = 52;
+    for (const id of ["origin", "collector", "bronze", "silver"]) {
       const key = !open[id] ? "closed"
         : (id === "origin" && service && SIZE[id].openSel) ? "openSel" : "open";
       const [w, h] = SIZE[id][key];
       boxes[id] = { id, x, y: CY - h / 2, w, h };
-      x += w + GAP;
+      x += w + (id === "bronze" ? DERIVE_GAP : GAP);
     }
     // Signal lanes leave the origin container's right edge, not individual services: the
     // three types are a property of every service, not of any one of them.
@@ -686,6 +691,51 @@
     });
   }
 
+  /** SILVER — what Bronze becomes, not where Bronze goes.
+   *
+   *  The link from bronze is NOT a pipe, and that is the point. Everything else on this
+   *  canvas transports something: signals move along a bore from one component to another.
+   *  Bronze to Silver moves nothing — ADR-0010's materialized views fire inside ClickHouse
+   *  on the same insert that writes bronze. Drawing a run between them would claim a hop
+   *  that never happens, so it is drawn as a derivation: a short double bar, no particles.
+   */
+  function silverBody(g, b, edges, fx) {
+    const sv = snap?.silver || {};
+    if (!sv.present) {
+      g.append(el("text", { class: "txt", x: b.x + 18, y: b.y + 66 }, "not deployed"),
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 88 }, "the DDL applies on"),
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 102 }, "ClickHouse boot — a volume"),
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 116 }, "older than it has no silver"));
+      return;
+    }
+    const models = sv.models || {}, total = Object.values(models).reduce((a, z) => a + z, 0);
+    if (!open.silver) {
+      g.append(el("text", { class: "txt", x: b.x + 18, y: b.y + 66 }, fmt(total) + " rows"),
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 88 },
+          `${Object.keys(models).length} models · ${(sv.views || []).length} read views`),
+        // Empty is the normal state of a stack nobody has streamed into yet, and it is a
+        // different statement from absent. Saying which keeps the box honest.
+        el("text", { class: "sub", x: b.x + 18, y: b.y + 106 },
+          total ? `${sv.mvs} materialized views feeding` : "empty — run a stream"));
+      return;
+    }
+    const names = Object.keys(models), TW = 218, TH = 34;
+    names.forEach((n, i) => {
+      const y = b.y + 46 + i * (TH + 6), x = b.x + 26;
+      g.append(el("rect", { class: "nd sub-nd", x, y, width: TW, height: TH, rx: 3 }),
+        el("text", { class: "txt", x: x + 10, y: y + 15 }, clip(n, 24)),
+        el("text", { class: "val", x: x + TW - 10, y: y + 15 }, fmt(models[n])),
+        el("text", { class: "sub", x: x + 10, y: y + 28 }, "one row per bronze record"));
+    });
+    const vy = b.y + 46 + names.length * (TH + 6) + 10;
+    g.append(el("text", { class: "lbl", x: b.x + 26, y: vy }, "READ VIEWS"));
+    (sv.views || []).forEach((v, i) => g.append(
+      el("text", { class: "sub", x: b.x + 26 + (i % 2) * 118, y: vy + 15 + Math.floor(i / 2) * 12,
+        // The one flow-ui actually consumes today, so the panel does not imply it uses six.
+        style: v === "service_health_1m" ? "fill:var(--sec)" : null },
+        (v === "service_health_1m" ? "▸ " : "· ") + clip(v, 17))));
+  }
+
   function bronzeBody(g, b, edges, fx) {
     const r = snap || {}, tables = graph?.tables || {};
     const total = Object.values(r.bronze || {}).reduce((a, z) => a + z, 0);
@@ -761,7 +811,8 @@
   }
 
   /* ── render ────────────────────────────────────────────────── */
-  const TITLE = { origin: "ORIGIN", collector: "COLLECTOR-RUST", bronze: "BRONZE" };
+  const TITLE = { origin: "ORIGIN", collector: "COLLECTOR-RUST", bronze: "BRONZE",
+                  silver: "SILVER" };
 
   function render() {
     const stage = $("stage");
@@ -786,6 +837,8 @@
     svg.append(defs);
 
     root = el("g", { id: "vp" });
+    //: Captions that must sit above the edge layer but are not part of any node.
+    const nodesLater = [];
     const edges = el("g", { class: "ed-layer" });
     vias = el("g", { class: "via" });
     const fx = el("g", { filter: "url(#bloom)" });
@@ -806,6 +859,21 @@
       route(B.collector.out[0], B.collector.out[1], B.bronze.in[0], B.bronze.in[1]), "trunk");
     mouth(B.collector.out[0], B.collector.out[1], 24);
     mouth(B.bronze.in[0], B.bronze.in[1], 24);
+
+    // BRONZE ⇒ SILVER. Not a pipe, and no mouths: nothing travels here. ADR-0010's
+    // materialized views fire inside ClickHouse on the same insert that writes bronze, so a
+    // run with dots in it would draw a hop that never happens. A double bar is the derivation
+    // mark — the two rules a reader has to keep apart are "moved" and "derived from".
+    const sb = B.bronze, sv = B.silver, dy = 5;
+    const x1 = sb.x + sb.w, x2 = sv.x, my = sb.y + sb.h / 2;
+    [-dy, dy].forEach((o) => edges.append(el("path", { class: "derive",
+      d: `M${x1} ${my + o} L${x2} ${my + o}` })));
+    edges.append(el("path", { class: "derive tip", "marker-end": "url(#arrow-tap)",
+      d: `M${x2 - 12} ${my} L${x2 - 1} ${my}` }));
+    nodesLater.push(el("text", { class: "sub", x: (x1 + x2) / 2, y: my - 12,
+      style: "text-anchor:middle" }, "derived"),
+      el("text", { class: "sub", x: (x1 + x2) / 2, y: my + 20,
+        style: "text-anchor:middle" }, "on insert"));
     // Three batches in flight, evenly spaced. Each one's ARRIVAL time is what the burst
     // and the per-table fan below are keyed to, so the unpacking is not decorative timing
     // — it happens when the batch actually gets there.
@@ -835,7 +903,7 @@
     }
     pools.__batch = { dur: BATCH_DUR, n: IN_FLIGHT };
 
-    for (const id of ["origin", "collector", "bronze"]) {
+    for (const id of ["origin", "collector", "bronze", "silver"]) {
       const b = B[id];
       const g = el("g", { class: "hit node", tabindex: "0", role: "button",
         "aria-expanded": String(open[id]),
@@ -853,9 +921,11 @@
         el("text", { class: "cue", x: b.x + b.w - 18, y: b.y + 26,
           style: "text-anchor:end" }, open[id] ? "CLOSE ▾" : "OPEN ▸"));
       nodes.append(g);
-      ({ origin: originBody, collector: collectorBody, bronze: bronzeBody }[id])(g, b, edges, fx);
+      ({ origin: originBody, collector: collectorBody, bronze: bronzeBody,
+         silver: silverBody }[id])(g, b, edges, fx);
     }
     if (open.bronze) datasheet(nodes, B.bronze);
+    nodesLater.forEach((n) => nodes.append(n));
     // The burst only means something when a batch is actually arriving.
     show("burst", 0);
 
@@ -1500,8 +1570,11 @@
 
   /* ── structural repaint ────────────────────────────────────── */
   function repaint() {
+    // Every box that can expand belongs in this key. Leaving one out does not fail loudly:
+    // the click flips `open[id]`, the key does not change, repaint returns early and the box
+    // simply never opens. `silver` was missing and the bug looked like a dead click.
     const key = [snap?.mode || "", graph ? 1 : 0, open.origin, open.collector, open.bronze,
-                 table, service].join("|");
+                 open.silver, table, service].join("|");
     if (key === painted) return false;
     const first = painted === "";
     painted = key;

--- a/services/flow-ui/tests/test_clickhouse.py
+++ b/services/flow-ui/tests/test_clickhouse.py
@@ -59,48 +59,68 @@ def test_a_row_that_does_not_parse_is_skipped_not_fatal(line):
     assert silver(f"MergeTree\tlog_events\t3\n{line}\n")["models"] == {"log_events": 3}
 
 
-def schema(keys: str, cols: str) -> dict:
+def sgraph(rows, cols: str = "") -> dict:
     ch = ClickHouse("http://ch:8123", "bronze")
-    seen: list[str] = []
 
     async def _query(sql: str) -> str:
-        seen.append(sql)
-        if isinstance(keys, Exception):
-            raise keys
-        return keys if "system.tables" in sql else cols
+        if isinstance(rows, Exception):
+            raise rows
+        return rows if "system.tables" in sql else cols
 
     ch._query = _query  # type: ignore[method-assign]
-    return asyncio.run(ch.silver_schema())
+    return asyncio.run(ch.silver_graph())
 
 
-def test_only_the_physical_models_get_a_schema():
-    """`system.columns` also returns the MVs and read views.
-
-    An MV's columns are its target's, so an unfiltered read returned each model's schema
-    three times under three names. Filtering happens in Python because ClickHouse 24.3
-    rejects `IN (SELECT … FROM system.tables)` with "Not-ready Set".
-    """
-    state = schema(
-        "log_events\tscenario, event_time\ttoDate(event_time)\n",
-        "log_events\tevent_time\tDateTime64(9)\n"
-        "log_events\tbody\tString\n"
-        "log_events_mv\tevent_time\tDateTime64(9)\n"
-        "log_health_1m\twindow_start\tDateTime\n",
-    )
-    assert list(state) == ["log_events"]
-    assert state["log_events"]["columns"] == [
-        ["event_time", "DateTime64(9)"], ["body", "String"]]
-    assert state["log_events"]["order_by"] == "scenario, event_time"
+MV = ("CREATE MATERIALIZED VIEW silver.log_events_mv TO silver.log_events "
+      "AS SELECT * FROM bronze.otel_logs")
+VIEW = "CREATE VIEW silver.log_health_1m AS SELECT * FROM silver.log_events"
+TBL = "CREATE TABLE silver.log_events (body String) ENGINE = MergeTree"
 
 
-def test_a_model_carries_its_hand_written_purpose():
-    """Columns are metadata and cannot drift. A purpose is a claim, so it is written down."""
-    state = schema("log_events\tk\tp\n", "log_events\tbody\tString\n")
-    assert "one row per log record" in state["log_events"]["summary"].lower()
+def test_the_three_kinds_are_told_apart_by_engine():
+    """A table stores rows, an MV is an insert trigger, a view is a query. Collapsing them
+    is exactly the thing the board now exists to un-collapse."""
+    g = sgraph(f"log_events\tMergeTree\tscenario\t{TBL}\n"
+               f"log_events_mv\tMaterializedView\t\t{MV}\n"
+               f"log_health_1m\tView\t\t{VIEW}\n")
+    assert {k: v["kind"] for k, v in g.items()} == {
+        "log_events": "table", "log_events_mv": "mv", "log_health_1m": "view"}
 
 
-def test_an_unreachable_clickhouse_yields_no_schema_rather_than_raising():
-    assert schema(httpx.ConnectError("refused"), "") == {}
+def test_an_mv_reads_its_from_and_writes_its_to():
+    """`TO silver.x` is the target and must not be reported as a source, or the MV would
+    look like it reads the table it writes."""
+    g = sgraph(f"log_events_mv\tMaterializedView\t\t{MV}\n")
+    assert g["log_events_mv"]["sources"] == ["bronze.otel_logs"]
+    assert g["log_events_mv"]["target"] == "log_events"
+
+
+def test_a_view_reads_every_table_it_names():
+    ddl = ("CREATE VIEW silver.run_summary AS SELECT * FROM silver.log_events "
+           "JOIN silver.operation_executions USING run_id")
+    g = sgraph(f"run_summary\tView\t\t{ddl}\n")
+    assert g["run_summary"]["sources"] == [
+        "silver.log_events", "silver.operation_executions"]
+
+
+def test_a_table_added_to_the_ddl_needs_no_code_change():
+    """The whole point of reading `system.tables`: the board is the database's shape, not a
+    list maintained here. Verified live too — a view created in ClickHouse appeared on the
+    board, wired to its source, with nothing edited."""
+    g = sgraph("brand_new\tMergeTree\tid\tCREATE TABLE silver.brand_new (id UInt8) "
+               "ENGINE = MergeTree\n")
+    assert g["brand_new"]["kind"] == "table"
+
+
+def test_an_mv_does_not_repeat_its_targets_columns():
+    """An MV's columns *are* its target's, so listing them says the same thing twice."""
+    g = sgraph(f"log_events_mv\tMaterializedView\t\t{MV}\n",
+               "log_events_mv\tbody\tString\n")
+    assert g["log_events_mv"]["columns"] == []
+
+
+def test_an_unreachable_clickhouse_yields_no_graph_rather_than_raising():
+    assert sgraph(httpx.ConnectError("refused")) == {}
 
 
 def test_every_read_view_the_box_lists_has_something_to_say_about_itself():

--- a/services/flow-ui/tests/test_clickhouse.py
+++ b/services/flow-ui/tests/test_clickhouse.py
@@ -128,3 +128,35 @@ def test_every_read_view_the_box_lists_has_something_to_say_about_itself():
     for name, (grain, what) in ClickHouse.SILVER_VIEW_DOCS.items():
         assert grain and what, name
         assert len(what) <= 41, (name, len(what))
+
+
+def test_the_whole_mergetree_family_is_a_table():
+    """A SummingMergeTree rollup is the obvious engine for a second-stage model.
+
+    Matching the literal string "MergeTree" made one invisible on the board with its own MV
+    left pointing at nothing — found by creating one against the live database, not in
+    review. Anything that is not one of the two view engines stores rows.
+    """
+    ddl = "CREATE TABLE silver.log_events_hourly (n UInt64) ENGINE = SummingMergeTree"
+    g = sgraph(f"log_events_hourly\tSummingMergeTree\tservice_name\t{ddl}\n")
+    assert g["log_events_hourly"]["kind"] == "table"
+
+
+def test_silver_state_classifies_engines_the_same_way():
+    """The two readings must agree, or the board draws a table it has no count for."""
+    state = silver("SummingMergeTree\tlog_events_hourly\t22\n"
+                   "MergeTree\tlog_events\t7\n"
+                   "View\tlog_health_1m\t0\n"
+                   "MaterializedView\tlog_events_hourly_mv\t0\n")
+    assert state["models"] == {"log_events_hourly": 22, "log_events": 7}
+    assert state["views"] == ["log_health_1m"] and state["mvs"] == 1
+
+
+def test_a_second_stage_mv_reads_silver_not_bronze():
+    """An hourly rollup reads a silver table. Laid out by kind it fell back into the first
+    column and its edge ran right to left; depth puts it after what it reads."""
+    ddl = ("CREATE MATERIALIZED VIEW silver.log_events_hourly_mv TO silver.log_events_hourly "
+           "AS SELECT count() FROM silver.log_events GROUP BY service_name")
+    g = sgraph(f"log_events_hourly_mv\tMaterializedView\t\t{ddl}\n")
+    assert g["log_events_hourly_mv"]["sources"] == ["silver.log_events"]
+    assert g["log_events_hourly_mv"]["target"] == "log_events_hourly"

--- a/services/flow-ui/tests/test_clickhouse.py
+++ b/services/flow-ui/tests/test_clickhouse.py
@@ -57,3 +57,54 @@ def test_an_unreachable_clickhouse_reads_as_absent_rather_than_raising():
 @pytest.mark.parametrize("line", ["", "   ", "MergeTree\tno_count_column"])
 def test_a_row_that_does_not_parse_is_skipped_not_fatal(line):
     assert silver(f"MergeTree\tlog_events\t3\n{line}\n")["models"] == {"log_events": 3}
+
+
+def schema(keys: str, cols: str) -> dict:
+    ch = ClickHouse("http://ch:8123", "bronze")
+    seen: list[str] = []
+
+    async def _query(sql: str) -> str:
+        seen.append(sql)
+        if isinstance(keys, Exception):
+            raise keys
+        return keys if "system.tables" in sql else cols
+
+    ch._query = _query  # type: ignore[method-assign]
+    return asyncio.run(ch.silver_schema())
+
+
+def test_only_the_physical_models_get_a_schema():
+    """`system.columns` also returns the MVs and read views.
+
+    An MV's columns are its target's, so an unfiltered read returned each model's schema
+    three times under three names. Filtering happens in Python because ClickHouse 24.3
+    rejects `IN (SELECT … FROM system.tables)` with "Not-ready Set".
+    """
+    state = schema(
+        "log_events\tscenario, event_time\ttoDate(event_time)\n",
+        "log_events\tevent_time\tDateTime64(9)\n"
+        "log_events\tbody\tString\n"
+        "log_events_mv\tevent_time\tDateTime64(9)\n"
+        "log_health_1m\twindow_start\tDateTime\n",
+    )
+    assert list(state) == ["log_events"]
+    assert state["log_events"]["columns"] == [
+        ["event_time", "DateTime64(9)"], ["body", "String"]]
+    assert state["log_events"]["order_by"] == "scenario, event_time"
+
+
+def test_a_model_carries_its_hand_written_purpose():
+    """Columns are metadata and cannot drift. A purpose is a claim, so it is written down."""
+    state = schema("log_events\tk\tp\n", "log_events\tbody\tString\n")
+    assert "one row per log record" in state["log_events"]["summary"].lower()
+
+
+def test_an_unreachable_clickhouse_yields_no_schema_rather_than_raising():
+    assert schema(httpx.ConnectError("refused"), "") == {}
+
+
+def test_every_read_view_the_box_lists_has_something_to_say_about_itself():
+    """Six names with no explanation is a list, not information."""
+    for name, (grain, what) in ClickHouse.SILVER_VIEW_DOCS.items():
+        assert grain and what, name
+        assert len(what) <= 41, (name, len(what))

--- a/services/flow-ui/tests/test_clickhouse.py
+++ b/services/flow-ui/tests/test_clickhouse.py
@@ -1,0 +1,59 @@
+"""Silver's state is read from `system.tables`, so the parsing is the whole risk."""
+
+import asyncio
+
+import httpx
+import pytest
+
+from flow_ui.clickhouse import ClickHouse
+
+
+def silver(rows: str | Exception) -> dict:
+    ch = ClickHouse("http://ch:8123", "bronze")
+
+    async def _query(_sql: str) -> str:
+        if isinstance(rows, Exception):
+            raise rows
+        return rows
+
+    ch._query = _query  # type: ignore[method-assign]
+    return asyncio.run(ch.silver_state())
+
+
+def test_engine_decides_what_a_table_counts_as():
+    state = silver(
+        "MergeTree\toperation_executions\t12849\n"
+        "MergeTree\tlog_events\t7\n"
+        "View\tservice_health_1m\t0\n"
+        "View\tapi_latency_1m\t0\n"
+        "MaterializedView\tmv_operation_executions\t0\n"
+    )
+    assert state["present"] is True
+    assert state["models"] == {"operation_executions": 12849, "log_events": 7}
+    assert state["views"] == ["api_latency_1m", "service_health_1m"]
+    assert state["mvs"] == 1
+
+
+def test_an_empty_silver_is_present_and_an_absent_one_is_not():
+    """A volume older than the Silver DDL has no `silver` database at all.
+
+    Both states are normal — the MVs do not POPULATE, so a fresh stack has the tables
+    and no rows — but the board says different things about them, so they must not
+    collapse into the same snapshot.
+    """
+    empty = silver("MergeTree\toperation_executions\t0\n")
+    assert empty["present"] is True and empty["models"] == {"operation_executions": 0}
+
+    absent = silver("")
+    assert absent["present"] is False and absent["models"] == {}
+
+
+def test_an_unreachable_clickhouse_reads_as_absent_rather_than_raising():
+    """The slow lane must not take the board down because Silver could not be probed."""
+    assert silver(httpx.ConnectError("refused")) == {
+        "present": False, "models": {}, "views": [], "mvs": 0}
+
+
+@pytest.mark.parametrize("line", ["", "   ", "MergeTree\tno_count_column"])
+def test_a_row_that_does_not_parse_is_skipped_not_fatal(line):
+    assert silver(f"MergeTree\tlog_events\t3\n{line}\n")["models"] == {"log_events": 3}


### PR DESCRIPTION
## What

Silver becomes visible on the Flow board, and the board draws it **from the database** rather
than from anything written down here.

- Each ORIGIN node draws **declared → measured**: the latency `topology.yaml` claims for a
  component, beside the p50 its operations actually took, from `silver.service_health_1m`.
- SILVER is the fourth box, and opened it is the whole `silver` DAG — 4 materialized views,
  3 tables, 6 read views — laid out by dependency depth, with the lineage between them.
- `ARCHITECTURE.md`: what this service is made of, in six Mermaid diagrams. It had a README,
  a DESIGN and a STATUS, and nothing that answered "what is this built with".

## Why

Closes #44.

#37 asked for two things with two different prerequisites; this is the half that ships now.
**#37 stays open** for migrating `contract_violations`, `volume_band` and `call_edges` off
Bronze, which needs Silver to have history first — numbers below.

flow-ui had no per-service latency at all: the Health board's quantiles are the collector's
*export* latency, which is how long writing to ClickHouse takes, not how long a producer's
operations take.

## The board reads the schema, it does not restate it

`silver_graph()` reads `system.tables`, classifies by engine, and parses lineage out of
`create_table_query` — `TO x.y` is a materialized view's target, every other `bronze.`/`silver.`
reference is a source. The old four-pair `DERIVES` constant in `app.js` was a fourth copy of the
DDL after the SQL, the MV definitions and `system.tables`; it is computed now, and so is the
box's own footprint.

Tested by building the awkward cases against the live database and looking, then dropping them:

| Case created live | Result |
|---|---|
| `CREATE VIEW silver.error_budget_1m … FROM silver.operation_executions` | appeared beside the table it reads, wired in that table's colour, box grown a row — **no code edited** |
| A second-stage MV `silver.log_events → silver.log_events_hourly` | landed in a **fourth column that did not exist before**, after the table it reads. It also worked: 22 rows |
| A table nothing feeds | column 0 with the sources, no incoming edge — correct |

That third case found a real bug: **`SummingMergeTree` did not match the literal string
`"MergeTree"`**, so a rollup table was invisible in `silver_graph` *and* missing from `models`
in `silver_state`. The obvious engine for exactly this kind of model. Both readings classify
identically now, and a test pins that they agree.

## Tests / evidence

Silver had to be deployed first — defined but absent (`system.databases` had no `silver`). The
DDL is idempotent, 14 × `CREATE ... IF NOT EXISTS`, so it was applied to the running instance
rather than via `make reset`, keeping 9.5M rows of Bronze.

```
silver.service_health()   0.025s · 7 producers
  pubsub-ingestion-topic     ops=7600  err=0.30%  p50=30.0    p99=33.0
  dataproc-spark-streaming   ops=3800  err=1.03%  p50=399.7   p99=439.5

silver_graph()            13 objects · 4 mv / 3 table / 6 view · lineage from create_table_query
on the board              compute · 1800 ms → 1800 ms      (declared → measured)
                          storage ·   80 ms →   80 ms

make test-flow-ui         73 passed
make lint                 exit 0
```

Declared and measured agree because the generator honours its own topology — the right
baseline. Divergence is the signal.

## What could this break, and how did you check?

**Stacks without Silver.** Any ClickHouse volume predating the DDL has no `silver.*` and the
query raises `UNKNOWN_TABLE`. `service_health()` catches it, logs at info, returns `[]`, and the
node falls back to the declared figure alone — the behaviour it had before this PR.
`silver_state()` distinguishes *absent* from *present and empty*, which are different statements
and both normal: the MVs do not `POPULATE`.

**Nothing was migrated off Bronze**, so Contract and Watchers answer exactly what they answered
before. That was the risk worth avoiding:

| | rows | history |
|---|---|---|
| `bronze.otel_traces` | 1,703,050 | 36 hours |
| `silver.operation_executions` | 12,849 | 12 minutes |

Migrating `contract_violations` would have reported nothing and lost the `legacy-billing-api`
finding — 104,610 rows missing four required keys. Migrating `volume_band` would have put every
producer under `MIN_BUCKETS` and turned the Watchers board grey.

**`/api/graph` now does I/O.** It was a pure return of constants; it makes two `system.*`
metadata queries per page load. Metadata only, no row scan. Silver's schema is served there
rather than in the snapshot for the same reason the bronze datasheets are: three models of
seventeen columns is ~3 KB repeated every second to say what it said the tick before.

**A regression I introduced and caught here:** adding the per-kind border strokes silently took
the selected border away from every silver node — `.nd.sel` and `.sub-nd.k-mv` are both two
classes, so the cascade falls back to source order. Selection now comes after. BRONZE's own
table selection shares that rule and was verified too.

**Docs swept** per `.claude/rules/pre-pr-discipline.md`: root README, `CLAUDE.md`,
`.claude/CLAUDE.md`, and the service's README / STATUS / new ARCHITECTURE.

## The UI half, which was driven by review rather than by me

Nine of the commits fix defects found by someone looking at the running board, not by a test:

- The bronze datasheet **covered SILVER**, and moving it past SILVER shrank every box to 58%
  to make room for a panel. It sits below BRONZE now, where at 320 against bronze's 318 it
  costs no width at all.
- The three object kinds are told apart by **ground**, not hue — hue means logs/traces/metrics
  on every edge and particle here. The first attempt measured **1.03:1** between adjacent
  grounds: three names for one colour.
- That surfaced a contrast bug **older than this PR**: substrate's `--dim` put every small
  label at 2.8:1, under the 3:1 floor, on labels that carry meaning. Raised until the worst
  case clears.
- The kind key read as three checkboxes. It is a passive legend now, and lights the swatch for
  whatever kind you select.
- **The lanes ran on a metronome** — `flow` spaced departures at exactly `dur / n`. Scattered
  and speed-varied now, seeded so a repaint does not reshuffle a lane you are watching.
- **The dot count beat 4,2,4,2** because the generator's 1s step and the poller's 1s interval
  alias against each other. Smoothed before quantising; display only, never the verdict.
- Opening a box **blacked the board out for a second**: `render` creates dots at opacity 0 and
  the tick skipped the reveal on a structural change.

One of those I introduced and shipped broken for a commit: the smoothing helper was named
`live`, which `density` already declares locally, so it was shadowed and everything from BRONZE
onward went dark. Renamed, with the reason written next to it.

---


<img width="3425" height="619" alt="image" src="https://github.com/user-attachments/assets/b0933375-5879-4cef-8522-e61ebd1f52d6" />

<img width="3431" height="594" alt="image" src="https://github.com/user-attachments/assets/f38f7580-0589-4043-b76f-260acbf7f0f1" />

<img width="1970" height="874" alt="image" src="https://github.com/user-attachments/assets/387f20cd-ccb5-4ac2-b3ee-63d958c8dd73" />
